### PR TITLE
Support batch chapter generation across backend and frontend

### DIFF
--- a/api/lib/services/storyService.ts
+++ b/api/lib/services/storyService.ts
@@ -4,7 +4,10 @@ import {
   ChapterContinuationSeam,
   ApiResponse,
   VALIDATION_RULES,
-  SpicyLevel
+  SpicyLevel,
+  Chapter,
+  ChapterGenerationError,
+  ChapterBatchSize
 } from '../types/contracts';
 import { logger, logError, logWarn, logApiError, logInfo, logPerformance, LogContext } from '../utils/logger';
 
@@ -44,56 +47,114 @@ export class StoryService {
   async generateStory(input: StoryGenerationSeam['input']): Promise<ApiResponse<StoryGenerationSeam['output']>> {
     const startTime = Date.now();
     const requestId = logger.generateRequestId();
-    
+    const normalizedChapterCount = this.normalizeChapterCount(input.requestedChapterCount);
+    const normalizedInput: StoryGenerationSeam['input'] = {
+      ...input,
+      requestedChapterCount: normalizedChapterCount
+    };
+
     const context: LogContext = {
       requestId,
       endpoint: 'generateStory',
       method: 'POST',
       userInput: {
-        creature: input.creature,
-        themes: input.themes,
-        spicyLevel: input.spicyLevel,
-        wordCount: input.wordCount
+        creature: normalizedInput.creature,
+        themes: normalizedInput.themes,
+        spicyLevel: normalizedInput.spicyLevel,
+        wordCount: normalizedInput.wordCount,
+        requestedChapterCount: normalizedChapterCount
       }
     };
 
     logInfo('Story generation request received', context);
 
     try {
-      // Validate input
-      const validationError = this.validateStoryInput(input);
+      const validationError = this.validateStoryInput(normalizedInput);
       if (validationError) {
         logWarn('Story input validation failed', context, { validationError });
-        
+
         return {
           success: false,
           error: validationError,
           metadata: {
             requestId,
-            processingTime: Date.now() - startTime
+            processingTime: Date.now() - startTime,
+            chaptersRequested: normalizedChapterCount,
+            chaptersGenerated: 0
           }
         };
       }
 
-      // Generate story using Grok AI
-      const rawStoryContent = await this.callGrokAI(input, context);
+      const storyId = this.generateStoryId();
+      const chapters: Chapter[] = [];
+      const partialFailures: ChapterGenerationError[] = [];
+      let appendedToStory = '';
+      let finalHint: string | undefined;
 
-      // Process content: keep raw version for audio, clean version for display
-      const displayContent = this.stripSpeakerTagsForDisplay(rawStoryContent);
+      for (let index = 0; index < normalizedChapterCount; index++) {
+        const chapterNumber = index + 1;
 
-      // Create response
+        try {
+          const { chapter, combinedContent, nextHint } = await this.generateInitialStoryChapter(
+            normalizedInput,
+            storyId,
+            chapterNumber,
+            appendedToStory,
+            context
+          );
+
+          chapters.push(chapter);
+          appendedToStory = combinedContent;
+          finalHint = nextHint;
+        } catch (error: any) {
+          const failure: ChapterGenerationError = {
+            chapterNumber,
+            message: error?.message || 'Unknown error generating chapter',
+            retryable: true
+          };
+
+          partialFailures.push(failure);
+          logWarn('Chapter generation failed, continuing with remaining chapters', context, {
+            chapterNumber,
+            error: failure.message
+          });
+        }
+      }
+
+      const totalWordCount = chapters.reduce((sum, chapter) => sum + chapter.wordCount, 0);
+
+      if (chapters.length === 0) {
+        return {
+          success: false,
+          error: {
+            code: 'GENERATION_FAILED',
+            message: 'Failed to generate any chapters for the story',
+            details: partialFailures
+          },
+          metadata: {
+            requestId,
+            processingTime: Date.now() - startTime,
+            chaptersRequested: normalizedChapterCount,
+            chaptersGenerated: 0,
+            partialFailures: partialFailures.length ? partialFailures : undefined
+          }
+        };
+      }
+
       const output: StoryGenerationSeam['output'] = {
-        storyId: this.generateStoryId(),
-        title: this.generateTitle(input),
-        content: displayContent, // Clean content for user display
-        rawContent: rawStoryContent, // Tagged content for audio processing
-        creature: input.creature,
-        themes: input.themes,
-        spicyLevel: input.spicyLevel,
-        actualWordCount: this.countWords(displayContent),
-        estimatedReadTime: Math.ceil(this.countWords(displayContent) / 200),
-        hasCliffhanger: this.detectCliffhanger(displayContent),
-        generatedAt: new Date()
+        storyId,
+        title: chapters[0].title,
+        chapters,
+        creature: normalizedInput.creature,
+        themes: normalizedInput.themes,
+        spicyLevel: normalizedInput.spicyLevel,
+        totalWordCount,
+        estimatedReadTime: Math.max(1, Math.ceil(totalWordCount / 200)),
+        hasCliffhanger: chapters[chapters.length - 1].cliffhangerEnding,
+        appendedToStory,
+        nextChapterHint: finalHint,
+        generatedAt: new Date(),
+        chapterErrors: partialFailures.length ? partialFailures : undefined
       };
 
       const duration = Date.now() - startTime;
@@ -101,8 +162,8 @@ export class StoryService {
         ...context,
         responseTime: duration
       }, {
-        actualWordCount: output.actualWordCount,
-        hasCliffhanger: output.hasCliffhanger
+        totalWordCount: output.totalWordCount,
+        chaptersGenerated: chapters.length
       });
 
       return {
@@ -110,13 +171,16 @@ export class StoryService {
         data: output,
         metadata: {
           requestId,
-          processingTime: Date.now() - startTime
+          processingTime: duration,
+          chaptersRequested: normalizedChapterCount,
+          chaptersGenerated: chapters.length,
+          partialFailures: partialFailures.length ? partialFailures : undefined
         }
       };
 
     } catch (error: any) {
       const duration = Date.now() - startTime;
-      
+
       logError('Story generation failed', error, {
         ...context,
         responseTime: duration,
@@ -135,7 +199,9 @@ export class StoryService {
         },
         metadata: {
           requestId: this.generateRequestId(),
-          processingTime: Date.now() - startTime
+          processingTime: Date.now() - startTime,
+          chaptersRequested: normalizedChapterCount,
+          chaptersGenerated: 0
         }
       };
     }
@@ -144,35 +210,93 @@ export class StoryService {
   async continueChapter(input: ChapterContinuationSeam['input']): Promise<ApiResponse<ChapterContinuationSeam['output']>> {
     const startTime = Date.now();
     const requestId = logger.generateRequestId();
-    
+    const normalizedChapterCount = this.normalizeChapterCount(input.requestedChapterCount);
+    const normalizedInput: ChapterContinuationSeam['input'] = {
+      ...input,
+      requestedChapterCount: normalizedChapterCount
+    };
+
     const context: LogContext = {
       requestId,
       endpoint: 'continueChapter',
       method: 'POST',
       userInput: {
-        currentChapterCount: input.currentChapterCount,
-        existingContentLength: input.existingContent?.length || 0,
-        maintainTone: input.maintainTone
+        currentChapterCount: normalizedInput.currentChapterCount,
+        existingContentLength: normalizedInput.existingContent?.length || 0,
+        maintainTone: normalizedInput.maintainTone,
+        requestedChapterCount: normalizedChapterCount
       }
     };
 
     logInfo('Chapter continuation request received', context);
 
     try {
-      // Generate continuation using Grok AI
-      const chapterContent = await this.callGrokAIForContinuation(input, context);
+      const chapters: Chapter[] = [];
+      const partialFailures: ChapterGenerationError[] = [];
+      let appendedToStory = normalizedInput.existingContent;
+      let chapterCursor = normalizedInput.currentChapterCount;
+      let finalHint: string | undefined;
 
-      // Create response
+      for (let index = 0; index < normalizedChapterCount; index++) {
+        const chapterNumber = chapterCursor + 1;
+
+        try {
+          const { chapter, combinedContent, nextHint } = await this.generateContinuationChapter(
+            normalizedInput,
+            chapterNumber,
+            appendedToStory,
+            context
+          );
+
+          chapters.push(chapter);
+          appendedToStory = combinedContent;
+          finalHint = nextHint;
+          chapterCursor = chapter.chapterNumber;
+        } catch (error: any) {
+          const failure: ChapterGenerationError = {
+            chapterNumber,
+            message: error?.message || 'Unknown error generating chapter continuation',
+            retryable: true
+          };
+
+          partialFailures.push(failure);
+          logWarn('Continuation chapter generation failed, continuing if possible', context, {
+            chapterNumber,
+            error: failure.message
+          });
+        }
+      }
+
+      if (chapters.length === 0) {
+        return {
+          success: false,
+          error: {
+            code: 'CONTINUATION_FAILED',
+            message: 'Failed to generate continuation chapters',
+            details: partialFailures
+          },
+          metadata: {
+            requestId,
+            processingTime: Date.now() - startTime,
+            chaptersRequested: normalizedChapterCount,
+            chaptersGenerated: 0,
+            partialFailures: partialFailures.length ? partialFailures : undefined
+          }
+        };
+      }
+
+      const totalWordCount = this.countWords(appendedToStory);
       const output: ChapterContinuationSeam['output'] = {
-        chapterId: this.generateChapterId(),
-        chapterNumber: input.currentChapterCount + 1,
-        title: `Chapter ${input.currentChapterCount + 1}: ${this.generateChapterTitle(input)}`,
-        content: chapterContent,
-        wordCount: this.countWords(chapterContent),
-        cliffhangerEnding: this.detectCliffhanger(chapterContent),
-        themesContinued: this.extractThemesFromContent(input.existingContent),
-        spicyLevelMaintained: this.extractSpicyLevelFromContent(input.existingContent),
-        appendedToStory: input.existingContent + '\n\n<hr>\n\n' + chapterContent
+        storyId: normalizedInput.storyId,
+        chapters,
+        totalWordCount,
+        appendedToStory,
+        finalChapterNumber: chapterCursor,
+        hasCliffhanger: chapters[chapters.length - 1].cliffhangerEnding,
+        themesContinued: this.extractThemesFromContent(appendedToStory),
+        spicyLevelMaintained: this.extractSpicyLevelFromContent(appendedToStory),
+        nextChapterHint: finalHint,
+        chapterErrors: partialFailures.length ? partialFailures : undefined
       };
 
       const duration = Date.now() - startTime;
@@ -180,8 +304,8 @@ export class StoryService {
         ...context,
         responseTime: duration
       }, {
-        chapterNumber: output.chapterNumber,
-        wordCount: output.wordCount
+        finalChapterNumber: output.finalChapterNumber,
+        chaptersGenerated: chapters.length
       });
 
       return {
@@ -189,13 +313,16 @@ export class StoryService {
         data: output,
         metadata: {
           requestId,
-          processingTime: duration
+          processingTime: duration,
+          chaptersRequested: normalizedChapterCount,
+          chaptersGenerated: chapters.length,
+          partialFailures: partialFailures.length ? partialFailures : undefined
         }
       };
 
     } catch (error: any) {
       const duration = Date.now() - startTime;
-      
+
       logError('Chapter continuation failed', error, {
         ...context,
         responseTime: duration,
@@ -211,10 +338,144 @@ export class StoryService {
         },
         metadata: {
           requestId,
-          processingTime: duration
+          processingTime: duration,
+          chaptersRequested: normalizedChapterCount,
+          chaptersGenerated: 0
         }
       };
     }
+  }
+
+  private normalizeChapterCount(value: number | undefined): ChapterBatchSize {
+    const numeric = Number(value ?? 1);
+    if (!Number.isFinite(numeric)) {
+      return 1;
+    }
+
+    const rounded = Math.round(numeric);
+    const clamped = Math.min(
+      Math.max(rounded, VALIDATION_RULES.requestedChapterCount.min),
+      VALIDATION_RULES.requestedChapterCount.max
+    );
+
+    return clamped as ChapterBatchSize;
+  }
+
+  private buildSequentialTitle(baseTitle: string, chapterNumber: number): string {
+    if (chapterNumber <= 1) {
+      return baseTitle;
+    }
+    return `${baseTitle} — Chapter ${chapterNumber}`;
+  }
+
+  private generateNextChapterHint(content: string, chapterNumber: number): string {
+    const cleanContent = content.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+    if (!cleanContent) {
+      return `Explore new twists in chapter ${chapterNumber + 1}.`;
+    }
+
+    const sentences = cleanContent.split(/(?<=[.!?])\s+/).filter(Boolean);
+    let hint = sentences[sentences.length - 1] || cleanContent;
+    hint = hint.trim();
+
+    if (hint.length > 160) {
+      hint = `${hint.slice(0, 157)}…`;
+    }
+
+    return `Next focus: ${hint}`;
+  }
+
+  private extractStoryTitle(content: string): string | undefined {
+    const match = content.match(/<h[1-4][^>]*>(.*?)<\/h[1-4]>/i);
+    if (match?.[1]) {
+      return match[1].replace(/<[^>]*>/g, '').trim();
+    }
+    return undefined;
+  }
+
+  private async generateInitialStoryChapter(
+    input: StoryGenerationSeam['input'],
+    storyId: string,
+    chapterNumber: number,
+    existingContent: string,
+    context: LogContext
+  ): Promise<{ chapter: Chapter; combinedContent: string; nextHint?: string }> {
+    const rawContent = chapterNumber === 1
+      ? await this.callGrokAI(input, context)
+      : await this.callGrokAIForContinuation(
+        {
+          storyId,
+          currentChapterCount: chapterNumber - 1,
+          existingContent,
+          userInput: input.userInput,
+          maintainTone: true,
+          requestedChapterCount: input.requestedChapterCount
+        },
+        context
+      );
+
+    const displayContent = this.stripSpeakerTagsForDisplay(rawContent);
+    const wordCount = this.countWords(displayContent);
+    const combinedContent = existingContent
+      ? `${existingContent}\n\n<hr>\n\n${displayContent}`
+      : displayContent;
+    const baseTitle = this.generateTitle(input);
+    const title = this.buildSequentialTitle(baseTitle, chapterNumber);
+    const nextHint = this.generateNextChapterHint(displayContent, chapterNumber);
+
+    const chapter: Chapter = {
+      chapterId: `${storyId}_chapter_${chapterNumber}`,
+      chapterNumber,
+      title,
+      content: displayContent,
+      rawContent,
+      wordCount,
+      generatedAt: new Date(),
+      hasAudio: false,
+      cliffhangerEnding: this.detectCliffhanger(displayContent),
+      nextChapterHint: nextHint
+    };
+
+    return { chapter, combinedContent, nextHint };
+  }
+
+  private async generateContinuationChapter(
+    input: ChapterContinuationSeam['input'],
+    chapterNumber: number,
+    existingContent: string,
+    context: LogContext
+  ): Promise<{ chapter: Chapter; combinedContent: string; nextHint?: string }> {
+    const continuationInput: ChapterContinuationSeam['input'] = {
+      ...input,
+      currentChapterCount: chapterNumber - 1,
+      existingContent,
+      requestedChapterCount: input.requestedChapterCount
+    };
+
+    const rawContent = await this.callGrokAIForContinuation(continuationInput, context);
+    const displayContent = this.stripSpeakerTagsForDisplay(rawContent);
+    const wordCount = this.countWords(displayContent);
+    const combinedContent = existingContent
+      ? `${existingContent}\n\n<hr>\n\n${displayContent}`
+      : displayContent;
+    const baseTitle = this.extractStoryTitle(existingContent) || `Story ${input.storyId}`;
+    const title = this.buildSequentialTitle(baseTitle, chapterNumber);
+    const nextHint = this.generateNextChapterHint(displayContent, chapterNumber);
+
+    const chapter: Chapter = {
+      chapterId: `${input.storyId}_chapter_${chapterNumber}`,
+      chapterNumber,
+      title,
+      content: displayContent,
+      rawContent,
+      wordCount,
+      generatedAt: new Date(),
+      hasAudio: false,
+      cliffhangerEnding: this.detectCliffhanger(displayContent),
+      nextChapterHint: nextHint
+    };
+
+    return { chapter, combinedContent, nextHint };
   }
 
   /**
@@ -1200,6 +1461,16 @@ Write 400-600 words for this chapter. Use HTML: <h3> for chapter title, <p> for 
       };
     }
 
+    if (!Array.isArray(input.themes) || input.themes.length === 0) {
+      return {
+        code: 'INVALID_INPUT',
+        message: 'At least one theme must be provided',
+        field: 'themes',
+        providedValue: input.themes,
+        expectedType: 'ThemeType[]'
+      };
+    }
+
     if (input.themes.length > VALIDATION_RULES.themes.maxCount) {
       return {
         code: 'INVALID_INPUT',
@@ -1217,6 +1488,34 @@ Write 400-600 words for this chapter. Use HTML: <h3> for chapter title, <p> for 
         field: 'userInput',
         providedValue: input.userInput,
         expectedType: 'string'
+      };
+    }
+
+    if (
+      typeof input.spicyLevel !== 'number' ||
+      input.spicyLevel < VALIDATION_RULES.spicyLevel.min ||
+      input.spicyLevel > VALIDATION_RULES.spicyLevel.max
+    ) {
+      return {
+        code: 'INVALID_INPUT',
+        message: `Spicy level must be between ${VALIDATION_RULES.spicyLevel.min} and ${VALIDATION_RULES.spicyLevel.max}`,
+        field: 'spicyLevel',
+        providedValue: input.spicyLevel,
+        expectedType: 'SpicyLevel'
+      };
+    }
+
+    if (
+      typeof input.requestedChapterCount !== 'number' ||
+      input.requestedChapterCount < VALIDATION_RULES.requestedChapterCount.min ||
+      input.requestedChapterCount > VALIDATION_RULES.requestedChapterCount.max
+    ) {
+      return {
+        code: 'INVALID_INPUT',
+        message: `Requested chapter count must be between ${VALIDATION_RULES.requestedChapterCount.min} and ${VALIDATION_RULES.requestedChapterCount.max}`,
+        field: 'requestedChapterCount',
+        providedValue: input.requestedChapterCount,
+        expectedType: 'ChapterBatchSize'
       };
     }
 

--- a/api/lib/types/contracts.ts
+++ b/api/lib/types/contracts.ts
@@ -20,6 +20,8 @@ export type ExportFormat = 'pdf' | 'txt' | 'html' | 'epub' | 'docx';
 export type ImageStyle = 'artistic' | 'photorealistic' | 'fantasy' | 'dark' | 'romantic';
 
 // ==================== CHAPTER MANAGEMENT ====================
+export type ChapterBatchSize = 1 | 2 | 3;
+
 export interface Chapter {
   chapterId: string;
   chapterNumber: number;
@@ -31,6 +33,14 @@ export interface Chapter {
   hasAudio: boolean;
   audioUrl?: string;
   audioDuration?: number;
+  cliffhangerEnding: boolean;
+  nextChapterHint?: string;
+}
+
+export interface ChapterGenerationError {
+  chapterNumber: number;
+  message: string;
+  retryable: boolean;
 }
 
 export interface AudioProgress {
@@ -51,20 +61,23 @@ export interface StoryGenerationSeam {
     userInput: string; // Optional custom ideas
     spicyLevel: SpicyLevel;
     wordCount: WordCount;
+    requestedChapterCount: ChapterBatchSize;
   };
 
   output: {
     storyId: string;
     title: string;
-    content: string; // HTML formatted content for [innerHTML] binding (speaker tags removed)
-    rawContent?: string; // Content with speaker tags for audio processing
+    chapters: Chapter[];
     creature: CreatureType;
     themes: ThemeType[];
     spicyLevel: SpicyLevel;
-    actualWordCount: number;
-    estimatedReadTime: number; // in minutes
-    hasCliffhanger: boolean; // determines if "Continue Chapter" button shows
+    totalWordCount: number;
+    estimatedReadTime: number; // in minutes (aggregate of all chapters)
+    hasCliffhanger: boolean; // derived from final chapter
+    appendedToStory: string; // Full story content aggregated from chapters
+    nextChapterHint?: string; // Hint produced from final chapter for future continuations
     generatedAt: Date;
+    chapterErrors?: ChapterGenerationError[];
   };
 
   errors: {
@@ -107,18 +120,20 @@ export interface ChapterContinuationSeam {
     existingContent: string; // Full story HTML content
     userInput?: string; // Optional continuation hints
     maintainTone: boolean; // Keep same spicy level and themes
+    requestedChapterCount: ChapterBatchSize;
   };
 
   output: {
-    chapterId: string;
-    chapterNumber: number;
-    title: string;
-    content: string; // New chapter HTML content
-    wordCount: number;
-    cliffhangerEnding: boolean;
+    storyId: string;
+    chapters: Chapter[]; // Newly generated chapters
+    totalWordCount: number;
+    appendedToStory: string; // Full updated story content including new chapters
+    finalChapterNumber: number;
+    hasCliffhanger: boolean; // Derived from the last generated chapter
     themesContinued: ThemeType[];
     spicyLevelMaintained: SpicyLevel;
-    appendedToStory: string; // Full updated story content
+    nextChapterHint?: string;
+    chapterErrors?: ChapterGenerationError[];
   };
 
   errors: {
@@ -153,6 +168,7 @@ export interface StreamingStoryGenerationSeam {
     userInput: string;
     spicyLevel: SpicyLevel;
     wordCount: WordCount;
+    requestedChapterCount: ChapterBatchSize;
   };
 
   progressUpdate: {
@@ -168,23 +184,12 @@ export interface StreamingStoryGenerationSeam {
       generationSpeed: number; // words per second
       percentage: number; // 0-100
       estimatedTimeRemaining?: number; // seconds
+      chapterNumber?: number;
+      nextChapterHint?: string;
     };
   };
 
-  finalOutput: {
-    // Same as StoryGenerationSeam output
-    storyId: string;
-    title: string;
-    content: string;
-    rawContent?: string;
-    creature: CreatureType;
-    themes: ThemeType[];
-    spicyLevel: SpicyLevel;
-    actualWordCount: number;
-    estimatedReadTime: number;
-    hasCliffhanger: boolean;
-    generatedAt: Date;
-  };
+  finalOutput: StoryGenerationSeam['output'];
 
   errors: {
     STREAMING_CONNECTION_FAILED: {
@@ -362,6 +367,10 @@ export const VALIDATION_RULES = {
   wordCount: {
     allowedValues: [700, 900, 1200]
   },
+  requestedChapterCount: {
+    min: 1,
+    max: 3
+  },
   audioSpeed: {
     min: 0.5,
     max: 1.5
@@ -401,5 +410,8 @@ export interface ApiResponse<T> {
     requestId: string;
     processingTime: number;
     rateLimitRemaining?: number;
+    chaptersRequested?: number;
+    chaptersGenerated?: number;
+    partialFailures?: ChapterGenerationError[];
   };
 }

--- a/api/story/continue.ts
+++ b/api/story/continue.ts
@@ -1,6 +1,14 @@
 import { StoryService } from '../lib/services/storyService';
-import { ChapterContinuationSeam } from '../lib/types/contracts';
+import { ChapterBatchSize, ChapterContinuationSeam } from '../lib/types/contracts';
 import { logInfo, logError, logWarn } from '../lib/utils/logger';
+
+function clampChapterCount(value: unknown): ChapterBatchSize {
+  const numeric = typeof value === 'number' ? value : Number.parseInt(String(value), 10);
+  if (!Number.isFinite(numeric)) {
+    return 1;
+  }
+  return Math.min(Math.max(numeric, 1), 3) as ChapterBatchSize;
+}
 
 export default async function handler(req: any, res: any) {
   const requestId = `req_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
@@ -34,7 +42,17 @@ export default async function handler(req: any, res: any) {
   }
 
   try {
-    const input: ChapterContinuationSeam['input'] = req.body;
+    const rawInput = req.body as Partial<ChapterContinuationSeam['input']>;
+    const requestedChapterCount = clampChapterCount(rawInput?.requestedChapterCount);
+
+    const input: ChapterContinuationSeam['input'] = {
+      storyId: rawInput?.storyId ?? '',
+      currentChapterCount: Number(rawInput?.currentChapterCount ?? 0),
+      existingContent: rawInput?.existingContent ?? '',
+      userInput: rawInput?.userInput,
+      maintainTone: Boolean(rawInput?.maintainTone),
+      requestedChapterCount
+    };
 
     // Validate required fields
     if (!input.storyId || !input.existingContent || typeof input.currentChapterCount !== 'number') {
@@ -42,8 +60,8 @@ export default async function handler(req: any, res: any) {
         requestId,
         endpoint: '/api/story/continue',
         method: 'POST'
-      }, { receivedFields: Object.keys(input) });
-      
+      }, { receivedFields: Object.keys(rawInput ?? {}) });
+
       return res.status(400).json({
         success: false,
         error: {
@@ -60,7 +78,8 @@ export default async function handler(req: any, res: any) {
       userInput: {
         storyId: input.storyId,
         currentChapterCount: input.currentChapterCount,
-        existingContentLength: input.existingContent.length
+        existingContentLength: input.existingContent.length,
+        requestedChapterCount: input.requestedChapterCount
       }
     });
 

--- a/api/story/generate.ts
+++ b/api/story/generate.ts
@@ -1,6 +1,14 @@
 import { StoryService } from '../lib/services/storyService';
-import { StoryGenerationSeam } from '../lib/types/contracts';
+import { ChapterBatchSize, StoryGenerationSeam } from '../lib/types/contracts';
 import { logInfo, logError, logWarn } from '../lib/utils/logger';
+
+function clampChapterCount(value: unknown): ChapterBatchSize {
+  const numeric = typeof value === 'number' ? value : Number.parseInt(String(value), 10);
+  if (!Number.isFinite(numeric)) {
+    return 1;
+  }
+  return Math.min(Math.max(numeric, 1), 3) as ChapterBatchSize;
+}
 
 export default async function handler(req: any, res: any) {
   // Generate or extract request ID for tracking
@@ -41,16 +49,26 @@ export default async function handler(req: any, res: any) {
   try {
     console.log(`[${requestId}] POST /api/story/generate - Request received`);
     
-    const input: StoryGenerationSeam['input'] = req.body;
+    const rawInput = req.body as Partial<StoryGenerationSeam['input']>;
+    const requestedChapterCount = clampChapterCount(rawInput?.requestedChapterCount);
+
+    const input: StoryGenerationSeam['input'] = {
+      creature: rawInput?.creature as StoryGenerationSeam['input']['creature'],
+      themes: Array.isArray(rawInput?.themes) ? (rawInput?.themes as StoryGenerationSeam['input']['themes']) : [],
+      userInput: rawInput?.userInput ?? '',
+      spicyLevel: rawInput?.spicyLevel as StoryGenerationSeam['input']['spicyLevel'],
+      wordCount: rawInput?.wordCount as StoryGenerationSeam['input']['wordCount'],
+      requestedChapterCount
+    };
 
     // Validate required fields
-    if (!input.creature || !input.themes || typeof input.spicyLevel !== 'number' || !input.wordCount) {
+    if (!input.creature || !Array.isArray(input.themes) || input.themes.length === 0 || typeof input.spicyLevel !== 'number' || !input.wordCount) {
       logWarn('Invalid input - missing required fields', {
         requestId,
         endpoint: '/api/story/generate',
         method: 'POST'
-      }, { receivedFields: Object.keys(input) });
-      
+      }, { receivedFields: Object.keys(rawInput ?? {}) });
+
       return res.status(400).json({
         success: false,
         error: {
@@ -68,7 +86,8 @@ export default async function handler(req: any, res: any) {
         creature: input.creature,
         themes: input.themes,
         spicyLevel: input.spicyLevel,
-        wordCount: input.wordCount
+        wordCount: input.wordCount,
+        requestedChapterCount: input.requestedChapterCount
       }
     });
 
@@ -79,17 +98,12 @@ export default async function handler(req: any, res: any) {
     res.status(200).json(result);
 
   } catch (error: any) {
-<<<<<<< HEAD
     logError('Story generation endpoint error', error, {
       requestId,
       endpoint: '/api/story/generate',
       method: 'POST',
       statusCode: 500
     });
-    
-=======
-    console.error(`[${requestId}] Story generation serverless function error:`, error);
->>>>>>> c07c20875b1643c77ba40490b75daf80504c0651
     res.status(500).json({
       success: false,
       error: {

--- a/story-generator/src/app/app.css
+++ b/story-generator/src/app/app.css
@@ -642,6 +642,31 @@ select:focus {
   border: 1px solid #c3e6cb;
 }
 
+.warning-message {
+  background: #fff3cd;
+  color: #856404;
+  padding: 1rem;
+  border-radius: 10px;
+  margin-top: 1rem;
+  border: 1px solid #ffeeba;
+}
+
+.warning-message ul {
+  margin: 0.5rem 0 0 1.25rem;
+  padding: 0;
+}
+
+.warning-message li {
+  margin-bottom: 0.25rem;
+}
+
+.form-helper {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.85rem;
+  color: rgba(0, 0, 0, 0.65);
+}
+
 /* Audio Player */
 .audio-player {
   background: white;

--- a/story-generator/src/app/app.html
+++ b/story-generator/src/app/app.html
@@ -87,6 +87,17 @@
         </select>
       </div>
 
+      <!-- Chapter Batch Size Dropdown -->
+      <div class="form-group">
+        <label for="chapterBatch">Chapters per request:</label>
+        <select id="chapterBatch" [(ngModel)]="requestedChapterCount">
+          <option *ngFor="let option of chapterBatchOptions" [value]="option.value">
+            {{ option.label }}
+          </option>
+        </select>
+        <small class="form-helper">Generate multiple chapters in a single request (1-3).</small>
+      </div>
+
       <!-- Generate Button -->
       <button
         class="generate-btn"
@@ -103,6 +114,12 @@
       <!-- Generation Error Display -->
       <div class="error-message" *ngIf="generationError">
         ❌ {{ generationError }}
+      </div>
+      <div class="warning-message" *ngIf="generationWarnings.length">
+        <span>⚠️ Generation warnings:</span>
+        <ul>
+          <li *ngFor="let warning of generationWarnings">{{ warning }}</li>
+        </ul>
       </div>
       </div>
     </div>
@@ -184,6 +201,12 @@
             </span>
           </button>
           <p *ngIf="!isLastChapter()" class="hint">Navigate to last chapter to continue story</p>
+          <div class="warning-message" *ngIf="continuationWarnings.length">
+            <span>⚠️ Continuation warnings:</span>
+            <ul>
+              <li *ngFor="let warning of continuationWarnings">{{ warning }}</li>
+            </ul>
+          </div>
         </div>
       </div>
 

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -122,24 +122,33 @@ describe('App', () => {
     });
 
     it('should generate story successfully', () => {
-      const mockResponse: ApiResponse<StoryGenerationSeam['output']> = {
-        success: true,
-        data: {
-          storyId: 'story_123',
-          title: 'Test Story',
-          content: '<h3>Chapter 1</h3><p>Story content...</p>',
-          creature: 'vampire' as CreatureType,
-          themes: ['forbidden_love', 'dark_secrets'] as ThemeType[],
-          spicyLevel: 3 as SpicyLevel,
-          actualWordCount: 150,
-          estimatedReadTime: 1,
-          hasCliffhanger: false,
-          generatedAt: new Date()
-        },
-        metadata: {
-          requestId: 'req_123',
-          processingTime: 2500
-        }
+      const generatedAt = new Date();
+      const mockResponse: ApiResponse<StoryGenerationSeam['output']> = createMockStoryResponse({
+        storyId: 'story_123',
+        title: 'Test Story',
+        chapters: [
+          {
+            chapterId: 'story_123-ch1',
+            chapterNumber: 1,
+            title: 'Test Story',
+            content: '<h3>Chapter 1</h3><p>Story content...</p>',
+            rawContent: '<h3>Chapter 1</h3><p>Story content...</p>',
+            wordCount: 150,
+            generatedAt,
+            hasAudio: false,
+            cliffhangerEnding: false
+          }
+        ],
+        themes: ['forbidden_love', 'dark_secrets'] as ThemeType[],
+        totalWordCount: 150,
+        estimatedReadTime: 1,
+        hasCliffhanger: false,
+        appendedToStory: '<h3>Chapter 1</h3><p>Story content...</p>',
+        generatedAt
+      });
+      mockResponse.metadata = {
+        requestId: 'req_123',
+        processingTime: 2500
       };
 
       storyService.generateStory.and.returnValue(of(mockResponse));
@@ -151,7 +160,8 @@ describe('App', () => {
         themes: ['forbidden_love', 'dark_secrets'],
         userInput: '',
         spicyLevel: 3,
-        wordCount: 900
+        wordCount: 900,
+        requestedChapterCount: 1
       });
 
       // Wait for async operation

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -4,7 +4,15 @@ import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { StoryService } from './story.service';
 import { ErrorLoggingService } from './error-logging';
 import { ErrorDisplayComponent } from './error-display/error-display';
-import { StoryGenerationSeam, ChapterContinuationSeam, AudioConversionSeam, SaveExportSeam, Chapter } from './contracts';
+import {
+  StoryGenerationSeam,
+  ChapterContinuationSeam,
+  AudioConversionSeam,
+  SaveExportSeam,
+  Chapter,
+  ChapterBatchSize,
+  ChapterGenerationError
+} from './contracts';
 import { DebugPanel } from './debug-panel/debug-panel';
 
 /**
@@ -78,6 +86,16 @@ export class App implements OnInit, OnDestroy {
   /** Target word count for story generation */
   wordCount: number = 900;
 
+  /** Number of chapters to request per generation batch */
+  requestedChapterCount: ChapterBatchSize = 1;
+
+  /** Available batch sizes for chapter generation */
+  chapterBatchOptions = [
+    { value: 1 as ChapterBatchSize, label: 'Generate 1 chapter' },
+    { value: 2 as ChapterBatchSize, label: 'Generate 2 chapters' },
+    { value: 3 as ChapterBatchSize, label: 'Generate 3 chapters' }
+  ];
+
   // ==================== UI STATE MANAGEMENT ====================
 
   /** Loading states for different operations */
@@ -92,6 +110,8 @@ export class App implements OnInit, OnDestroy {
   generationError: string = '';
   audioError: string = '';
   exportError: string = '';
+  generationWarnings: string[] = [];
+  continuationWarnings: string[] = [];
 
   // ==================== STORY DATA MANAGEMENT ====================
 
@@ -128,6 +148,9 @@ export class App implements OnInit, OnDestroy {
   get currentChapterCount(): number {
     return this.chapters.length;
   }
+
+  /** Cached appended story HTML for continuation requests */
+  appendedStoryCache: string = '';
 
   /** Themes used in current story generation */
   currentStoryThemes: string[] = [];
@@ -232,7 +255,10 @@ export class App implements OnInit, OnDestroy {
 
     this.isGenerating = true;
     this.generationError = ''; // Clear previous errors
-    this.currentStory = '';
+    this.generationWarnings = [];
+    this.continuationWarnings = [];
+    this.chapters = [];
+    this.appendedStoryCache = '';
     this.saveSuccess = false;
     this.audioSuccess = false;
 
@@ -244,7 +270,8 @@ export class App implements OnInit, OnDestroy {
       creature: this.selectedCreature,
       themes: this.selectedThemes,
       spicyLevel: this.spicyLevel,
-      wordCount: this.wordCount
+      wordCount: this.wordCount,
+      requestedChapterCount: this.requestedChapterCount
     });
 
     const request: StoryGenerationSeam['input'] = {
@@ -252,43 +279,42 @@ export class App implements OnInit, OnDestroy {
       themes: Array.from(this.selectedThemes) as any,
       userInput: this.userInput,
       spicyLevel: this.spicyLevel as any,
-      wordCount: this.wordCount as any
+      wordCount: this.wordCount as any,
+      requestedChapterCount: this.requestedChapterCount
     };
 
     this.storyService.generateStory(request).subscribe({
       next: (response) => {
+        this.isGenerating = false;
+
         if (response.success && response.data) {
-          // Create first chapter from generated story
-          const firstChapter: Chapter = {
-            chapterId: `chapter_1_${Date.now()}`,
-            chapterNumber: 1,
-            title: response.data.title,
-            content: response.data.content,
-            rawContent: response.data.rawContent || response.data.content,
-            wordCount: response.data.actualWordCount,
-            generatedAt: new Date(),
-            hasAudio: false
-          };
+          const normalizedChapters = (response.data.chapters || []).map(chapter => this.normalizeChapter(chapter));
 
-          // Initialize chapters array with first chapter
-          this.chapters = [firstChapter];
+          if (normalizedChapters.length === 0) {
+            this.generationError = 'Story generation returned no chapters. Please try again.';
+            this.errorLogging.logWarning('Story generation completed without chapters', 'App.generateStory', { response });
+            return;
+          }
+
+          this.chapters = normalizedChapters;
           this.currentChapterIndex = 0;
-
-          // Store story metadata
           this.currentStoryId = response.data.storyId;
           this.currentStoryTitle = response.data.title;
           this.currentStoryThemes = response.data.themes;
           this.currentStorySpicyLevel = response.data.spicyLevel;
+          this.appendedStoryCache = response.data.appendedToStory;
 
-          this.isGenerating = false;
-          this.generationError = ''; // Clear any previous errors
+          this.generationWarnings = this.formatChapterWarnings(
+            response.data.chapterErrors?.length ? response.data.chapterErrors : response.metadata?.partialFailures
+          );
+
           this.errorLogging.logInfo('Story generation completed successfully', 'App.generateStory', {
             storyId: response.data.storyId,
-            wordCount: response.data.actualWordCount
+            chaptersGenerated: normalizedChapters.length,
+            totalWordCount: response.data.totalWordCount
           });
         } else {
           // Handle successful response but no data
-          this.isGenerating = false;
           this.generationError = response.error?.message || 'Story generation failed. Please try again.';
           this.errorLogging.logError(
             new Error('Empty response data'),
@@ -307,7 +333,7 @@ export class App implements OnInit, OnDestroy {
         });
 
         this.isGenerating = false;
-
+        this.generationWarnings = [];
         // Provide user-friendly error messages
         if (error.error?.code === 'GENERATION_FAILED') {
           this.generationError = 'Our AI storyteller is having trouble. Please try again in a moment.';
@@ -350,37 +376,34 @@ export class App implements OnInit, OnDestroy {
       themes: ['forbidden_love'],
       userInput: 'A brief encounter in a moonlit garden. Keep it under 200 words.',
       spicyLevel: 2,
-      wordCount: 700 // API will be instructed to keep it short via userInput
+      wordCount: 700, // API will be instructed to keep it short via userInput
+      requestedChapterCount: 1
     };
 
     this.storyService.generateStory(testRequest).subscribe({
       next: (response) => {
         if (response.success && response.data) {
-          // Create quick test chapter
-          const testChapter: Chapter = {
-            chapterId: `chapter_test_${Date.now()}`,
-            chapterNumber: 1,
-            title: response.data.title,
-            content: response.data.content,
-            rawContent: response.data.rawContent || response.data.content,
-            wordCount: response.data.actualWordCount,
-            generatedAt: new Date(),
-            hasAudio: false
-          };
+          const normalizedChapters = (response.data.chapters || []).map(chapter => this.normalizeChapter(chapter));
 
-          // Initialize with test chapter
-          this.chapters = [testChapter];
+          if (normalizedChapters.length === 0) {
+            this.generationError = 'Quick test returned no chapters. Please try again.';
+            return;
+          }
+
+          this.chapters = normalizedChapters;
           this.currentChapterIndex = 0;
           this.currentStoryId = response.data.storyId;
           this.currentStoryTitle = response.data.title;
           this.currentStoryThemes = response.data.themes;
           this.currentStorySpicyLevel = response.data.spicyLevel;
+          this.appendedStoryCache = response.data.appendedToStory;
 
           this.isGenerating = false;
           this.generationError = '';
           this.errorLogging.logInfo('Quick test completed successfully', 'App.quickTest', {
             storyId: response.data.storyId,
-            wordCount: response.data.actualWordCount
+            chaptersGenerated: normalizedChapters.length,
+            totalWordCount: response.data.totalWordCount
           });
         } else {
           this.isGenerating = false;
@@ -409,42 +432,46 @@ export class App implements OnInit, OnDestroy {
 
   generateNextChapter() {
     this.isContinuing = true;
+    this.isGeneratingNext = true;
+    this.continuationWarnings = [];
 
     this.errorLogging.logInfo('User initiated chapter continuation', 'App.generateNextChapter');
 
     const request: ChapterContinuationSeam['input'] = {
       storyId: this.currentStoryId,
       currentChapterCount: this.chapters.length,
-      existingContent: this.chapters.map(ch => ch.content).join('\n\n'),
+      existingContent: this.appendedStoryCache || this.chapters.map(ch => ch.content).join('\n\n'),
       userInput: '',
-      maintainTone: true
+      maintainTone: true,
+      requestedChapterCount: this.requestedChapterCount
     };
 
     this.storyService.generateNextChapter(request).subscribe({
       next: (response) => {
-        if (response.success && response.data) {
-          // Create new chapter
-          const newChapter: Chapter = {
-            chapterId: response.data.chapterId,
-            chapterNumber: response.data.chapterNumber,
-            title: response.data.title,
-            content: response.data.content,
-            rawContent: response.data.content, // Backend should provide rawContent
-            wordCount: response.data.content.split(/\s+/).length,
-            generatedAt: new Date(),
-            hasAudio: false
-          };
+        this.isContinuing = false;
+        this.isGeneratingNext = false;
 
-          // Add to chapters array
-          this.chapters.push(newChapter);
-          
-          // Navigate to new chapter
+        if (response.success && response.data) {
+          const newChapters = (response.data.chapters || []).map(chapter => this.normalizeChapter(chapter));
+
+          if (newChapters.length === 0) {
+            this.continuationWarnings = ['No new chapters were returned from the continuation request.'];
+            this.errorLogging.logWarning('Continuation returned no chapters', 'App.generateNextChapter', { response });
+            return;
+          }
+
+          this.chapters = [...this.chapters, ...newChapters];
           this.currentChapterIndex = this.chapters.length - 1;
 
-          this.isGeneratingNext = false;
+          this.continuationWarnings = this.formatChapterWarnings(
+            response.data.chapterErrors?.length ? response.data.chapterErrors : response.metadata?.partialFailures
+          );
+          this.appendedStoryCache = response.data.appendedToStory;
+
           this.errorLogging.logInfo('Chapter continuation completed successfully', 'App.generateNextChapter', {
-            chapterId: response.data.chapterId,
-            chapterNumber: response.data.chapterNumber
+            storyId: this.currentStoryId,
+            chaptersGenerated: newChapters.length,
+            finalChapterNumber: response.data.finalChapterNumber
           });
         }
       },
@@ -453,9 +480,34 @@ export class App implements OnInit, OnDestroy {
           request,
           userAction: 'chapter_continuation'
         });
+        this.isContinuing = false;
         this.isGeneratingNext = false;
+        this.continuationWarnings = [];
       }
     });
+  }
+
+  private normalizeChapter(chapter: Chapter): Chapter {
+    const generatedAt = chapter.generatedAt instanceof Date
+      ? chapter.generatedAt
+      : new Date(chapter.generatedAt);
+
+    return {
+      ...chapter,
+      generatedAt,
+      rawContent: chapter.rawContent || chapter.content,
+      hasAudio: chapter.hasAudio ?? false,
+      nextChapterHint: chapter.nextChapterHint,
+      cliffhangerEnding: chapter.cliffhangerEnding
+    };
+  }
+
+  private formatChapterWarnings(failures?: ChapterGenerationError[] | undefined): string[] {
+    if (!failures || failures.length === 0) {
+      return [];
+    }
+
+    return failures.map(failure => `Chapter ${failure.chapterNumber}: ${failure.message}`);
   }
 
   convertToAudio() {

--- a/story-generator/src/app/contracts.ts
+++ b/story-generator/src/app/contracts.ts
@@ -19,6 +19,8 @@ export type AudioFormat = 'mp3' | 'wav' | 'aac';
 export type ExportFormat = 'pdf' | 'txt' | 'html' | 'epub' | 'docx';
 
 // ==================== CHAPTER MANAGEMENT ====================
+export type ChapterBatchSize = 1 | 2 | 3;
+
 export interface Chapter {
   chapterId: string;
   chapterNumber: number;
@@ -30,6 +32,14 @@ export interface Chapter {
   hasAudio: boolean;
   audioUrl?: string;
   audioDuration?: number;
+  cliffhangerEnding: boolean;
+  nextChapterHint?: string;
+}
+
+export interface ChapterGenerationError {
+  chapterNumber: number;
+  message: string;
+  retryable: boolean;
 }
 
 export interface AudioProgress {
@@ -50,20 +60,23 @@ export interface StoryGenerationSeam {
     userInput: string; // Optional custom ideas
     spicyLevel: SpicyLevel;
     wordCount: WordCount;
+    requestedChapterCount: ChapterBatchSize;
   };
 
   output: {
     storyId: string;
     title: string;
-    content: string; // HTML formatted content for [innerHTML] binding (speaker tags removed)
-    rawContent?: string; // Content with speaker tags for audio processing
+    chapters: Chapter[];
     creature: CreatureType;
     themes: ThemeType[];
     spicyLevel: SpicyLevel;
-    actualWordCount: number;
-    estimatedReadTime: number; // in minutes
+    totalWordCount: number;
+    estimatedReadTime: number; // in minutes (aggregate of all chapters)
     hasCliffhanger: boolean; // determines if "Continue Chapter" button shows
+    appendedToStory: string; // Full story content aggregated from chapters
+    nextChapterHint?: string;
     generatedAt: Date;
+    chapterErrors?: ChapterGenerationError[];
   };
 
   errors: {
@@ -106,18 +119,20 @@ export interface ChapterContinuationSeam {
     existingContent: string; // Full story HTML content
     userInput?: string; // Optional continuation hints
     maintainTone: boolean; // Keep same spicy level and themes
+    requestedChapterCount: ChapterBatchSize;
   };
 
   output: {
-    chapterId: string;
-    chapterNumber: number;
-    title: string;
-    content: string; // New chapter HTML content
-    wordCount: number;
-    cliffhangerEnding: boolean;
+    storyId: string;
+    chapters: Chapter[];
+    totalWordCount: number;
+    appendedToStory: string; // Full updated story content
+    finalChapterNumber: number;
+    hasCliffhanger: boolean;
     themesContinued: ThemeType[];
     spicyLevelMaintained: SpicyLevel;
-    appendedToStory: string; // Full updated story content
+    nextChapterHint?: string;
+    chapterErrors?: ChapterGenerationError[];
   };
 
   errors: {
@@ -150,12 +165,16 @@ export interface StreamingProgressChunk {
   content?: string;
   storyId?: string;
   streamId?: string;
-  metadata?: {
-    wordsGenerated: number;
-    estimatedWordsRemaining: number;
-    generationSpeed: number; // words per second
-    percentage: number; // 0-100
-  };
+    metadata?: {
+      wordsGenerated: number;
+      totalWordsTarget?: number;
+      estimatedWordsRemaining: number;
+      generationSpeed: number; // words per second
+      percentage: number; // 0-100
+      estimatedTimeRemaining?: number; // seconds
+      chapterNumber?: number;
+      nextChapterHint?: string;
+    };
   error?: {
     code: string;
     message: string;
@@ -174,6 +193,7 @@ export interface StreamingStoryGenerationSeam {
     userInput: string;
     spicyLevel: SpicyLevel;
     wordCount: WordCount;
+    requestedChapterCount: ChapterBatchSize;
   };
 
   progressUpdate: {
@@ -189,23 +209,12 @@ export interface StreamingStoryGenerationSeam {
       generationSpeed: number; // words per second
       percentage: number; // 0-100
       estimatedTimeRemaining?: number; // seconds
+      chapterNumber?: number;
+      nextChapterHint?: string;
     };
   };
 
-  finalOutput: {
-    // Same as StoryGenerationSeam output
-    storyId: string;
-    title: string;
-    content: string;
-    rawContent?: string;
-    creature: CreatureType;
-    themes: ThemeType[];
-    spicyLevel: SpicyLevel;
-    actualWordCount: number;
-    estimatedReadTime: number;
-    hasCliffhanger: boolean;
-    generatedAt: Date;
-  };
+    finalOutput: StoryGenerationSeam['output'];
 
   errors: {
     STREAMING_CONNECTION_FAILED: {
@@ -404,5 +413,8 @@ export interface ApiResponse<T> {
     requestId: string;
     processingTime: number;
     rateLimitRemaining?: number;
+    chaptersRequested?: number;
+    chaptersGenerated?: number;
+    partialFailures?: ChapterGenerationError[];
   };
 }

--- a/story-generator/src/app/debug-panel/debug-panel.html
+++ b/story-generator/src/app/debug-panel/debug-panel.html
@@ -62,9 +62,9 @@
         <div class="heather-story-result" *ngIf="heatherStoryResult">
           <div class="story-preview">
             <h5>{{ heatherStoryResult.title }}</h5>
-            <p [innerHTML]="heatherStoryResult.content | slice:0:200"></p>
-            <small *ngIf="heatherStoryResult.content.length > 200">
-              ...{{ heatherStoryResult.actualWordCount }} words total
+            <p [innerHTML]="heatherStoryResult.appendedToStory | slice:0:200"></p>
+            <small *ngIf="heatherStoryResult.totalWordCount > 200">
+              ...{{ heatherStoryResult.totalWordCount }} words total
             </small>
           </div>
         </div>

--- a/story-generator/src/app/debug-panel/debug-panel.ts
+++ b/story-generator/src/app/debug-panel/debug-panel.ts
@@ -195,7 +195,8 @@ export class DebugPanel implements OnInit, OnDestroy {
       themes: ['desire'],
       userInput: '',
       spicyLevel: 2,
-      wordCount: 700
+      wordCount: 700,
+      requestedChapterCount: 1
     };
 
     const start = performance.now();
@@ -248,7 +249,8 @@ export class DebugPanel implements OnInit, OnDestroy {
       themes: ['forbidden_love', 'desire', 'passion'],
       userInput: 'Write a 250-word story about Heather, an immortal vampire who has lived for centuries. Focus on a moment of vulnerability when she encounters something that reminds her of her lost humanity.',
       spicyLevel: 3,
-      wordCount: 700 // Using minimum word count for shorter story
+      wordCount: 700, // Using minimum word count for shorter story
+      requestedChapterCount: 1
     };
 
     const start = performance.now();
@@ -259,8 +261,8 @@ export class DebugPanel implements OnInit, OnDestroy {
           const duration = Math.round(performance.now() - start);
           this.addError(
             'API',
-            `✅ Heather's story generated successfully in ${duration}ms (${resp.data.actualWordCount} words)`,
-            { storyId: resp.data.storyId, title: resp.data.title, duration, wordCount: resp.data.actualWordCount },
+            `✅ Heather's story generated successfully in ${duration}ms (${resp.data.totalWordCount} words)`,
+            { storyId: resp.data.storyId, title: resp.data.title, duration, wordCount: resp.data.totalWordCount },
             '/api/story/generate',
             'info'
           );

--- a/story-generator/src/app/story.service.spec.ts
+++ b/story-generator/src/app/story.service.spec.ts
@@ -57,24 +57,33 @@ describe('StoryService', () => {
       userInput: 'Victorian setting'
     });
 
-    const mockSuccessResponse: ApiResponse<StoryGenerationSeam['output']> = {
-      success: true,
-      data: {
-        storyId: 'story_123',
-        title: "The Vampire's Forbidden Passion",
-        content: '<h3>Chapter 1</h3><p>Story content...</p>',
-        creature: 'vampire' as CreatureType,
-        themes: ['forbidden_love', 'dark_secrets'] as ThemeType[],
-        spicyLevel: 3 as SpicyLevel,
-        actualWordCount: 150,
-        estimatedReadTime: 1,
-        hasCliffhanger: false,
-        generatedAt: new Date()
-      },
-      metadata: {
-        requestId: 'req_123',
-        processingTime: 2500
-      }
+    const generatedAt = new Date();
+    const mockSuccessResponse: ApiResponse<StoryGenerationSeam['output']> = createMockStoryResponse({
+      storyId: 'story_123',
+      title: "The Vampire's Forbidden Passion",
+      chapters: [
+        {
+          chapterId: 'story_123-ch1',
+          chapterNumber: 1,
+          title: "The Vampire's Forbidden Passion",
+          content: '<h3>Chapter 1</h3><p>Story content...</p>',
+          rawContent: '<h3>Chapter 1</h3><p>Story content...</p>',
+          wordCount: 150,
+          generatedAt,
+          hasAudio: false,
+          cliffhangerEnding: false
+        }
+      ],
+      themes: ['forbidden_love', 'dark_secrets'] as ThemeType[],
+      totalWordCount: 150,
+      estimatedReadTime: 1,
+      hasCliffhanger: false,
+      appendedToStory: '<h3>Chapter 1</h3><p>Story content...</p>',
+      generatedAt
+    });
+    mockSuccessResponse.metadata = {
+      requestId: 'req_123',
+      processingTime: 2500
     };
 
     it('should generate story successfully', () => {

--- a/story-generator/src/app/story.service.ts
+++ b/story-generator/src/app/story.service.ts
@@ -8,7 +8,8 @@ import {
   AudioConversionSeam,
   SaveExportSeam,
   ApiResponse,
-  StreamingProgressChunk
+  StreamingProgressChunk,
+  Chapter
 } from './contracts';
 import { ErrorLoggingService } from './error-logging';
 
@@ -36,7 +37,16 @@ export class StoryService {
     ).pipe(
       tap(response => {
         if (response.success) {
-          this.errorLogging.logInfo('Story generation successful', 'StoryService.generateStory', { storyId: response.data?.storyId });
+          this.errorLogging.logInfo('Story generation successful', 'StoryService.generateStory', {
+            storyId: response.data?.storyId,
+            chaptersGenerated: response.data?.chapters?.length || 0
+          });
+
+          if (response.metadata?.partialFailures?.length) {
+            this.errorLogging.logWarning('Story generation completed with partial failures', 'StoryService.generateStory', {
+              failures: response.metadata.partialFailures.map(failure => failure.chapterNumber)
+            });
+          }
         }
       }),
       catchError(error => this.handleError(error, 'generateStory'))
@@ -62,7 +72,8 @@ export class StoryService {
         themes: input.themes.join(','),
         spicyLevel: input.spicyLevel.toString(),
         wordCount: input.wordCount.toString(),
-        userInput: input.userInput || ''
+        userInput: input.userInput || '',
+        requestedChapterCount: String(input.requestedChapterCount ?? 1)
       });
       const url = `${this.apiUrl}/story/stream?${params.toString()}`;
       
@@ -114,27 +125,43 @@ export class StoryService {
               // Final story received
               finalStoryId = data.storyId || `story_${streamId}`;
               const finalContent = data.content || accumulatedContent;
-              
+              const chapterGeneratedAt = new Date();
+              const derivedTitle = this.extractTitle(finalContent);
+              const chapterWordCount = data.metadata?.wordsGenerated || this.computeWordCountFromHtml(finalContent);
+              const primaryChapter: Chapter = {
+                chapterId: data.chapterId || `${finalStoryId}-ch1`,
+                chapterNumber: data.metadata?.chapterNumber || 1,
+                title: derivedTitle || 'Chapter 1',
+                content: finalContent,
+                rawContent: finalContent,
+                wordCount: chapterWordCount,
+                generatedAt: chapterGeneratedAt,
+                hasAudio: false,
+                cliffhangerEnding: this.detectCliffhanger(finalContent),
+                nextChapterHint: data.metadata?.nextChapterHint
+              };
+
               const finalStory: ApiResponse<StoryGenerationSeam['output']> = {
                 success: true,
                 data: {
                   storyId: finalStoryId,
-                  title: this.extractTitle(finalContent),
-                  content: finalContent,
-                  rawContent: finalContent,
+                  title: derivedTitle || 'Untitled Adventure',
+                  chapters: [primaryChapter],
                   creature: input.creature,
                   themes: input.themes,
                   spicyLevel: input.spicyLevel,
-                  actualWordCount: data.metadata?.wordsGenerated || 0,
-                  estimatedReadTime: Math.ceil((data.metadata?.wordsGenerated || 0) / 200),
-                  hasCliffhanger: this.detectCliffhanger(finalContent),
-                  generatedAt: new Date()
+                  totalWordCount: chapterWordCount,
+                  estimatedReadTime: Math.ceil(chapterWordCount / 200),
+                  hasCliffhanger: primaryChapter.cliffhangerEnding,
+                  appendedToStory: finalContent,
+                  nextChapterHint: primaryChapter.nextChapterHint,
+                  generatedAt: chapterGeneratedAt
                 }
               };
-              
-              this.errorLogging.logInfo('Stream completed successfully', 'StoryService.generateStoryStreaming', { 
+
+              this.errorLogging.logInfo('Stream completed successfully', 'StoryService.generateStoryStreaming', {
                 storyId: finalStoryId,
-                wordCount: data.metadata?.wordsGenerated 
+                wordCount: chapterWordCount
               });
               
               if (onProgress) {
@@ -241,7 +268,16 @@ export class StoryService {
     ).pipe(
       tap(response => {
         if (response.success) {
-          this.errorLogging.logInfo('Chapter continuation successful', 'StoryService.generateNextChapter', { chapterId: response.data?.chapterId });
+          this.errorLogging.logInfo('Chapter continuation successful', 'StoryService.generateNextChapter', {
+            storyId: input.storyId,
+            chaptersGenerated: response.data?.chapters?.length || 0
+          });
+
+          if (response.metadata?.partialFailures?.length) {
+            this.errorLogging.logWarning('Chapter continuation completed with partial failures', 'StoryService.generateNextChapter', {
+              failures: response.metadata.partialFailures.map(failure => failure.chapterNumber)
+            });
+          }
         }
       }),
       catchError(error => this.handleError(error, 'generateNextChapter'))
@@ -313,9 +349,23 @@ export class StoryService {
    */
   private extractTitle(htmlContent: string): string {
     if (!htmlContent) return 'Untitled Story';
-    
+
     const titleMatch = htmlContent.match(/<h3[^>]*>(.*?)<\/h3>/);
     return titleMatch ? titleMatch[1].trim() : 'Untitled Story';
+  }
+
+  /**
+   * Estimate word count by stripping HTML tags and splitting on whitespace
+   */
+  private computeWordCountFromHtml(content: string): number {
+    if (!content) return 0;
+
+    const textOnly = content.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+    if (!textOnly) {
+      return 0;
+    }
+
+    return textOnly.split(' ').length;
   }
 
   /**

--- a/story-generator/src/app/streaming-story/streaming-story.component.spec.ts
+++ b/story-generator/src/app/streaming-story/streaming-story.component.spec.ts
@@ -216,20 +216,33 @@ describe('StreamingStoryComponent', () => {
     });
 
     it('should handle successful completion', (done) => {
+      const generatedAt = new Date();
       const mockResponse: ApiResponse<StoryGenerationSeam['output']> = {
         success: true,
         data: {
           storyId: 'story_123',
           title: 'Complete Story',
-          content: '<h3>Complete Story</h3><p>Final content</p>',
-          rawContent: '<h3>Complete Story</h3><p>Final content</p>',
+          chapters: [
+            {
+              chapterId: 'story_123-ch1',
+              chapterNumber: 1,
+              title: 'Complete Story',
+              content: '<h3>Complete Story</h3><p>Final content</p>',
+              rawContent: '<h3>Complete Story</h3><p>Final content</p>',
+              wordCount: 900,
+              generatedAt,
+              hasAudio: false,
+              cliffhangerEnding: false
+            }
+          ],
           creature: 'vampire' as CreatureType,
           themes: ['forbidden_love'] as ThemeType[],
           spicyLevel: 3 as SpicyLevel,
-          actualWordCount: 900,
+          totalWordCount: 900,
           estimatedReadTime: 5,
           hasCliffhanger: false,
-          generatedAt: new Date()
+          appendedToStory: '<h3>Complete Story</h3><p>Final content</p>',
+          generatedAt
         }
       };
 

--- a/story-generator/src/app/streaming-story/streaming-story.component.ts
+++ b/story-generator/src/app/streaming-story/streaming-story.component.ts
@@ -6,7 +6,7 @@
 import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { StoryService } from '../story.service';
-import { StoryGenerationSeam, CreatureType, ThemeType, WordCount } from '../contracts';
+import { StoryGenerationSeam, CreatureType, ThemeType, WordCount, Chapter } from '../contracts';
 
 @Component({
   selector: 'app-streaming-story',
@@ -238,7 +238,8 @@ export class StreamingStoryComponent {
       themes: ['forbidden_love', 'seduction'],
       userInput: 'A vampire lord meets a curious human in a moonlit garden',
       spicyLevel: 3,
-      wordCount: this.targetWords as WordCount
+      wordCount: this.targetWords as WordCount,
+      requestedChapterCount: 1
     };
 
     try {
@@ -322,6 +323,14 @@ export class StreamingStoryComponent {
       this.storyTitle = finalStory.data.title;
     } else if (finalStory?.title) {
       this.storyTitle = finalStory.title;
+    }
+
+    if (finalStory?.data?.appendedToStory) {
+      this.streamedContent = finalStory.data.appendedToStory;
+    } else if (finalStory?.data?.chapters?.length) {
+      this.streamedContent = finalStory.data.chapters
+        .map((chapter: Chapter) => chapter.content)
+        .join('');
     }
     
     // Add a small celebration effect

--- a/story-generator/src/testing/data-factory.ts
+++ b/story-generator/src/testing/data-factory.ts
@@ -1,0 +1,101 @@
+import {
+  StoryGenerationSeam,
+  Chapter,
+  StreamingProgressChunk,
+  ApiResponse
+} from '../app/contracts';
+
+function defaultChapter(overrides: Partial<Chapter> = {}): Chapter {
+  const generatedAt = overrides.generatedAt ?? new Date();
+  return {
+    chapterId: overrides.chapterId ?? 'chapter_1',
+    chapterNumber: overrides.chapterNumber ?? 1,
+    title: overrides.title ?? 'Mock Chapter',
+    content: overrides.content ?? '<h3>Mock Chapter</h3><p>Content...</p>',
+    rawContent: overrides.rawContent ?? '<h3>Mock Chapter</h3><p>Content...</p>',
+    wordCount: overrides.wordCount ?? 900,
+    generatedAt,
+    hasAudio: overrides.hasAudio ?? false,
+    audioUrl: overrides.audioUrl,
+    audioDuration: overrides.audioDuration,
+    cliffhangerEnding: overrides.cliffhangerEnding ?? false,
+    nextChapterHint: overrides.nextChapterHint
+  };
+}
+
+export function createMockStoryInput(
+  overrides: Partial<StoryGenerationSeam['input']> = {}
+): StoryGenerationSeam['input'] {
+  return {
+    creature: 'vampire',
+    themes: ['forbidden_love'],
+    userInput: 'A moonlit encounter',
+    spicyLevel: 3,
+    wordCount: 900,
+    requestedChapterCount: 1,
+    ...overrides
+  } as StoryGenerationSeam['input'];
+}
+
+export function createMockStoryOutput(
+  overrides: Partial<StoryGenerationSeam['output']> = {}
+): StoryGenerationSeam['output'] {
+  const chapters = overrides.chapters ?? [defaultChapter(overrides as Partial<Chapter>)];
+  const totalWordCount =
+    overrides.totalWordCount ?? chapters.reduce((sum, chapter) => sum + chapter.wordCount, 0);
+  const generatedAt = overrides.generatedAt ?? chapters[0]?.generatedAt ?? new Date();
+
+  return {
+    storyId: overrides.storyId ?? 'story_123',
+    title: overrides.title ?? chapters[0]?.title ?? 'Mock Story',
+    chapters,
+    creature: overrides.creature ?? 'vampire',
+    themes: overrides.themes ?? ['forbidden_love'],
+    spicyLevel: overrides.spicyLevel ?? 3,
+    totalWordCount,
+    estimatedReadTime: overrides.estimatedReadTime ?? Math.ceil(totalWordCount / 200),
+    hasCliffhanger:
+      overrides.hasCliffhanger ?? chapters.some(chapter => chapter.cliffhangerEnding === true),
+    appendedToStory:
+      overrides.appendedToStory ?? chapters.map(chapter => chapter.content).join(''),
+    nextChapterHint: overrides.nextChapterHint ?? chapters.find(ch => ch.nextChapterHint)?.nextChapterHint,
+    generatedAt,
+    chapterErrors: overrides.chapterErrors
+  };
+}
+
+export function createMockStoryResponse(
+  overrides: Partial<StoryGenerationSeam['output']> = {}
+): ApiResponse<StoryGenerationSeam['output']> {
+  return {
+    success: true,
+    data: createMockStoryOutput(overrides)
+  };
+}
+
+export function createMockProgressChunk(
+  type: StreamingProgressChunk['type'],
+  data: Partial<StreamingProgressChunk> = {}
+): StreamingProgressChunk {
+  return {
+    type,
+    storyId: data.storyId ?? 'story_123',
+    streamId: data.streamId ?? 'stream_123',
+    content: data.content,
+    metadata:
+      data.metadata ?? {
+        wordsGenerated: 150,
+        totalWordsTarget: 900,
+        estimatedWordsRemaining: 750,
+        generationSpeed: 50,
+        percentage: 10
+      }
+  };
+}
+
+export function createSSEMessage(payload: any): MessageEvent {
+  return {
+    data: JSON.stringify(payload)
+  } as MessageEvent;
+}
+

--- a/story-generator/src/testing/index.ts
+++ b/story-generator/src/testing/index.ts
@@ -6,4 +6,4 @@
  */
 
 export * from './event-source-mock';
-export * from './test-data-factory';
+export * from './data-factory';

--- a/tests/story-service.test.mjs
+++ b/tests/story-service.test.mjs
@@ -8,8 +8,8 @@
  * Run: node tests/story-service.test.mjs
  */
 
-import { StoryService } from '../api/lib/services/storyService.js';
-import { logger } from '../api/lib/utils/logger.js';
+const { StoryService } = await import('../api/lib/services/storyService.ts');
+const { logger } = await import('../api/lib/utils/logger.ts');
 
 // ANSI color codes for terminal output
 const colors = {
@@ -94,7 +94,8 @@ async function testBasicStoryGeneration() {
     themes: ['forbidden_love', 'desire'],
     userInput: 'A vampire lord meets a mortal librarian',
     spicyLevel: 3,
-    wordCount: 700
+    wordCount: 700,
+    requestedChapterCount: 1
   };
   
   logInfo(`Input: ${JSON.stringify(input, null, 2)}`);
@@ -133,25 +134,41 @@ async function testBasicStoryGeneration() {
     `Story has valid title: "${story.title}"`, 
     'Story missing or invalid title');
   
-  assert(typeof story.content === 'string' && story.content.length > 0, 
-    `Story has content (${story.content.length} chars)`, 
-    'Story missing or invalid content');
-  
-  assert(typeof story.actualWordCount === 'number' && story.actualWordCount > 0, 
-    `Story has word count: ${story.actualWordCount}`, 
+  assert(Array.isArray(story.chapters) && story.chapters.length === input.requestedChapterCount,
+    `Story returned ${story.chapters.length} chapter(s)`,
+    'Story missing chapter array');
+
+  const combinedContent = story.appendedToStory;
+  assert(typeof combinedContent === 'string' && combinedContent.length > 0,
+    `Story has combined content (${combinedContent.length} chars)`,
+    'Story missing combined content');
+
+  assert(typeof story.totalWordCount === 'number' && story.totalWordCount > 0,
+    `Story has word count: ${story.totalWordCount}`,
     'Story missing or invalid word count');
-  
-  assert(typeof story.estimatedReadTime === 'number' && story.estimatedReadTime > 0, 
-    `Story has read time: ${story.estimatedReadTime} min`, 
+
+  assert(typeof story.estimatedReadTime === 'number' && story.estimatedReadTime > 0,
+    `Story has read time: ${story.estimatedReadTime} min`,
     'Story missing or invalid read time');
-  
-  assert(typeof story.hasCliffhanger === 'boolean', 
-    `Story has cliffhanger flag: ${story.hasCliffhanger}`, 
+
+  assert(typeof story.hasCliffhanger === 'boolean',
+    `Story has cliffhanger flag: ${story.hasCliffhanger}`,
     'Story missing or invalid cliffhanger flag');
-  
+
+  const firstChapter = story.chapters[0];
+  assert(firstChapter.chapterNumber === 1,
+    'First chapter numbered correctly',
+    `First chapter number mismatch: ${firstChapter.chapterNumber}`);
+  assert(typeof firstChapter.content === 'string' && firstChapter.content.length > 0,
+    'First chapter has content',
+    'First chapter missing content');
+  assert(typeof firstChapter.wordCount === 'number' && firstChapter.wordCount > 0,
+    'First chapter has word count',
+    'First chapter missing word count');
+
   // Test: Word count accuracy (within 20% tolerance)
   const targetWordCount = input.wordCount;
-  const actualWordCount = story.actualWordCount;
+  const actualWordCount = story.totalWordCount;
   const tolerance = targetWordCount * 0.2; // 20% tolerance
   const withinTolerance = Math.abs(actualWordCount - targetWordCount) <= tolerance;
   
@@ -162,7 +179,7 @@ async function testBasicStoryGeneration() {
   }
   
   // Test: Content quality checks
-  const hasHTML = /<[^>]+>/.test(story.content);
+  const hasHTML = /<[^>]+>/.test(combinedContent);
   assert(hasHTML, 'Content contains HTML formatting', 'Content missing HTML formatting');
   
   // Test: Metadata
@@ -175,7 +192,7 @@ async function testBasicStoryGeneration() {
     'Metadata missing processingTime');
   
   // Display content preview
-  const cleanContent = story.content.replace(/<[^>]*>/g, '').trim();
+  const cleanContent = combinedContent.replace(/<[^>]*>/g, '').trim();
   const preview = cleanContent.substring(0, 300);
   logInfo(`Content preview:\n${preview}...`);
   
@@ -190,13 +207,14 @@ async function testAllCreatureTypes() {
   
   for (const creature of creatures) {
     logInfo(`\nTesting creature: ${creature}`);
-    
+
     const input = {
       creature,
       themes: ['desire', 'passion'],
       userInput: `A ${creature} story`,
       spicyLevel: 2,
-      wordCount: 700
+      wordCount: 700,
+      requestedChapterCount: 1
     };
     
     const result = await service.generateStory(input);
@@ -230,7 +248,8 @@ async function testAllSpicyLevels() {
       themes: ['passion', 'desire'],
       userInput: `Spicy level ${level} test`,
       spicyLevel: level,
-      wordCount: 700
+      wordCount: 700,
+      requestedChapterCount: 1
     };
     
     const result = await service.generateStory(input);
@@ -251,7 +270,7 @@ async function testAllSpicyLevels() {
 
 async function testWordCountVariations() {
   logTest('Word Count Variations (700, 900, 1200)');
-  
+
   const service = new StoryService();
   const wordCounts = [700, 900, 1200];
   
@@ -263,7 +282,8 @@ async function testWordCountVariations() {
       themes: ['obsession'],
       userInput: `Word count ${wordCount} test`,
       spicyLevel: 3,
-      wordCount
+      wordCount,
+      requestedChapterCount: 1
     };
     
     const startTime = Date.now();
@@ -275,7 +295,7 @@ async function testWordCountVariations() {
       `${wordCount} word story failed: ${result.error?.message}`);
     
     if (result.success) {
-      const actual = result.data.actualWordCount;
+      const actual = result.data.totalWordCount;
       const tolerance = wordCount * 0.2;
       const withinTolerance = Math.abs(actual - wordCount) <= tolerance;
       
@@ -287,6 +307,59 @@ async function testWordCountVariations() {
     }
     
     await new Promise(resolve => setTimeout(resolve, 1000));
+  }
+}
+
+async function testMultiChapterBatches() {
+  logTest('Requested Chapter Batches (1, 2, 3)');
+
+  const service = new StoryService();
+  const batchSizes = [1, 2, 3];
+
+  for (const batch of batchSizes) {
+    logInfo(`\nRequesting ${batch} chapter(s)`);
+
+    const input = {
+      creature: 'vampire',
+      themes: ['forbidden_love', 'desire'],
+      userInput: `Batch size ${batch} test`,
+      spicyLevel: 3,
+      wordCount: 700,
+      requestedChapterCount: batch
+    };
+
+    const result = await service.generateStory(input);
+
+    assert(result.success,
+      `Batch of ${batch} chapter(s) generated`,
+      `Batch generation failed: ${result.error?.message}`);
+
+    if (result.success) {
+      const chapters = result.data.chapters;
+      assert(chapters.length === batch,
+        `Received ${chapters.length} chapter(s)`,
+        `Expected ${batch} chapters, got ${chapters.length}`);
+
+      const totalFromChapters = chapters.reduce((sum, chapter) => sum + chapter.wordCount, 0);
+      assert(totalFromChapters === result.data.totalWordCount,
+        `Total word count matches sum of chapters (${totalFromChapters})`,
+        `Total word count mismatch: expected ${totalFromChapters}, got ${result.data.totalWordCount}`);
+
+      chapters.forEach((chapter, index) => {
+        const expectedNumber = index + 1;
+        assert(chapter.chapterNumber === expectedNumber,
+          `Chapter ${expectedNumber} correctly numbered`,
+          `Chapter numbering mismatch: expected ${expectedNumber}, got ${chapter.chapterNumber}`);
+      });
+
+      const expectedSeparatorCount = Math.max(0, batch - 1);
+      const separatorMatches = result.data.appendedToStory.match(/<hr>/g) || [];
+      assert(separatorMatches.length === expectedSeparatorCount,
+        `Appended story contains ${expectedSeparatorCount} separator(s)`,
+        `Separator count mismatch: expected ${expectedSeparatorCount}, got ${separatorMatches.length}`);
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 500));
   }
 }
 
@@ -302,7 +375,8 @@ async function testChapterContinuation() {
     themes: ['forbidden_love', 'betrayal'],
     userInput: 'A fairy princess falls for a dark sorcerer',
     spicyLevel: 3,
-    wordCount: 700
+    wordCount: 700,
+    requestedChapterCount: 1
   };
   
   const initialStory = await service.generateStory(initialInput);
@@ -320,8 +394,9 @@ async function testChapterContinuation() {
   const continueInput = {
     storyId: initialStory.data.storyId,
     currentChapterCount: 1,
-    existingContent: initialStory.data.content,
-    maintainTone: true
+    existingContent: initialStory.data.appendedToStory,
+    maintainTone: true,
+    requestedChapterCount: 2
   };
   
   const chapter2 = await service.continueChapter(continueInput);
@@ -331,17 +406,24 @@ async function testChapterContinuation() {
     `Chapter 2 failed: ${chapter2.error?.message}`);
   
   if (chapter2.success) {
-    assert(chapter2.data.chapterNumber === 2, 
-      `Chapter number is 2`, 
-      `Chapter number mismatch: ${chapter2.data.chapterNumber}`);
-    
-    assert(chapter2.data.content.length > 0, 
-      `Chapter 2 has content (${chapter2.data.content.length} chars)`, 
-      'Chapter 2 has no content');
-    
-    logInfo(`Chapter 2 word count: ${chapter2.data.wordCount}`);
+    const newChapters = chapter2.data.chapters;
+    assert(newChapters.length === 2,
+      'Continuation returned 2 chapters',
+      `Continuation returned ${newChapters.length} chapters`);
+
+    const chapterNumbers = newChapters.map(chapter => chapter.chapterNumber);
+    assert(chapterNumbers[0] === 2 && chapterNumbers[1] === 3,
+      'Chapters numbered sequentially (2, 3)',
+      `Chapter numbers mismatch: ${chapterNumbers.join(', ')}`);
+
+    newChapters.forEach((chapter, index) => {
+      assert(chapter.content.length > 0,
+        `Chapter ${chapter.chapterNumber} has content`,
+        `Chapter ${chapter.chapterNumber} missing content`);
+      logInfo(`Chapter ${chapter.chapterNumber} word count: ${chapter.wordCount}`);
+    });
   }
-  
+
   return chapter2.success;
 }
 
@@ -357,7 +439,8 @@ async function testInputValidation() {
     themes: ['passion'],
     userInput: 'Test',
     spicyLevel: 3,
-    wordCount: 700
+    wordCount: 700,
+    requestedChapterCount: 1
   });
   
   assert(!result.success && result.error?.code === 'INVALID_INPUT', 
@@ -371,7 +454,8 @@ async function testInputValidation() {
     themes: ['passion'],
     userInput: 'Test',
     spicyLevel: 10, // Invalid!
-    wordCount: 700
+    wordCount: 700,
+    requestedChapterCount: 1
   });
   
   assert(!result.success && result.error?.code === 'INVALID_INPUT', 
@@ -385,12 +469,34 @@ async function testInputValidation() {
     themes: [], // Invalid!
     userInput: 'Test',
     spicyLevel: 3,
-    wordCount: 700
+    wordCount: 700,
+    requestedChapterCount: 1
   });
-  
-  assert(!result.success && result.error?.code === 'INVALID_INPUT', 
-    'Empty themes rejected', 
+
+  assert(!result.success && result.error?.code === 'INVALID_INPUT',
+    'Empty themes rejected',
     'Empty themes were not rejected');
+
+  // Test invalid requested chapter count (should clamp to 3)
+  logInfo('\nTesting invalid requestedChapterCount...');
+  result = await service.generateStory({
+    creature: 'vampire',
+    themes: ['passion'],
+    userInput: 'Test',
+    spicyLevel: 3,
+    wordCount: 700,
+    requestedChapterCount: 5
+  });
+
+  assert(result.success,
+    'Invalid requestedChapterCount is clamped and request succeeds',
+    `Invalid requestedChapterCount caused failure: ${result.error?.message}`);
+
+  if (result.success) {
+    assert(result.data.chapters.length === 3,
+      'Chapter count clamped to maximum of 3',
+      `Chapter count not clamped: ${result.data.chapters.length}`);
+  }
 }
 
 async function testSpeakerTags() {
@@ -402,7 +508,8 @@ async function testSpeakerTags() {
     themes: ['passion', 'desire'],
     userInput: 'A vampire and a mortal have a passionate encounter with lots of dialogue',
     spicyLevel: 4,
-    wordCount: 900
+    wordCount: 900,
+    requestedChapterCount: 1
   };
   
   const result = await service.generateStory(input);
@@ -412,21 +519,22 @@ async function testSpeakerTags() {
     `Story failed: ${result.error?.message}`);
   
   if (result.success) {
-    const content = result.data.content;
-    const hasSpeakerTags = /\[([^\]]+)\]:/.test(content);
-    
+    const combinedContent = result.data.appendedToStory;
+    const firstChapter = result.data.chapters[0];
+    const hasSpeakerTags = /\[([^\]]+)\]:/.test(combinedContent);
+
     if (hasSpeakerTags) {
-      const speakerMatches = content.match(/\[([^\]]+)\]:/g);
+      const speakerMatches = combinedContent.match(/\[([^\]]+)\]:/g);
       const uniqueSpeakers = [...new Set(speakerMatches)];
-      
+
       logSuccess(`Speaker tags found: ${uniqueSpeakers.length} unique speakers`);
       logInfo(`Speakers: ${uniqueSpeakers.slice(0, 5).join(', ')}${uniqueSpeakers.length > 5 ? '...' : ''}`);
     } else {
       warn('No speaker tags found in content (expected for dialogue-heavy stories)');
     }
-    
-    // Check for rawContent (should have speaker tags preserved)
-    if (result.data.rawContent) {
+
+    // Check for rawContent on chapter (should have speaker tags preserved)
+    if (firstChapter?.rawContent) {
       logSuccess('rawContent field present (for audio processing)');
     } else {
       warn('rawContent field missing (needed for multi-voice audio)');
@@ -446,7 +554,8 @@ async function testLoggingIntegration() {
     themes: ['power_dynamics'],
     userInput: 'Testing logging',
     spicyLevel: 2,
-    wordCount: 700
+    wordCount: 700,
+    requestedChapterCount: 1
   };
   
   await service.generateStory(input);
@@ -493,6 +602,7 @@ async function runAllTests() {
     { name: 'All Creature Types', fn: testAllCreatureTypes },
     { name: 'All Spicy Levels', fn: testAllSpicyLevels },
     { name: 'Word Count Variations', fn: testWordCountVariations },
+    { name: 'Requested Chapter Batches', fn: testMultiChapterBatches },
     { name: 'Chapter Continuation', fn: testChapterContinuation },
     { name: 'Input Validation', fn: testInputValidation },
     { name: 'Speaker Tags (Multi-Voice)', fn: testSpeakerTags },


### PR DESCRIPTION
## Summary
- expand story generation and continuation contracts to accept requested chapter counts and return aggregated chapter arrays with hints
- update backend story service and endpoints to iterate through requested batches, clamp inputs, and collect partial failures
- teach the Angular client to send batch sizes, merge chapter arrays, surface warnings, and add testing helpers for the new response shape

## Testing
- `npx tsx tests/story-service.test.mjs > test-output.log`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6902a6083f3483208995fc7b65fb4cbd

## Summary by Sourcery

Support batch chapter generation across backend and frontend: normalize and clamp requested chapter counts, iterate to generate aggregated chapter arrays with hints and partial failure collection, update contracts and metadata, and teach the Angular UI to send batch sizes, render multiple chapters, and surface warnings.

New Features:
- Enable requesting multiple chapters per story generation and continuation on backend
- Add chapter batch size dropdown and warnings in the Angular client

Enhancements:
- Introduce helper functions for normalizing chapter count, sequencing titles, and generating next-chapter hints
- Extend API contracts and logging to include chaptersRequested, chaptersGenerated, and partialFailures metadata

Tests:
- Update unit tests and test data factory to cover multi-chapter batches and new response shape
- Add end-to-end tests for batch chapter generation and partial failure handling