### PR TITLE
Refactor: Deduplicate Grok model name with private class constant

### DIFF
--- a/api/lib/services/storyService.ts
+++ b/api/lib/services/storyService.ts
@@ -9,6 +9,7 @@ import {
 import { logger, logError, logWarn, logApiError, logInfo, logPerformance, LogContext } from '../utils/logger';
 
 export class StoryService {
+  private readonly grokModel = 'grok-4-1-fast-reasoning';
   private grokApiUrl = 'https://api.x.ai/v1/chat/completions';
   private grokApiKey = process.env['XAI_API_KEY'];
 
@@ -243,7 +244,7 @@ export class StoryService {
       const response = await axios.post(
         this.grokApiUrl,
         {
-          model: 'grok-4-fast-reasoning', // Use same model for consistency
+          model: this.grokModel, // Use same model for consistency
           messages: [
             { role: 'system', content: systemPrompt },
             { role: 'user', content: userPrompt }
@@ -373,12 +374,12 @@ export class StoryService {
 
     try {
       logInfo('Calling Grok API', context, {
-        model: 'grok-4-fast-reasoning',
+        model: this.grokModel,
         maxTokens: this.calculateOptimalTokens(input.wordCount)
       });
 
       const response = await axios.post(this.grokApiUrl, {
-        model: 'grok-4-fast-reasoning',
+        model: this.grokModel,
         messages: [
           {
             role: 'system',
@@ -413,7 +414,7 @@ export class StoryService {
 
     } catch (error: any) {
       logApiError('Grok AI', error, context, {
-        model: 'grok-4-fast-reasoning',
+        model: this.grokModel,
         wordCount: input.wordCount,
         creature: input.creature,
         spicyLevel: input.spicyLevel
@@ -436,7 +437,7 @@ export class StoryService {
       logInfo('Calling Grok API for chapter continuation', context);
 
       const response = await axios.post(this.grokApiUrl, {
-        model: 'grok-4-fast-reasoning',
+        model: this.grokModel,
         messages: [
           {
             role: 'system',
@@ -471,7 +472,7 @@ export class StoryService {
 
     } catch (error: any) {
       logApiError('Grok AI (Continuation)', error, context, {
-        model: 'grok-4-fast-reasoning',
+        model: this.grokModel,
         chapterNumber: input.currentChapterCount + 1
       });
       


### PR DESCRIPTION
- Add private readonly constant `grokModel` = 'grok-4-1-fast-reasoning'
- Replace all 6 hardcoded model name instances with `this.grokModel`
- Update model name from 'grok-4-fast-reasoning' to 'grok-4-1-fast-reasoning'

This change improves maintainability by centralizing the model name in a single location, making future updates easier and reducing the risk of inconsistencies across API calls and log statements.

Addresses code review feedback to follow DRY principle.

## Summary by Sourcery

Enhancements:
- Introduce a private class constant for the Grok model name and replace hardcoded usages to improve maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal AI configuration for enhanced system operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->