### PR TITLE
Wire Story Lab to the real story engine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,9 @@ This file is read automatically by AI coding agents. It is the repo-level operat
 
 The active direction is documented in `PR70_RECOVERY_PLAN.md`.
 
-The next parallel-agent execution plan is `plan.md`. Use it only after the current review-fix/polish branch is merged; do not use it as permission to keep expanding the recovery baseline PR.
+The next Story Lab real-engine execution plan is `STORY_LAB_REAL_ENGINE_EXEC_PLAN.md`. Use it before changing Story Lab generation semantics.
+
+The previous parallel-agent execution plan is `plan.md`. Treat it as superseded for the immediate Story Lab real-engine work; do not use it as permission to broaden this branch.
 
 Follow that plan before doing broad PR reconciliation work. The intended recovery path is:
 

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -97,3 +97,7 @@ This file consolidates lessons that should shape the PR #70 recovery and future 
 - Review-polish branches need a hard scope boundary. Fix review comments, validate, and merge; put the next large product move in a separate plan/branch so cleanup work does not become another oversized mixed PR.
 - Prefer direct local tool binaries in recovery scripts when `npx` behavior is ambiguous. In this repo, `npx tsc -p ...` can hang under `npm exec`, while `node_modules/.bin/tsc` runs predictably.
 - A function-count check is stronger when it names the expected functions. A raw count can pass while hiding accidental helper placement; an allow-list makes deployable API shape intentional.
+- A Story Lab-to-engine bridge becomes technical debt if it compresses rich blueprint fields into a generic prompt string. Promote the rich fields into the real generation contract instead.
+- Mock fallback must be explicit and honest. It is acceptable when no provider key exists or a mock flag is set; it should not hide configured provider failures.
+- Heuristic continuity state should be labeled by behavior, not ambition. Until AI state extraction or durable persistence exists, real generated prose can seed Story Lab panels, but those panels are not proof of durable continuity intelligence.
+- When a rich UI uses free-form labels but an older engine uses a closed union, preserve the rich data separately and canonicalize only the legacy field. Casting free-form IDs into closed contracts hides generation bugs.

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -976,3 +976,71 @@ Self-review:
 - Problem found: Running `npx tsc -p ...` inside preflight hung as `npm exec`; direct local `tsc` binaries are more predictable for this repo.
 - Problem found: A stricter discriminated API response type immediately exposed an evaluation-route variable collision.
 - Should have anticipated sooner: Review comments that look cosmetic can expose real boundaries, especially API envelope shape and Vercel function counting.
+
+## 2026-05-27 21:05 EDT - Story Lab Real Engine Work Started
+
+Actions:
+
+- Created `STORY_LAB_REAL_ENGINE_EXEC_PLAN.md` with three implementation critique/revision passes and three autonomous execution-plan critique/revision passes.
+- Updated `AGENTS.md` so future Story Lab generation work starts from the new real-engine plan.
+- Added first-class Story Lab generation context to the real story engine contract:
+  - logline,
+  - tone,
+  - protagonist and antagonist names,
+  - world details,
+  - narrative directives,
+  - full theme seed metadata.
+- Updated the real `StoryService` prompt builder so Story Lab blueprint fields are explicit prompt constraints rather than flattened into a generic user-input blob.
+- Added `api/_lib/story-lab/storyLabEngine.ts` to orchestrate Story Lab genesis and continuation through the real `StoryService` when `XAI_API_KEY` is configured.
+- Kept mock Story Lab generation only for missing provider key or explicit `STORY_LAB_FORCE_MOCK`.
+- Wired Story Lab genesis, continuation, and streaming genesis routes to the new Story Lab engine orchestration.
+- Marked mock Story Lab telemetry as `custom` instead of `gpt`.
+- Added `tests/story-lab-real-engine.test.ts` and a root `test:story-lab-real-engine` script.
+- Added an explicit test proving configured provider failure returns the provider error instead of silently falling back to mock Story Lab output.
+
+Validation:
+
+- `git diff --check` passed.
+- Direct Vercel API typecheck passed after replacing an `.at(-1)` use that the ES2020 Vercel typecheck target rejected.
+- `npm run test:story-lab-real-engine` passed.
+- `npm run test:story-lab-state` passed.
+- `npm run test:all` passed.
+- `scripts/recovery/check-vercel-function-count.sh` passed and reported `12/12`.
+- `scripts/recovery/preflight.sh --quick --skip-status` passed.
+- Node 20 Angular build passed with `npx -p node@20 -c "node -v && npm run build"`.
+
+Self-review:
+
+- Good: Story Lab no longer needs a permanent lossy adapter to reach the real engine; the rich blueprint now enters the real prompt contract as structured context.
+- Good: Configured provider failures should not silently fall back to fake Story Lab content.
+- Problem found: Story Lab continuity state derived from real prose is still heuristic. That is acceptable for this slice only because it is not represented as durable storage or AI-grade story analysis.
+- Should have anticipated: the Vercel API typecheck target still rejects `.at()`, so new recovery code should use index access consistently.
+
+## 2026-05-27 22:52 EDT - PR90 Automated Review Fixes
+
+Actions:
+
+- Addressed automated review feedback on PR #90:
+  - canonicalized Story Lab theme IDs before passing them to the classic engine instead of casting free-form IDs to `ThemeType`,
+  - preserved full Story Lab theme seeds in `generationContext`,
+  - carried trope metadata through `StorySummary` so continuations can reuse the original trope-subversion state,
+  - changed continuation content assembly to fall back from empty `rawContent` to `htmlContent`,
+  - sent SSE headers and the initial `connected` event before awaiting real generation,
+  - forwarded `protagonistName`, `antagonistName`, and `worldDetails` through the streaming genesis path,
+  - converted partial real-engine batch failures into explicit Story Lab errors instead of silently returning a shorter completed batch,
+  - mapped real `StoryService` processing time into Story Lab telemetry latency,
+  - replaced regex-based HTML/speaker-tag stripping with linear scans to satisfy SonarCloud hotspot checks,
+  - fixed timestamp headers on new files and updated word-count pacing guidance for 600 and 1500 words.
+
+Validation:
+
+- `git diff --check` passed before the first review-fix amend.
+- `npm run test:story-lab-real-engine` passed after review fixes.
+- Direct Vercel API typecheck passed after review fixes.
+- Angular TypeScript check passed with `cd story-generator && npx tsc --noEmit --project tsconfig.json`.
+
+Self-review:
+
+- Good: The review comments improved the architecture instead of just polishing style. Theme canonicalization and trope metadata preservation directly protect story-generation quality.
+- Problem found: The first implementation made the streaming endpoint production-capable in name but still delayed the first event until after generation. The fix makes the endpoint at least connection-honest, though true token/chapter streaming remains future work.
+- Should have anticipated: Story Lab's free-form theme IDs and the classic engine's closed `ThemeType` union were a contract mismatch. The rich `generationContext` made this survivable, but the classic field still needed canonicalization.

--- a/STORY_LAB_REAL_ENGINE_EXEC_PLAN.md
+++ b/STORY_LAB_REAL_ENGINE_EXEC_PLAN.md
@@ -1,0 +1,136 @@
+# Story Lab Real Engine Execution Plan
+
+Created: 2026-05-28 02:20 UTC
+
+## Objective
+
+Make the Story Lab UI drive the real story-generation engine without losing advanced Story Lab intent and without creating a permanent lossy adapter layer.
+
+The app currently has:
+
+- a live Story Lab UI backed by `api/story-lab/*`,
+- a working real story-generation engine behind `api/story/generate`,
+- mock Story Lab response builders in `api/_lib/story-lab/mockData.ts`.
+
+The target is one production generation engine that accepts the richer Story Lab blueprint as first-class input. Mock generation remains available only as development fallback when no provider key exists.
+
+## Implementation Idea Passes
+
+### Implementation Idea V1
+
+Wire `api/story-lab/stories.ts` to call the existing `StoryService.generateStory()` and map the result back into `StoryIterationPayload`. Keep the current Story Lab UI and generated state panels.
+
+### Hostile Senior Review 1
+
+This sounds like the exact adapter debt the user objected to. If you stuff `logline`, protagonist, world details, and directives into `userInput`, you degrade the prompt and bless a translation layer that will become permanent. Also, continuation will drift because generated Story Lab state will not be meaningful enough for later chapters.
+
+### Revised Idea V2
+
+Extend the real generator contract so the engine receives Story Lab context explicitly:
+
+- logline,
+- tone,
+- protagonist name,
+- antagonist name,
+- world details,
+- narrative directives,
+- full theme seed metadata,
+- chapter batch size.
+
+Then add a Story Lab orchestration method that calls the real engine with this richer canonical request and derives Story Lab output from real generated chapters. The mapper is limited to UI envelope shaping, not prompt meaning compression.
+
+### Hostile Senior Review 2
+
+Better, but now you may pollute the older `/api/story/generate` contract with Story Lab-only fields and make both routes harder to reason about. You also have to prove the generator prompt actually uses the fields, not just type-accepts them. If tests only check shapes, quality can still be lost.
+
+### Revised Idea V3
+
+Introduce `generationContext` as an additive field on the real generation input. Existing legacy callers remain valid, while Story Lab calls pass rich context. Update prompt construction to use those fields explicitly and visibly. Add contract/shape tests that assert Story Lab input reaches the real prompt contract and that Story Lab endpoints no longer call mock builders in production paths.
+
+### Hostile Senior Review 3
+
+Do not over-abstract provider switching yet. The real problem is mock-vs-real Story Lab. If you introduce OpenAI/Grok provider ports, model registries, visual redesign, and persistence in the same PR, you will make another monster branch. Also, do not delete mocks; they are useful when no API key exists.
+
+### Final Implementation Idea
+
+For this slice:
+
+1. Add a canonical rich generation context to the real story engine input.
+2. Make Story Lab genesis and continuation call the real `StoryService` in production-capable paths.
+3. Keep `buildGenesisResponse()` / `buildContinuationResponse()` as explicit mock fallback only when the real engine is unavailable or intentionally in mock mode.
+4. Convert real generated chapters into Story Lab chapter/state envelopes without discarding chapter HTML, raw content, cliffhanger flags, trope metadata, or story summary.
+5. Leave OpenAI/provider abstraction and visual charm restoration as follow-up work.
+
+## Autonomous Execution Plan Passes
+
+### Exec Plan V1
+
+1. Add a helper under `api/_lib/story-lab/`.
+2. Update Story Lab routes to call it.
+3. Add tests.
+4. Validate.
+
+### Hostile Senior Review 1
+
+This is too vague. It does not say which helpers are canonical, which files are touched, how mocks are protected, or how you will avoid Vercel function-count drift. It also skips continuation, which means the first generation might work but the app workflow still breaks.
+
+### Revised Exec Plan V2
+
+1. Create `api/_lib/story-lab/realStoryEngine.ts` as the Story Lab orchestration layer.
+2. Extend `api/_lib/types/contracts.ts` with additive `generationContext`.
+3. Update `StoryService.buildUserPrompt()` and chapter prompt paths to read `generationContext`.
+4. Update `api/story-lab/stories.ts` and continuation route to call the real orchestrator.
+5. Keep mock fallback in the same route behind explicit fallback logic.
+6. Add root TSX tests for mapping, fallback, and response shape.
+7. Run quick preflight and Node 20 Angular build.
+
+### Hostile Senior Review 2
+
+Naming it `realStoryEngine` may hide that `StoryService` is still the actual engine. Also, route fallback can mask real production failures if you silently fall back from a configured provider failure to mock content. That would make a demo look successful while story quality is fake.
+
+### Revised Exec Plan V3
+
+1. Name the orchestration file `storyLabEngine.ts`.
+2. In routes, mock fallback is allowed only when no provider key exists or an explicit mock env flag is set. If a provider key exists and real generation fails, return an error.
+3. Add telemetry that reports `engine: 'grok'` for real StoryService calls and `engine: 'custom'` for mock fallback.
+4. Add tests for "configured provider failure does not silently mock."
+5. Update changelog with the fallback policy.
+
+### Hostile Senior Review 3
+
+Still too much if you try to solve continuation perfectly. You do not have durable state yet, and generated state is partly heuristic. Deliver the smallest honest production win: real genesis, real continuation using previous chapter content, and transparent state heuristics. Document what remains heuristic instead of pretending it is solved.
+
+### Final Autonomous Exec Plan
+
+#### Phase 1 - Real Story Lab Genesis
+
+- Add `generationContext` to the real generation contract.
+- Update prompt construction to consume Story Lab context explicitly.
+- Add `api/_lib/story-lab/storyLabEngine.ts`.
+- Update `api/story-lab/stories.ts` so genesis calls the real engine when `XAI_API_KEY` exists.
+- Keep mock fallback only when no provider key exists.
+- Add tests for real-engine mapping in mock mode and fallback policy.
+
+#### Phase 2 - Real Story Lab Continuation
+
+- Convert Story Lab continuation state and previous chapters into the real continuation request.
+- Return real generated continuation chapters in the Story Lab envelope.
+- Preserve prior Story Lab state and add heuristic deltas for new chapters.
+- Keep transient persistence honest; do not claim durable storage.
+
+#### Phase 3 - Validation And Review
+
+- Run `git diff --check`.
+- Run Story Lab engine tests.
+- Run root story tests.
+- Run `scripts/recovery/preflight.sh --quick --skip-status`.
+- Run Node 20 Angular build.
+- Update `PR70_RECOVERY_CHANGELOG.md` and `LESSONS_LEARNED.md`.
+- Self-review the implementation against this document before opening a PR.
+
+## Current Known Tradeoffs
+
+- Story Lab state extraction from real prose will initially be heuristic. That is acceptable if documented and not represented as AI-analyzed durable continuity.
+- Mocks remain useful for local/no-key development but must not mask production provider failures.
+- Provider abstraction for OpenAI vs Grok is intentionally deferred until Story Lab is connected to the real engine.
+- Visual charm restoration is product work and should follow this engine unification rather than mix into it.

--- a/api/_lib/services/storyService.ts
+++ b/api/_lib/services/storyService.ts
@@ -1162,9 +1162,10 @@ Your goal: Create episodes that make listeners desperate for "Continue Chapter."
 
   private buildUserPrompt(input: StoryGenerationSeam['input']): string {
     const creatureName = this.getCreatureDisplayName(input.creature);
-    const themesText = input.themes.join(', ');
+    const themesText = this.formatThemeContext(input);
     const spicyLabel = this.getSpicyLabel(input.spicyLevel);
     const chekovElements = this.generateChekovElements();
+    const storyLabContext = this.formatStoryLabContext(input);
 
     return `Write a ${input.wordCount}-word spicy supernatural romance story optimized for audio narration:
 
@@ -1172,6 +1173,7 @@ PROTAGONIST: ${creatureName} with complex motivations and hidden depths
 THEMES TO WEAVE: ${themesText}
 SPICE LEVEL: ${spicyLabel} (Level ${input.spicyLevel}/5) - maintain this intensity throughout
 ${input.userInput ? `CREATIVE DIRECTION: ${input.userInput}` : ''}
+${storyLabContext}
 
 CHEKHOV LEDGER (plant these elements for future payoff):
 ${chekovElements}
@@ -1186,9 +1188,11 @@ STORY REQUIREMENTS:
 - Follow the selected beat structure precisely
 
 WORD COUNT PACING:
+- 600 words: Compressed hook, immediate tension, clean payoff
 - 700 words: Fast, tense, sharp progression
 - 900 words: Character depth with tight focus  
 - 1200 words: Layered, immersive with complex tension
+- 1500 words: Multi-scene escalation with richer reversals and payoff
 
 MANDATORY FORMATTING FOR AUDIO:
 - [Character Name, voice: 4-word description]: "dialogue" for FIRST appearance of each major character
@@ -1206,6 +1210,57 @@ USE CREATIVE, UNCONVENTIONAL VOICE DESCRIPTORS - NO REPEATED WORDS ACROSS CHARAC
 Create a complete story that feels like it could continue but is satisfying on its own. Make every word count toward character development, world-building, or advancing romantic/sexual tension.
 
 Plant your Chekhov elements naturally and ensure the moral dilemma occurs at midpoint. End with a cliffhanger that creates genuine desire for continuation.`;
+  }
+
+  private formatThemeContext(input: StoryGenerationSeam['input']): string {
+    const themeSeeds = input.generationContext?.themeSeeds ?? [];
+    if (themeSeeds.length > 0) {
+      return themeSeeds
+        .map(theme => `${theme.label} (${theme.description})`)
+        .join('; ');
+    }
+
+    return input.themes.join(', ');
+  }
+
+  private formatStoryLabContext(input: StoryGenerationSeam['input']): string {
+    const context = input.generationContext;
+    if (context?.source !== 'story_lab') {
+      return '';
+    }
+
+    const lines = [
+      '',
+      'STORY LAB BLUEPRINT - FIRST-CLASS CREATIVE CONSTRAINTS:'
+    ];
+
+    if (context.logline) {
+      lines.push(`- Logline: ${context.logline}`);
+    }
+    if (context.tone) {
+      lines.push(`- Narrative tone: ${context.tone.split('_').join(' ')}`);
+    }
+    if (context.protagonistName) {
+      lines.push(`- Protagonist name: ${context.protagonistName}`);
+    }
+    if (context.antagonistName) {
+      lines.push(`- Antagonist name or opposing force: ${context.antagonistName}`);
+    }
+    if (context.worldDetails) {
+      lines.push(`- World details: ${context.worldDetails}`);
+    }
+    if (context.narrativeDirectives) {
+      lines.push(`- Narrative directives: ${context.narrativeDirectives}`);
+    }
+    if (context.themeSeeds?.length) {
+      lines.push('- Theme seed intent:');
+      for (const theme of context.themeSeeds) {
+        lines.push(`  * ${theme.label}: ${theme.description}`);
+      }
+    }
+
+    lines.push('- Treat these blueprint fields as binding story intent, not as optional flavor.');
+    return lines.join('\n');
   }
 
   private buildChapterUserPrompt(

--- a/api/_lib/story-lab/mockData.ts
+++ b/api/_lib/story-lab/mockData.ts
@@ -300,7 +300,7 @@ export function buildGenesisResponse(
     state,
     stateDelta: buildStateDelta(storyId, null, state, chapters),
     telemetry: {
-      engine: 'gpt',
+      engine: 'custom',
       totalLatencyMs: 2200,
       averageChapterLatencyMs: Math.round(2200 / input.chapterBatchSize),
       tokensConsumed: 1600,
@@ -343,7 +343,7 @@ export function buildContinuationResponse(
     state: nextState,
     stateDelta: buildStateDelta(input.storyId, input.storyState, nextState, chapters),
     telemetry: {
-      engine: 'gpt',
+      engine: 'custom',
       totalLatencyMs: 2400,
       averageChapterLatencyMs: Math.round(2400 / input.chapterBatchSize),
       tokensConsumed: 1750,

--- a/api/_lib/story-lab/storyLabEngine.ts
+++ b/api/_lib/story-lab/storyLabEngine.ts
@@ -1,0 +1,681 @@
+// Created: 2026-05-28 02:39 UTC
+
+import type {
+  ApiResponse,
+  CharacterProfile,
+  ChapterDelta,
+  GenerationTelemetry,
+  GeneratedChapter,
+  LoreArtifact,
+  PlotThread,
+  StoryContinuationSeam as LabContinuationSeam,
+  StoryGenerationSeam as LabGenerationSeam,
+  StoryIterationPayload,
+  StoryStateDelta,
+  StoryStateSnapshot,
+  StorySummary
+} from './contracts';
+import type {
+  Chapter as ClassicChapter,
+  ChapterContinuationSeam as ClassicContinuationSeam,
+  ChapterFailure,
+  ApiResponseMetadata,
+  StoryGenerationSeam as ClassicGenerationSeam,
+  ThemeType
+} from '../types/contracts';
+import { StoryService } from '../services/storyService';
+import { buildContinuationResponse, buildGenesisResponse } from './mockData';
+import { getTransientStorySnapshot, persistStoryIteration } from './stateStore';
+
+type ClassicStoryOutput = ClassicGenerationSeam['output'];
+type ClassicContinuationOutput = ClassicContinuationSeam['output'];
+type StoryServiceLike = Pick<StoryService, 'generateStory' | 'continueChapter'>;
+type StoryLabErrorResponse = Extract<ApiResponse<never>, { success: false }>;
+
+interface StoryLabEngineOptions {
+  serviceFactory?: () => StoryServiceLike;
+}
+
+const MOCK_FLAG_VALUES = new Set(['1', 'true', 'yes']);
+const CLASSIC_THEME_TYPES: readonly ThemeType[] = [
+  'betrayal',
+  'obsession',
+  'power_dynamics',
+  'forbidden_love',
+  'revenge',
+  'manipulation',
+  'seduction',
+  'dark_secrets',
+  'corruption',
+  'dominance',
+  'submission',
+  'jealousy',
+  'temptation',
+  'sin',
+  'desire',
+  'passion',
+  'lust',
+  'deceit'
+];
+const CLASSIC_THEME_SET = new Set<string>(CLASSIC_THEME_TYPES);
+const DEFAULT_CLASSIC_THEME: ThemeType = 'forbidden_love';
+
+export function shouldUseMockStoryLab(): boolean {
+  const forceMock = process.env['STORY_LAB_FORCE_MOCK'] ?? '';
+  return MOCK_FLAG_VALUES.has(forceMock.toLowerCase()) || !process.env['XAI_API_KEY'];
+}
+
+function toClassicThemes(themeIds: string[]): ThemeType[] {
+  const classicThemes = themeIds
+    .map(themeId => themeId.split('-').join('_'))
+    .filter(isThemeType)
+    .slice(0, 5);
+
+  return classicThemes.length ? classicThemes : [DEFAULT_CLASSIC_THEME];
+}
+
+function isThemeType(themeId: string): themeId is ThemeType {
+  return CLASSIC_THEME_SET.has(themeId);
+}
+
+export function toClassicGenerationInput(input: LabGenerationSeam['input']): ClassicGenerationSeam['input'] {
+  return {
+    creature: input.creature,
+    themes: toClassicThemes(input.themes.map(theme => theme.id)),
+    userInput: input.logline,
+    spicyLevel: input.spicyLevel,
+    wordCount: input.desiredWordBudget,
+    requestedChapterCount: input.chapterBatchSize,
+    generationContext: {
+      source: 'story_lab',
+      logline: input.logline,
+      tone: input.tone,
+      protagonistName: input.protagonistName,
+      antagonistName: input.antagonistName,
+      worldDetails: input.worldDetails,
+      narrativeDirectives: input.narrativeDirectives,
+      themeSeeds: input.themes
+    }
+  };
+}
+
+export async function generateStoryLabGenesis(
+  input: LabGenerationSeam['input'],
+  options: StoryLabEngineOptions = {}
+): Promise<ApiResponse<StoryIterationPayload>> {
+  if (shouldUseMockStoryLab()) {
+    return withMockTelemetry(buildGenesisResponse(input));
+  }
+
+  const service = options.serviceFactory?.() ?? new StoryService();
+  const result = await service.generateStory(toClassicGenerationInput(input));
+
+  if (!result.success) {
+    return {
+      success: false,
+      error: {
+        code: result.error.code ?? 'GENERATION_FAILED',
+        message: result.error.message,
+        details: result.error.details
+      }
+    };
+  }
+
+  const partialError = getPartialGenerationError(
+    input.chapterBatchSize,
+    result.metadata?.chaptersGenerated ?? result.data.chapters?.length ?? 1,
+    result.metadata?.partialFailures ?? result.data.failedChapters
+  );
+  if (partialError) {
+    return partialError;
+  }
+
+  const payload = buildStoryLabPayloadFromGeneratedStory(input, result.data, result.metadata);
+  payload.persistence = persistStoryIteration(payload);
+
+  return {
+    success: true,
+    data: payload
+  };
+}
+
+export async function continueStoryLab(
+  input: LabContinuationSeam['input'],
+  options: StoryLabEngineOptions = {}
+): Promise<ApiResponse<StoryIterationPayload & { appendedChapterNumbers: number[] }>> {
+  const transientSnapshot = getTransientStorySnapshot(input.storyId);
+  const previousChapters = input.previouslyGeneratedChapters.length
+    ? input.previouslyGeneratedChapters
+    : transientSnapshot?.chapters ?? [];
+  const storyState = input.storyState ?? transientSnapshot?.state;
+  const existingSummary = input.existingSummary ?? transientSnapshot?.summary;
+
+  if (shouldUseMockStoryLab()) {
+    return withMockTelemetry(buildContinuationResponse({
+      ...input,
+      storyState: storyState ?? input.storyState,
+      previouslyGeneratedChapters: previousChapters,
+      existingSummary
+    }));
+  }
+
+  if (!storyState || previousChapters.length === 0) {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_REQUEST',
+        message: 'Real continuation requires story state and previous chapters.'
+      }
+    };
+  }
+
+  const service = options.serviceFactory?.() ?? new StoryService();
+  const currentChapterCount = Math.max(...previousChapters.map(chapter => chapter.chapterNumber));
+  const existingContent = previousChapters.map(chapter => chapter.rawContent || chapter.htmlContent).join('\n\n');
+  const result = await service.continueChapter({
+    storyId: input.storyId,
+    currentChapterCount,
+    existingContent,
+    userInput: input.continuationBrief,
+    maintainTone: true,
+    tropeMetadata: existingSummary?.tropeMetadata,
+    requestedChapterCount: input.chapterBatchSize
+  });
+
+  if (!result.success) {
+    return {
+      success: false,
+      error: {
+        code: result.error.code ?? 'CONTINUATION_FAILED',
+        message: result.error.message,
+        details: result.error.details
+      }
+    };
+  }
+
+  const partialError = getPartialGenerationError(
+    input.chapterBatchSize,
+    result.metadata?.chaptersGenerated ?? result.data.chapters?.length ?? 1,
+    result.metadata?.partialFailures ?? result.data.failedChapters
+  );
+  if (partialError) {
+    return partialError;
+  }
+
+  const payload = buildStoryLabPayloadFromContinuation(input, result.data, storyState, existingSummary, previousChapters, result.metadata);
+  payload.persistence = persistStoryIteration(payload, previousChapters);
+
+  return {
+    success: true,
+    data: payload
+  };
+}
+
+export function buildStoryLabPayloadFromGeneratedStory(
+  input: LabGenerationSeam['input'],
+  story: ClassicStoryOutput,
+  metadata?: ApiResponseMetadata
+): StoryIterationPayload {
+  const now = new Date().toISOString();
+  const chapters = toStoryLabChapters(story.storyId, story.chapters, story.content, story.rawContent, input.chapterBatchSize);
+  const summary: StorySummary = {
+    storyId: story.storyId,
+    title: story.title,
+    synopsis: input.logline,
+    tone: input.tone,
+    spicyLevel: input.spicyLevel,
+    createdAt: now,
+    updatedAt: now,
+    tropeMetadata: story.tropeMetadata
+  };
+  const state = buildStateSnapshot(input, story.storyId, chapters, null, now);
+
+  return {
+    summary,
+    batch: {
+      chapters,
+      totalWordCount: chapters.reduce((sum, chapter) => sum + chapter.wordCount, 0),
+      suggestedNextPrompts: buildSuggestedPrompts(input, story.nextChapterHint)
+    },
+    state,
+    stateDelta: buildStateDelta(story.storyId, null, state, chapters),
+    telemetry: buildGrokTelemetry(metadata, chapters.length)
+  };
+}
+
+function buildStoryLabPayloadFromContinuation(
+  input: LabContinuationSeam['input'],
+  continuation: ClassicContinuationOutput,
+  previousState: StoryStateSnapshot,
+  existingSummary: StorySummary | undefined,
+  previousChapters: GeneratedChapter[],
+  metadata?: ApiResponseMetadata
+): StoryIterationPayload & { appendedChapterNumbers: number[] } {
+  const now = new Date().toISOString();
+  const chapters = toStoryLabChapters(
+    input.storyId,
+    continuation.chapters,
+    continuation.content,
+    undefined,
+    input.chapterBatchSize,
+    previousChapters.length ? Math.max(...previousChapters.map(chapter => chapter.chapterNumber)) + 1 : continuation.chapterNumber
+  );
+  const summary: StorySummary = {
+    ...(existingSummary ?? {
+      storyId: input.storyId,
+      title: continuation.title,
+      synopsis: input.continuationBrief ?? 'Continuation batch',
+      tone: 'dark_romance',
+      spicyLevel: continuation.spicyLevelMaintained,
+      createdAt: now,
+      tropeMetadata: continuation.tropeMetadata
+    }),
+    tropeMetadata: existingSummary?.tropeMetadata ?? continuation.tropeMetadata,
+    updatedAt: now
+  };
+  const state = buildStateSnapshot(undefined, input.storyId, chapters, previousState, now);
+  const payload: StoryIterationPayload & { appendedChapterNumbers: number[] } = {
+    summary,
+    batch: {
+      chapters,
+      totalWordCount: chapters.reduce((sum, chapter) => sum + chapter.wordCount, 0),
+      suggestedNextPrompts: buildContinuationPrompts(input, continuation.nextChapterHint)
+    },
+    state,
+    stateDelta: buildStateDelta(input.storyId, previousState, state, chapters),
+    telemetry: buildGrokTelemetry(metadata, chapters.length),
+    appendedChapterNumbers: chapters.map(chapter => chapter.chapterNumber)
+  };
+
+  return payload;
+}
+
+function toStoryLabChapters(
+  storyId: string,
+  classicChapters: ClassicChapter[] | undefined,
+  fallbackHtml: string,
+  fallbackRawHtml: string | undefined,
+  batchSize: number,
+  firstChapterNumber = 1
+): GeneratedChapter[] {
+  const sourceChapters = classicChapters?.length
+    ? classicChapters
+    : [{
+        chapterId: `${storyId}-chapter-${firstChapterNumber}`,
+        chapterNumber: firstChapterNumber,
+        title: 'Chapter 1',
+        content: fallbackHtml,
+        rawContent: fallbackRawHtml,
+        wordCount: countWords(fallbackHtml),
+        generatedAt: new Date(),
+        hasAudio: false,
+        cliffhangerEnding: false
+      } satisfies ClassicChapter];
+
+  return sourceChapters.map((chapter, index) => {
+    const chapterNumber = chapter.chapterNumber || firstChapterNumber + index;
+    const htmlContent = chapter.content || fallbackHtml;
+
+    return {
+      chapterId: chapter.chapterId || `${storyId}-chapter-${chapterNumber}`,
+      chapterNumber,
+      title: normalizeChapterTitle(chapter.title, chapterNumber),
+      htmlContent,
+      rawContent: chapter.rawContent,
+      summary: summarizeHtml(htmlContent),
+      wordCount: chapter.wordCount || countWords(htmlContent),
+      hasCliffhanger: Boolean(chapter.cliffhangerEnding),
+      delta: buildChapterDelta(storyId, chapterNumber, batchSize, Boolean(chapter.cliffhangerEnding))
+    };
+  });
+}
+
+function buildStateSnapshot(
+  input: LabGenerationSeam['input'] | undefined,
+  storyId: string,
+  chapters: GeneratedChapter[],
+  previousState: StoryStateSnapshot | null,
+  now: string
+): StoryStateSnapshot {
+  const revision = previousState ? previousState.revision + 1 : 1;
+  const generatedCharacters = input ? buildInitialCharacters(storyId, input) : [];
+  const generatedThreads = input ? buildInitialThreads(storyId, input) : [];
+  const generatedArtifacts = input?.worldDetails ? [buildWorldArtifact(storyId, input.worldDetails)] : [];
+  const previousBeats = previousState?.beats ?? [];
+  const previousSpicyLevel = previousBeats.length
+    ? previousBeats[previousBeats.length - 1]?.spicyLevel
+    : undefined;
+
+  return {
+    storyId,
+    revision,
+    characters: mergeUniqueById(previousState?.characters ?? [], [
+      ...generatedCharacters,
+      ...chapters.flatMap(chapter => chapter.delta.introducedCharacters)
+    ]),
+    threads: mergeThreads(previousState?.threads ?? generatedThreads, chapters),
+    artifacts: mergeUniqueById(previousState?.artifacts ?? [], [
+      ...generatedArtifacts,
+      ...chapters.flatMap(chapter => chapter.delta.foreshadowedArtifacts)
+    ]),
+    beats: [
+      ...(previousState?.beats ?? []),
+      ...chapters.map(chapter => ({
+        id: `${storyId}-beat-${chapter.chapterNumber}`,
+        chapterNumber: chapter.chapterNumber,
+        summary: chapter.summary,
+        beatType: chapter.chapterNumber === 1 ? 'inciting_incident' as const : 'rising_action' as const,
+        tensionLevel: Math.min(5, 2 + (chapter.chapterNumber % 4)) as 1 | 2 | 3 | 4 | 5,
+        spicyLevel: input?.spicyLevel ?? previousSpicyLevel ?? 3
+      }))
+    ],
+    continuityWarnings: uniqueStrings([
+      ...(previousState?.continuityWarnings ?? []),
+      ...chapters.flatMap(chapter => chapter.delta.continuityFlags)
+    ]),
+    narrativeVoice: input?.tone?.split('_').join(' ') ?? previousState?.narrativeVoice ?? 'dark romance',
+    lastUpdatedAt: now
+  };
+}
+
+function buildInitialCharacters(storyId: string, input: LabGenerationSeam['input']): CharacterProfile[] {
+  const protagonistName = input.protagonistName?.trim() || `${capitalize(input.creature)} protagonist`;
+  const characters: CharacterProfile[] = [
+    {
+      id: `${storyId}-protagonist`,
+      displayName: protagonistName,
+      archetype: 'protagonist',
+      summary: `${protagonistName} anchors the ${input.creature} story promised by the blueprint.`,
+      currentGoal: input.logline,
+      internalConflict: 'Desire and self-protection pull in opposite directions.',
+      externalConflict: input.antagonistName?.trim() || 'The supernatural world resists the romance.',
+      secrets: [],
+      relationships: [],
+      spiceCompatibilities: [input.spicyLevel]
+    }
+  ];
+
+  if (input.antagonistName?.trim()) {
+    characters.push({
+      id: `${storyId}-antagonist`,
+      displayName: input.antagonistName.trim(),
+      archetype: 'antagonist',
+      summary: 'An opposing force named in the Story Lab blueprint.',
+      currentGoal: 'Pressure the protagonist into a costly choice.',
+      internalConflict: 'Their own desire complicates the threat they represent.',
+      externalConflict: input.logline,
+      secrets: [],
+      relationships: [],
+      spiceCompatibilities: [input.spicyLevel]
+    });
+  }
+
+  return characters;
+}
+
+function buildInitialThreads(storyId: string, input: LabGenerationSeam['input']): PlotThread[] {
+  const themeThreads = input.themes.length
+    ? input.themes.map((theme, index) => ({
+        id: `${storyId}-thread-${index + 1}`,
+        label: theme.label,
+        status: 'active' as const,
+        description: theme.description,
+        foreshadowedDevices: []
+      }))
+    : [];
+
+  return themeThreads.length ? themeThreads : [{
+    id: `${storyId}-thread-1`,
+    label: 'Central romance',
+    status: 'active',
+    description: input.logline,
+    foreshadowedDevices: []
+  }];
+}
+
+function buildWorldArtifact(storyId: string, worldDetails: string): LoreArtifact {
+  return {
+    id: `${storyId}-world-details`,
+    name: 'World Details',
+    significance: worldDetails,
+    introducedInChapter: 1
+  };
+}
+
+function buildChapterDelta(
+  storyId: string,
+  chapterNumber: number,
+  batchSize: number,
+  hasCliffhanger: boolean
+): ChapterDelta {
+  const continuityFlags = batchSize > 1 && chapterNumber % batchSize === 0
+    ? [`Review Chapter ${chapterNumber} ending for payoff before expanding the next batch.`]
+    : [];
+
+  return {
+    introducedCharacters: [],
+    resolvedThreads: [],
+    escalatedThreads: hasCliffhanger ? [`${storyId}-thread-1`] : [],
+    foreshadowedArtifacts: [],
+    continuityFlags
+  };
+}
+
+function buildStateDelta(
+  storyId: string,
+  fromState: StoryStateSnapshot | null,
+  toState: StoryStateSnapshot,
+  chapters: GeneratedChapter[]
+): StoryStateDelta {
+  const addedChapterNumbers = chapters.map(chapter => chapter.chapterNumber);
+
+  return {
+    storyId,
+    fromRevision: fromState?.revision ?? null,
+    toRevision: toState.revision,
+    addedChapterNumbers,
+    introducedCharacters: chapters.flatMap(chapter => chapter.delta.introducedCharacters),
+    updatedCharacters: [],
+    resolvedThreads: uniqueStrings(chapters.flatMap(chapter => chapter.delta.resolvedThreads)),
+    escalatedThreads: toState.threads.filter(thread =>
+      chapters.some(chapter => chapter.delta.escalatedThreads.includes(thread.id))
+    ),
+    foreshadowedArtifacts: chapters.flatMap(chapter => chapter.delta.foreshadowedArtifacts),
+    continuityWarnings: uniqueStrings(chapters.flatMap(chapter => chapter.delta.continuityFlags)),
+    beatIds: addedChapterNumbers.map(chapterNumber => `${storyId}-beat-${chapterNumber}`),
+    summary: `Added chapter${addedChapterNumbers.length === 1 ? '' : 's'} ${addedChapterNumbers.join(', ')} from the real story engine.`
+  };
+}
+
+function mergeThreads(existingThreads: PlotThread[], chapters: GeneratedChapter[]): PlotThread[] {
+  const escalatedThreadIds = new Set(chapters.flatMap(chapter => chapter.delta.escalatedThreads));
+  return existingThreads.map(thread =>
+    escalatedThreadIds.has(thread.id) && thread.status !== 'resolved'
+      ? { ...thread, status: 'escalating' as const }
+      : thread
+  );
+}
+
+function mergeUniqueById<T extends { id: string }>(existing: T[], additions: T[]): T[] {
+  const byId = new Map<string, T>();
+  for (const item of existing) {
+    byId.set(item.id, item);
+  }
+  for (const item of additions) {
+    byId.set(item.id, item);
+  }
+  return Array.from(byId.values());
+}
+
+function buildSuggestedPrompts(input: LabGenerationSeam['input'], nextChapterHint?: string): string[] {
+  return [
+    nextChapterHint,
+    input.antagonistName ? `Let ${input.antagonistName} force a dangerous bargain.` : undefined,
+    input.worldDetails ? 'Reveal how the world rules make the romance more costly.' : undefined,
+    'Escalate the central desire-vs-duty conflict.'
+  ].filter((prompt): prompt is string => Boolean(prompt));
+}
+
+function buildContinuationPrompts(input: LabContinuationSeam['input'], nextChapterHint?: string): string[] {
+  return [
+    nextChapterHint,
+    input.continuationBrief ? `Pay off: ${input.continuationBrief}` : undefined,
+    'Answer one open question and raise a sharper one.'
+  ].filter((prompt): prompt is string => Boolean(prompt));
+}
+
+function buildGrokTelemetry(metadata: ApiResponseMetadata | undefined, chapterCount: number): GenerationTelemetry {
+  const totalLatencyMs = metadata?.processingTime ?? 0;
+
+  return {
+    engine: 'grok',
+    totalLatencyMs,
+    averageChapterLatencyMs: chapterCount > 0 ? Math.round(totalLatencyMs / chapterCount) : totalLatencyMs,
+    tokensConsumed: 0,
+    retryCount: 0
+  };
+}
+
+function getPartialGenerationError(
+  requestedChapterCount: number,
+  generatedChapterCount: number,
+  partialFailures: ChapterFailure[] | undefined
+): StoryLabErrorResponse | null {
+  const failures = partialFailures ?? [];
+  if (generatedChapterCount >= requestedChapterCount && failures.length === 0) {
+    return null;
+  }
+
+  return {
+    success: false,
+    error: {
+      code: 'PARTIAL_GENERATION_FAILED',
+      message: `Generated ${generatedChapterCount} of ${requestedChapterCount} requested chapter${requestedChapterCount === 1 ? '' : 's'}.`,
+      details: {
+        chaptersRequested: requestedChapterCount,
+        chaptersGenerated: generatedChapterCount,
+        partialFailures: failures
+      }
+    }
+  };
+}
+
+function withMockTelemetry<T extends StoryIterationPayload>(response: ApiResponse<T>): ApiResponse<T> {
+  if (!response.success) {
+    return response;
+  }
+
+  return {
+    success: true,
+    data: {
+      ...response.data,
+      telemetry: {
+        ...response.data.telemetry,
+        engine: 'custom'
+      }
+    }
+  };
+}
+
+function normalizeChapterTitle(title: string | undefined, chapterNumber: number): string {
+  if (!title) {
+    return `Chapter ${chapterNumber}`;
+  }
+
+  return title.replace(/^Chapter\s+\d+:\s*/i, '').trim() || `Chapter ${chapterNumber}`;
+}
+
+function summarizeHtml(html: string): string {
+  const words = wordsFromHtml(html);
+  return `${words.slice(0, 28).join(' ')}${words.length > 28 ? '...' : ''}`;
+}
+
+function countWords(html: string): number {
+  return wordsFromHtml(html).length;
+}
+
+function wordsFromHtml(html: string): string[] {
+  const text = stripHtml(html);
+  return text ? text.split(' ') : [];
+}
+
+function stripHtml(html: string): string {
+  const withoutTags = stripMarkupTags(html);
+  const withoutSpeakerTags = stripSpeakerTags(withoutTags);
+  return collapseWhitespace(withoutSpeakerTags).trim();
+}
+
+function stripMarkupTags(value: string): string {
+  let result = '';
+  let insideTag = false;
+
+  for (const char of value) {
+    if (char === '<') {
+      insideTag = true;
+      result += ' ';
+      continue;
+    }
+
+    if (insideTag) {
+      if (char === '>') {
+        insideTag = false;
+        result += ' ';
+      }
+      continue;
+    }
+
+    result += char;
+  }
+
+  return result;
+}
+
+function stripSpeakerTags(value: string): string {
+  let result = '';
+
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index] === '[') {
+      const closingIndex = value.indexOf(']:', index + 1);
+      if (closingIndex >= 0) {
+        index = closingIndex + 1;
+        continue;
+      }
+    }
+
+    result += value[index];
+  }
+
+  return result;
+}
+
+function collapseWhitespace(value: string): string {
+  let result = '';
+  let previousWasWhitespace = false;
+
+  for (const char of value) {
+    if (isWhitespace(char)) {
+      if (!previousWasWhitespace) {
+        result += ' ';
+        previousWasWhitespace = true;
+      }
+      continue;
+    }
+
+    result += char;
+    previousWasWhitespace = false;
+  }
+
+  return result;
+}
+
+function isWhitespace(char: string): boolean {
+  return char === ' ' || char === '\n' || char === '\r' || char === '\t' || char === '\f' || char === '\v';
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+function capitalize(value: string): string {
+  return value ? `${value.charAt(0).toUpperCase()}${value.slice(1)}` : value;
+}

--- a/api/_lib/types/contracts.ts
+++ b/api/_lib/types/contracts.ts
@@ -6,7 +6,26 @@
 export type CreatureType = 'vampire' | 'werewolf' | 'fairy' | 'siren' | 'djinn';
 export type ThemeType = 'betrayal' | 'obsession' | 'power_dynamics' | 'forbidden_love' | 'revenge' | 'manipulation' | 'seduction' | 'dark_secrets' | 'corruption' | 'dominance' | 'submission' | 'jealousy' | 'temptation' | 'sin' | 'desire' | 'passion' | 'lust' | 'deceit';
 export type SpicyLevel = 1 | 2 | 3 | 4 | 5;
-export type WordCount = 700 | 900 | 1200;
+export type WordCount = 600 | 700 | 900 | 1200 | 1500;
+export type NarrativeTone = 'romance' | 'dark_romance' | 'mystery' | 'adventure' | 'comedy' | 'tragedy';
+export type GenerationSource = 'classic_generator' | 'story_lab';
+
+export interface GenerationThemeSeed {
+  id: string;
+  label: string;
+  description: string;
+}
+
+export interface StoryGenerationContext {
+  source: GenerationSource;
+  logline?: string;
+  tone?: NarrativeTone;
+  protagonistName?: string;
+  antagonistName?: string;
+  worldDetails?: string;
+  narrativeDirectives?: string;
+  themeSeeds?: GenerationThemeSeed[];
+}
 export type VoiceType = 'female' | 'male' | 'neutral';
 export type CharacterVoiceType = 
   | 'vampire_male' | 'vampire_female' 
@@ -76,6 +95,7 @@ export interface StoryGenerationSeam {
     spicyLevel: SpicyLevel;
     wordCount: WordCount;
     requestedChapterCount?: 1 | 2 | 3;
+    generationContext?: StoryGenerationContext;
   };
 
   output: {
@@ -407,7 +427,7 @@ export const VALIDATION_RULES = {
     max: 5
   },
   wordCount: {
-    allowedValues: [700, 900, 1200]
+    allowedValues: [600, 700, 900, 1200, 1500]
   },
   audioSpeed: {
     min: 0.5,

--- a/api/story-lab/stories.ts
+++ b/api/story-lab/stories.ts
@@ -1,7 +1,7 @@
 // Created: 2025-10-29 08:27 UTC
 
 import type { ApiResponse, StoryGenerationSeam, StoryIterationPayload } from '../_lib/story-lab/contracts';
-import { buildGenesisResponse } from '../_lib/story-lab/mockData';
+import { generateStoryLabGenesis } from '../_lib/story-lab/storyLabEngine';
 
 const VALID_BATCH_SIZES: ReadonlyArray<StoryGenerationSeam['input']['chapterBatchSize']> = [1, 2, 3];
 
@@ -62,6 +62,6 @@ export default async function handler(req: any, res: any) {
     themes: Array.isArray(input.themes) ? input.themes : []
   };
 
-  const payload: ApiResponse<StoryIterationPayload> = buildGenesisResponse(normalizedInput);
+  const payload: ApiResponse<StoryIterationPayload> = await generateStoryLabGenesis(normalizedInput);
   res.status(200).json(payload);
 }

--- a/api/story-lab/stories/[storyId]/continue.ts
+++ b/api/story-lab/stories/[storyId]/continue.ts
@@ -1,7 +1,7 @@
 // Created: 2025-10-29 08:27 UTC
 
 import type { ApiResponse, StoryContinuationSeam, StoryIterationPayload } from '../../../_lib/story-lab/contracts';
-import { buildContinuationResponse } from '../../../_lib/story-lab/mockData';
+import { continueStoryLab } from '../../../_lib/story-lab/storyLabEngine';
 import { getTransientStorySnapshot } from '../../../_lib/story-lab/stateStore';
 
 const isValidBatchSize = (size: number): size is StoryContinuationSeam['input']['chapterBatchSize'] =>
@@ -73,6 +73,6 @@ export default async function handler(req: any, res: any) {
   };
 
   const payload: ApiResponse<StoryIterationPayload & { appendedChapterNumbers: number[] }> =
-    buildContinuationResponse(normalizedInput);
+    await continueStoryLab(normalizedInput);
   res.status(200).json(payload);
 }

--- a/api/story-lab/stream/genesis.ts
+++ b/api/story-lab/stream/genesis.ts
@@ -7,7 +7,7 @@ import type {
   StreamingProgressChunk,
   ThemeSeed
 } from '../../_lib/story-lab/contracts';
-import { buildGenesisResponse } from '../../_lib/story-lab/mockData';
+import { generateStoryLabGenesis } from '../../_lib/story-lab/storyLabEngine';
 
 const ACCESS_CONTROL_METHODS = 'GET, OPTIONS';
 const ACCESS_CONTROL_HEADERS = 'Content-Type';
@@ -50,28 +50,6 @@ export default async function handler(req: any, res: any) {
     return;
   }
 
-  let genesis: GenesisResponse;
-  try {
-    genesis = buildGenesisResponse(parsed.blueprint);
-  } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: {
-        code: 'GENERATION_FAILED',
-        message: error instanceof Error ? error.message : 'Failed to generate mock response.'
-      }
-    });
-    return;
-  }
-
-  if (!genesis.success) {
-    res.status(500).json(genesis);
-    return;
-  }
-
-  const storyId = genesis.data.summary.storyId;
-  const totalChapters = genesis.data.batch.chapters.length;
-
   res.writeHead(200, {
     'Content-Type': 'text/event-stream',
     'Cache-Control': 'no-cache, no-transform',
@@ -98,10 +76,40 @@ export default async function handler(req: any, res: any) {
 
   sendChunk({
     type: 'connected',
-    storyId,
     percentage: 0,
-    estimatedMsRemaining: totalChapters * 500
+    estimatedMsRemaining: parsed.blueprint.chapterBatchSize * 90000
   });
+
+  let genesis: GenesisResponse;
+  try {
+    genesis = await generateStoryLabGenesis(parsed.blueprint);
+  } catch (error) {
+    sendChunk({
+      type: 'error',
+      percentage: 100,
+      error: {
+        code: 'GENERATION_FAILED',
+        message: error instanceof Error ? error.message : 'Failed to generate response.'
+      }
+    });
+    cleanup();
+    res.end();
+    return;
+  }
+
+  if (!genesis.success) {
+    sendChunk({
+      type: 'error',
+      percentage: 100,
+      error: genesis.error
+    });
+    cleanup();
+    res.end();
+    return;
+  }
+
+  const storyId = genesis.data.summary.storyId;
+  const totalChapters = genesis.data.batch.chapters.length;
 
   genesis.data.batch.chapters.forEach((chapter, index) => {
     const timeout = setTimeout(() => {
@@ -204,7 +212,10 @@ function parseBlueprint(req: any): ParsedBlueprint {
       desiredWordBudget,
       chapterBatchSize,
       themes: parseThemes(req.query.themes),
-      narrativeDirectives: getString(req.query.narrativeDirectives) ?? undefined
+      narrativeDirectives: getString(req.query.narrativeDirectives) ?? undefined,
+      protagonistName: getString(req.query.protagonistName) ?? undefined,
+      antagonistName: getString(req.query.antagonistName) ?? undefined,
+      worldDetails: getString(req.query.worldDetails) ?? undefined
     };
 
     return { blueprint };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:tropes": "tsx tests/trope-subversion.test.ts",
     "test:cliffhangers": "tsx tests/cliffhanger-service.test.ts",
     "test:story-lab-state": "tsx tests/story-lab-state.test.ts",
-    "test:all": "npm run test:story && npm run test:tropes && npm run test:cliffhangers && npm run test:story-lab-state"
+    "test:story-lab-real-engine": "tsx tests/story-lab-real-engine.test.ts",
+    "test:all": "npm run test:story && npm run test:tropes && npm run test:cliffhangers && npm run test:story-lab-state && npm run test:story-lab-real-engine"
   },
   "devDependencies": {
     "@types/node": "^24.5.2",

--- a/story-generator/src/app/contracts.ts
+++ b/story-generator/src/app/contracts.ts
@@ -96,6 +96,7 @@ export interface StorySummary {
   synopsis: string;
   tone: NarrativeTone;
   spicyLevel: SpicyLevel;
+  tropeMetadata?: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/story-generator/src/app/story.service.ts
+++ b/story-generator/src/app/story.service.ts
@@ -93,6 +93,15 @@ export class StoryService {
       if (input.narrativeDirectives) {
         params.set('narrativeDirectives', input.narrativeDirectives);
       }
+      if (input.protagonistName) {
+        params.set('protagonistName', input.protagonistName);
+      }
+      if (input.antagonistName) {
+        params.set('antagonistName', input.antagonistName);
+      }
+      if (input.worldDetails) {
+        params.set('worldDetails', input.worldDetails);
+      }
 
       const streamUrl = `${this.apiUrl}/stream/genesis?${params.toString()}`;
       const eventSource = new EventSource(streamUrl);

--- a/tests/story-lab-real-engine.test.ts
+++ b/tests/story-lab-real-engine.test.ts
@@ -1,0 +1,219 @@
+#!/usr/bin/env tsx
+// Created: 2026-05-28 02:31 UTC
+
+import {
+  buildStoryLabPayloadFromGeneratedStory,
+  generateStoryLabGenesis,
+  shouldUseMockStoryLab,
+  toClassicGenerationInput
+} from '../api/_lib/story-lab/storyLabEngine';
+import type { StoryGenerationSeam as LabGenerationSeam } from '../api/_lib/story-lab/contracts';
+import type { StoryGenerationSeam as ClassicGenerationSeam } from '../api/_lib/types/contracts';
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function withEnv<T>(updates: Record<string, string | undefined>, fn: () => T): T {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(updates)) {
+    previous.set(key, process.env[key]);
+    const value = updates[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+async function withEnvAsync<T>(updates: Record<string, string | undefined>, fn: () => Promise<T>): Promise<T> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(updates)) {
+    previous.set(key, process.env[key]);
+    const value = updates[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+const blueprint: LabGenerationSeam['input'] = {
+  creature: 'siren',
+  themes: [
+    {
+      id: 'forbidden_love',
+      label: 'Forbidden Love',
+      description: 'A relationship that breaks supernatural law.'
+    },
+    {
+      id: 'court_intrigue',
+      label: 'Court Intrigue',
+      description: 'Power changes hands through ceremony and betrayal.'
+    }
+  ],
+  logline: 'A siren diplomat must betray her court to save a forbidden lover.',
+  spicyLevel: 3,
+  tone: 'dark_romance',
+  desiredWordBudget: 1500,
+  chapterBatchSize: 2,
+  protagonistName: 'Mira',
+  antagonistName: 'Lord Brine',
+  worldDetails: 'A moonlit reef court ruled by vow-binding songs.',
+  narrativeDirectives: 'Keep the prose lush but tense.'
+};
+
+const classicInput = toClassicGenerationInput(blueprint);
+assert(classicInput.creature === 'siren', 'creature should pass through');
+assert(classicInput.wordCount === 1500, 'Story Lab word budget should remain first-class');
+assert(classicInput.requestedChapterCount === 2, 'chapterBatchSize should map to requestedChapterCount');
+assert(classicInput.generationContext?.source === 'story_lab', 'generation context should identify Story Lab');
+assert(classicInput.generationContext?.logline === blueprint.logline, 'logline should not be flattened away');
+assert(classicInput.generationContext?.themeSeeds?.[1]?.description.includes('betrayal'), 'theme descriptions should survive mapping');
+assert(classicInput.userInput === blueprint.logline, 'legacy userInput fallback should stay concise');
+assert(classicInput.themes.length === 1, 'unknown Story Lab theme ids should not enter classic themes');
+assert(classicInput.themes[0] === 'forbidden_love', 'known Story Lab theme ids should map to classic themes');
+
+const classicStory: ClassicGenerationSeam['output'] = {
+  storyId: 'story-test',
+  title: 'Song of the Reef Court',
+  content: '<h3>Chapter 1: Salt Vows</h3><p>Mira chose the forbidden door.</p>',
+  rawContent: '<p>[Mira, voice: moonlit-silk defiant]: "Open it."</p>',
+  creature: 'siren',
+  themes: ['forbidden_love'],
+  spicyLevel: 3,
+  actualWordCount: 8,
+  estimatedReadTime: 1,
+  hasCliffhanger: true,
+  generatedAt: new Date(),
+  tropeMetadata: 'serialized-trope-state',
+  chapters: [
+    {
+      chapterId: 'chapter-1',
+      chapterNumber: 1,
+      title: 'Salt Vows',
+      content: '<p>Mira chose the forbidden door.</p>',
+      rawContent: '<p>[Mira, voice: moonlit-silk defiant]: "Open it."</p>',
+      wordCount: 6,
+      generatedAt: new Date(),
+      hasAudio: false,
+      cliffhangerEnding: true,
+      nextChapterHint: 'Reveal what waits below the reef court.'
+    }
+  ],
+  totalWordCount: 6,
+  appendedToStory: '<p>Mira chose the forbidden door.</p>',
+  nextChapterHint: 'Reveal what waits below the reef court.'
+};
+
+const payload = buildStoryLabPayloadFromGeneratedStory(blueprint, classicStory, {
+  requestId: 'req-test',
+  processingTime: 2000,
+  chaptersRequested: 2,
+  chaptersGenerated: 1
+});
+assert(payload.summary.storyId === 'story-test', 'summary should keep real story id');
+assert(payload.summary.title === 'Song of the Reef Court', 'summary should keep real title');
+assert(payload.summary.tropeMetadata === 'serialized-trope-state', 'trope metadata should survive for continuations');
+assert(payload.batch.chapters.length === 1, 'real chapters should be mapped into Story Lab batch');
+assert(payload.batch.chapters[0].rawContent?.includes('[Mira'), 'raw speaker-tag content should survive');
+assert(payload.batch.suggestedNextPrompts.some(prompt => prompt.includes('Reveal what waits')), 'next chapter hint should become a prompt');
+assert(payload.state.characters.some(character => character.displayName === 'Mira'), 'protagonist should seed continuity state');
+assert(payload.state.threads.some(thread => thread.label === 'Court Intrigue'), 'theme seeds should become continuity threads');
+assert(payload.telemetry.engine === 'grok', 'real StoryService mapping should report grok telemetry');
+assert(payload.telemetry.totalLatencyMs === 2000, 'real StoryService latency metadata should reach Story Lab telemetry');
+
+withEnv({ XAI_API_KEY: undefined, STORY_LAB_FORCE_MOCK: undefined }, () => {
+  assert(shouldUseMockStoryLab(), 'missing provider key should use mock Story Lab fallback');
+});
+
+withEnv({ XAI_API_KEY: 'test-key', STORY_LAB_FORCE_MOCK: undefined }, () => {
+  assert(!shouldUseMockStoryLab(), 'provider key should choose real engine path');
+});
+
+withEnv({ XAI_API_KEY: 'test-key', STORY_LAB_FORCE_MOCK: 'true' }, () => {
+  assert(shouldUseMockStoryLab(), 'explicit mock flag should override provider key');
+});
+
+(async () => {
+  await withEnvAsync({ XAI_API_KEY: 'test-key', STORY_LAB_FORCE_MOCK: undefined }, async () => {
+    const response = await generateStoryLabGenesis(blueprint, {
+      serviceFactory: () => ({
+        generateStory: async () => ({
+          success: false,
+          error: {
+            code: 'UPSTREAM_DOWN',
+            message: 'Provider was configured but unavailable.'
+          }
+        }),
+        continueChapter: async () => {
+          throw new Error('continueChapter should not be called by genesis test');
+        }
+      })
+    });
+
+    assert(!response.success, 'configured provider failure should return an error');
+    assert(response.error.code === 'UPSTREAM_DOWN', 'provider error code should be preserved');
+    assert(response.error.message.includes('configured'), 'provider error message should be preserved');
+  });
+
+  await withEnvAsync({ XAI_API_KEY: 'test-key', STORY_LAB_FORCE_MOCK: undefined }, async () => {
+    const response = await generateStoryLabGenesis(blueprint, {
+      serviceFactory: () => ({
+        generateStory: async () => ({
+          success: true,
+          data: classicStory,
+          metadata: {
+            requestId: 'req-partial',
+            processingTime: 3000,
+            chaptersRequested: 2,
+            chaptersGenerated: 1,
+            partialFailures: [{
+              chapterNumber: 2,
+              message: 'Provider timed out before chapter 2.'
+            }]
+          }
+        }),
+        continueChapter: async () => {
+          throw new Error('continueChapter should not be called by genesis test');
+        }
+      })
+    });
+
+    assert(!response.success, 'partial provider success should not look like a complete Story Lab batch');
+    assert(response.error.code === 'PARTIAL_GENERATION_FAILED', 'partial failure should use a specific error code');
+  });
+
+  console.log('Story Lab real-engine mapping tests passed');
+})().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- Add a self-contained Story Lab real-engine execution plan with three hostile review/revision passes for both the implementation idea and autonomous plan.
- Add first-class `generationContext` support to the real story engine so Story Lab blueprint fields reach the prompt as structured constraints instead of being flattened into generic text.
- Add `storyLabEngine.ts` to route Story Lab genesis and continuation through the real `StoryService` when `XAI_API_KEY` is configured.
- Keep mock Story Lab output only for no-key local mode or explicit `STORY_LAB_FORCE_MOCK`; configured provider failures return errors instead of fake success.
- Add tests for Story Lab mapping, 1500-word budgets, rich theme metadata preservation, real-output payload shaping, mock policy, and configured provider failure behavior.

## Validation

- `git diff --check`
- direct Vercel API typecheck: `find api -name '*.ts' ! -name '*.spec.ts' ! -name '*.test.ts' -print0 | xargs -0 node_modules/.bin/tsc --noEmit --target es2020 --lib es2020,dom --module commonjs --moduleResolution node --esModuleInterop --skipLibCheck --types node`
- `npm run test:story-lab-real-engine`
- `npm run test:story-lab-state`
- `npm run test:all`
- `scripts/recovery/preflight.sh --quick --skip-status`
- `npx -p node@20 -c "node -v && npm run build"` from `story-generator/`
- pre-commit/pre-push hook also revalidated `pocketfm-contest-forge` formatting, guards, tests, check, and build

## Known Follow-ups

- Story Lab continuity state derived from real prose is still heuristic; AI state extraction or durable persistence should be a follow-up, not claimed as solved here.
- Streaming genesis now uses the real engine path, but the primary app path still uses POST; true progressive streaming of real provider output remains future work.
- Provider abstraction/OpenAI support and visual charm restoration are intentionally kept out of this branch.

## Summary by Sourcery

Route Story Lab genesis and continuation through the real story engine while promoting Story Lab blueprint fields to first-class generation context and keeping mock behavior only for explicit local fallback.

New Features:
- Introduce a rich Story Lab generation context on the core story engine contract, including logline, tone, named characters, world details, narrative directives, and theme seed metadata.
- Add a Story Lab engine orchestration layer that maps Story Lab genesis and continuation flows onto the real StoryService when a provider key is configured.
- Support an expanded word count range, including 600- and 1500-word stories, in the story generation API.

Bug Fixes:
- Prevent silent fallback to mock Story Lab output when a configured provider fails by surfacing provider errors instead.

Enhancements:
- Update StoryService prompt construction to consume structured Story Lab generation context so blueprint constraints appear explicitly in the real model prompt.
- Preserve real-engine chapter HTML, raw content, theme threads, and continuity metadata when shaping Story Lab responses, and adjust continuity state heuristics to reflect generated prose.
- Mark mock Story Lab telemetry as a custom engine and route streaming genesis through the same real-engine orchestration when available.

Documentation:
- Add a Story Lab real-engine execution plan and update agent/recovery documentation and lessons learned to cover the new engine wiring, fallback policy, and heuristic continuity behavior.

Tests:
- Add Story Lab real-engine mapping tests and a dedicated test script to verify generation context preservation, word-count handling, mock policy, and provider-failure behavior.