### PR TITLE
Record final dependency audit evidence

### DIFF
--- a/MVP_TO_SHIPPING_EXEC_PLAN.md
+++ b/MVP_TO_SHIPPING_EXEC_PLAN.md
@@ -33,6 +33,7 @@ Shipping means the MVP is hardened enough for broader release. Main branch CI, V
 - [x] Run final local branch validation after dependency/Sonar fixes. `git diff --check`, `node --check`, runtime audits, quick preflight, story-lab real-engine tests, root test suite, browser smoke, and build verification passed.
 - [x] Open shipping-hardening PR and verify GitHub checks. PR #94 passed Recovery CI, Vercel, SonarCloud, and automated review gates.
 - [x] Merge shipping-hardening PR, supersede PR #88, and verify production status. PR #94 merged as `a71aef4dec43c8720096b4db5b21dc051a6a3c06`; PR #88 was closed as superseded; main Recovery CI, main Dependabot Updates, Vercel production, and production live browser smoke passed.
+- [x] Merge follow-up Dependabot PR #95. Lockfile-only `picomatch`/`qs` update reduced full Story Generator audit findings from seven to four; main Recovery CI, Vercel production, and production live browser smoke passed after merge.
 
 ## Surprises & Discoveries
 
@@ -49,6 +50,7 @@ Shipping means the MVP is hardened enough for broader release. Main branch CI, V
 - The repo still tracks some root `node_modules` files from old history. This branch should not commit generated `node_modules` churn; use package manifests and lockfiles as the source of truth.
 - Main Sonar's top returned source findings were in the browser smoke harness and Story Lab engine. Both were small enough to fix inside the shipping branch instead of leaving as report-only triage.
 - PR #94 passed its checks and merged cleanly. PR #88 was closed as superseded after the fresher dependency update landed, leaving no open PRs at the time of the final shipping evidence update.
+- A follow-up Dependabot PR #95 appeared immediately after #94/#96. It was worth merging because it was lockfile-only, checks were green, and it cut the remaining dev/test audit findings from seven to four.
 
 ## Decision Log
 
@@ -80,7 +82,7 @@ Fill this in as work proceeds:
 - What became MVP-ready:
 - Public UI default no longer shows the developer debug panel; local built-artifact browser smoke proves genesis and continuation mechanics with mocked responses; production live browser smoke proves the deployed Story Lab can generate and continue through the UI.
 - What became shipping-hardened locally and on main:
-- Runtime dependency audits are clean; stale PR #88 was superseded and closed; top Sonar findings from the current main query were fixed; PR #94 passed GitHub checks and merged; main Recovery CI, main Dependabot Updates, Vercel production deployment, and production live browser smoke passed.
+- Runtime dependency audits are clean; stale PR #88 was superseded and closed; top Sonar findings from the current main query were fixed; PR #94 passed GitHub checks and merged; PR #95 reduced dev/test audit findings; main Recovery CI, Vercel production deployment, and production live browser smoke passed.
 - What remained below shipping quality:
 - Current Story Lab MVP/shipping scope is complete. Runtime audits are clean, while full dev audit and historical Sonar cleanup remain documented risks.
 - What hostile review found:

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -1270,3 +1270,30 @@ Self-review:
 - Good: PR #88 was closed only after the replacement dependency work landed and production checks passed.
 - Problem found: The final evidence update itself needed a small follow-up branch because the report could only be fully accurate after merge.
 - Should have anticipated: Any report that promises post-merge production status should reserve a final docs-only pass to record the exact merge commit and production smoke result.
+
+## 2026-05-28 03:28 EDT - PR95 Dev/Test Audit Cleanup Merged
+
+Actions:
+
+- Found new Dependabot PR #95 after the shipping evidence pass.
+- Inspected #95 and confirmed it was lockfile-only for `story-generator/package-lock.json`.
+- Merged PR #95 as `d1b7458b71d232b5e38e94755776c69c7c165381`.
+- Confirmed open PR list is empty after the merge.
+- Confirmed main Recovery CI passed for `d1b7458`.
+- Confirmed Vercel production deployment succeeded for `d1b7458`.
+- Confirmed production root `https://fairytaleswith-spice.vercel.app` returned HTTP `200`.
+- Ran production live browser smoke:
+  - `STORY_LAB_SMOKE_URL=https://fairytaleswith-spice.vercel.app STORY_LAB_SMOKE_LIVE=1 npm run smoke:story-lab-ui`
+  - Result: passed.
+
+Dependency/security evidence:
+
+- `cd story-generator && npm audit --omit=dev --json` still reports zero vulnerabilities.
+- `cd story-generator && npm audit --json` now reports four dev/test-toolchain findings, down from seven.
+- Remaining full-audit findings are `engine.io`, `socket.io-adapter`, `socket.io-parser`, and `ws`.
+
+Self-review:
+
+- Good: The follow-up PR was small, green, and improved a documented risk, so merging it was better than leaving it open.
+- Problem found: The final report had already become stale because the queue changed immediately after the docs-only evidence PR.
+- Should have anticipated: Dependabot can open a cleanup PR immediately after a dependency branch lands; final reports should be checked against the PR queue one last time before calling the queue closed.

--- a/PR70_RECOVERY_LEDGER.md
+++ b/PR70_RECOVERY_LEDGER.md
@@ -18,6 +18,7 @@ Status values:
 
 | PR | Planned action | Actual status | Notes |
 |---:|---|---|---|
+| #95 | merge | merged | Lockfile-only Dependabot PR updated Story Generator `picomatch` and `qs`, reducing full dev/test audit findings from seven to four. |
 | #88 | recreate/supersede | superseded; closed | Dependency-only Dependabot PR was superseded by fresher dependency updates in PR #94, then closed. |
 | #86 | merge | merged; closed | Merged design system doc; normalized nonzero letter-spacing tokens; closed as superseded by #87. |
 | #85 | merge | merged; closed | Merged `path-to-regexp` 8.4.0 lockfile update; closed as superseded by #87. |
@@ -1662,3 +1663,42 @@ Use this template for detailed entries as each PR is handled:
   - Do not overstate the audit result: runtime is clean, full dev audit is still not clean.
 - GitHub PR closure note:
   - Closed as superseded after PR #94 merged, pointing to the fresher dependency update and `STORY_LAB_SHIPPING_READINESS_REPORT.md`.
+
+## PR #95 - chore(deps): bump the npm_and_yarn group across 1 directory with 2 updates
+
+- Source branch: `dependabot/npm_and_yarn/story-generator/npm_and_yarn-3477c3f106`
+- Planned disposition: merge
+- Actual disposition: merged as `d1b7458b71d232b5e38e94755776c69c7c165381`
+- Story-generation impact: None direct. This is dev/test dependency risk reduction only; Story Lab runtime generation behavior is unchanged.
+- Accepted material:
+  - `story-generator/package-lock.json` transitive `picomatch` update from `2.3.1` to `2.3.2`.
+  - `story-generator/package-lock.json` transitive `qs` update from `6.13.0` to `6.15.2`.
+  - Reduction of full Story Generator audit findings from seven to four.
+- Not taking now:
+  - No feature material omitted.
+- Why not taking:
+  - Not applicable.
+- Future mining value:
+  - Remaining full-audit cleanup should focus on the Karma/socket chain: `engine.io`, `socket.io-adapter`, `socket.io-parser`, and `ws`.
+- Files inspected:
+  - PR #95 body and changed-file list from GitHub.
+  - `story-generator/package-lock.json`.
+- Files changed in recovery branch:
+  - `story-generator/package-lock.json`.
+- Conflicts encountered:
+  - None. The PR was lockfile-only and mergeable.
+- Tests/checks run:
+  - PR #95 Recovery CI passed.
+  - PR #95 SonarCloud checks passed.
+  - PR #95 Vercel preview passed.
+  - Main Recovery CI passed after merge.
+  - Vercel production deployment succeeded after merge.
+  - `git diff --check` passed locally after merge.
+  - `cd story-generator && npm audit --omit=dev --json` reported zero vulnerabilities.
+  - `cd story-generator && npm audit --json` reported four remaining dev/test-toolchain findings.
+  - Production live browser smoke passed against `https://fairytaleswith-spice.vercel.app`.
+- Self-review notes:
+  - This should not be described as production feature work.
+  - It does materially improve the documented dev/test audit state, so the shipping report needed a final accuracy update.
+- GitHub PR closure note:
+  - Merged. No closure comment needed.

--- a/STORY_LAB_SHIPPING_READINESS_REPORT.md
+++ b/STORY_LAB_SHIPPING_READINESS_REPORT.md
@@ -17,7 +17,16 @@ Tier 2 shipping hardening merged through PR #94:
 - Vercel production deployment: successful for `a71aef4`.
 - Production live browser smoke: passed against `https://fairytaleswith-spice.vercel.app`.
 
-Dependabot PR #88 is closed as superseded by PR #94. There are no open PRs at the time of this report update.
+Follow-up dev/test dependency cleanup merged through PR #95:
+
+- PR: `https://github.com/Phazzie/FairytaleswithSpice/pull/95`
+- Merge commit: `d1b7458b71d232b5e38e94755776c69c7c165381`
+- Main Recovery CI: passed for `d1b7458`.
+- Vercel production deployment: successful for `d1b7458`.
+- Production live browser smoke: passed against `https://fairytaleswith-spice.vercel.app`.
+- Full Story Generator audit risk dropped from seven findings to four dev/test-toolchain findings.
+
+Dependabot PR #88 is closed as superseded by PR #94. Follow-up Dependabot PR #95 is merged. There are no open PRs at the time of this report update.
 
 ## What Is Safe To Promise
 
@@ -36,11 +45,8 @@ Dependabot PR #88 is closed as superseded by PR #94. There are no open PRs at th
 - Do not promise durable long-term story memory. Current Story Lab continuity/state is client-carried and heuristic.
 - Do not promise audio. Audio remains deferred and inactive for this recovery.
 - Do not promise DigitalOcean deployment. Docker/DigitalOcean files are historical unless deliberately revived later.
-- Do not promise a totally clean full dev audit. Full `story-generator npm audit --json` still reports seven dev/test-toolchain findings under Karma/socket tooling:
-  - `body-parser` via Karma's nested `qs`,
+- Do not promise a totally clean full dev audit. Full `story-generator npm audit --json` still reports four dev/test-toolchain findings under Karma/socket tooling:
   - `engine.io` via `ws`,
-  - `picomatch` via Karma/watch tooling,
-  - Karma's nested `qs`,
   - `socket.io-adapter` via `ws`,
   - `socket.io-parser`,
   - `ws`.
@@ -62,6 +68,14 @@ Why not merge #88 directly:
 - This branch updates Angular runtime packages to `20.3.22` and Angular CLI/build/SSR packages to `20.3.26`.
 - This branch also moves Angular build/type tooling out of production dependencies and into devDependencies.
 
+PR #95 appeared after PR #94 and was merged directly:
+
+- PR: `https://github.com/Phazzie/FairytaleswithSpice/pull/95`
+- Title: `chore(deps): bump the npm_and_yarn group across 1 directory with 2 updates`
+- Files: `story-generator/package-lock.json`
+- Disposition: merged.
+- Effect: updated transitive dev/test packages `picomatch` `2.3.1 -> 2.3.2` and `qs` `6.13.0 -> 6.15.2`, reducing full Story Generator audit findings from seven to four.
+
 Runtime dependency result:
 
 ```bash
@@ -78,7 +92,7 @@ Remaining full-audit result:
 cd story-generator && npm audit --json
 ```
 
-This still reported seven findings, all in dev/test tooling reachable through Karma/socket packages. These should be treated as follow-up test-infrastructure risk, not production runtime risk.
+After PR #95, this still reported four findings, all in dev/test tooling reachable through Karma/socket packages. These should be treated as follow-up test-infrastructure risk, not production runtime risk.
 
 ## Sonar Triage
 
@@ -154,13 +168,14 @@ Do not put live mode into default CI because it consumes provider quota and depe
 What a senior dev who hates this would object to:
 
 - The dependency update is still large because Angular patch updates move a lot of lockfile entries.
-- The full `story-generator npm audit` is not clean; calling the whole repo "secure" would be overstated.
+- The full `story-generator npm audit` is not clean even after PR #95; calling the whole repo "secure" would be overstated.
 - Sonar is triaged, not fully burned down.
 - The repo still tracks some root `node_modules` files from old history. This branch intentionally does not commit generated `node_modules` churn, but that means a local checkout can need `npm install` before `npm ls` reflects the new root axios range.
 
 What was fixed now instead of documented:
 
 - Runtime dependency audit findings for root and Story Generator production dependencies.
+- Transitive dev/test `picomatch` and `qs` findings through PR #95.
 - The top Sonar nested-callback issue in the browser smoke harness.
 - The top Sonar loop-counter mutation issue in Story Lab continuation cleanup.
 
@@ -189,6 +204,10 @@ Local validation passed on 2026-05-28:
 - [x] Main Dependabot Updates workflow after merge
 - [x] Vercel production deployment after merge
 - [x] Production live browser smoke after merge
+- [x] PR #95 checks on GitHub
+- [x] Main Recovery CI after PR #95
+- [x] Vercel production deployment after PR #95
+- [x] Production live browser smoke after PR #95
 
 Validation notes:
 
@@ -199,4 +218,7 @@ Validation notes:
 - PR #94 initially exposed a CI-only install-order issue: `npm ci` mutates historical tracked root `node_modules` files before preflight. `scripts/recovery/preflight.sh` now excludes `node_modules` from its whitespace diff check so generated dependency files do not block source validation.
 - PR #94 review also tightened the smoke server: SPA fallback is now limited to extensionless routes so missing `.js`, `.css`, or image assets return `404` instead of receiving HTML.
 - Post-merge production live smoke command passed:
+  `STORY_LAB_SMOKE_URL=https://fairytaleswith-spice.vercel.app STORY_LAB_SMOKE_LIVE=1 npm run smoke:story-lab-ui`
+- PR #95 reduced full Story Generator audit findings from seven to four. The remaining findings are `engine.io`, `socket.io-adapter`, `socket.io-parser`, and `ws` in dev/test tooling.
+- Post-PR #95 production live smoke command passed:
   `STORY_LAB_SMOKE_URL=https://fairytaleswith-spice.vercel.app STORY_LAB_SMOKE_LIVE=1 npm run smoke:story-lab-ui`


### PR DESCRIPTION
## Summary

- records follow-up Dependabot PR #95 in the shipping report, recovery ledger, changelog, and MVP-to-shipping plan
- updates the remaining full Story Generator audit risk from seven dev/test findings to four
- documents final PR #95 production verification and live Story Lab browser smoke

## Validation

- git diff --check
- cd story-generator && npm audit --omit=dev --json
- cd story-generator && npm audit --json (expected nonzero; now four dev/test findings)
- production live Story Lab browser smoke passed after PR #95
- commit/push hooks passed pocketfm-contest-forge guards/tests/check/build

Docs-only accuracy update after PR #95.