### PR TITLE
Wire Story Lab genesis UI to jobs

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -1927,6 +1927,39 @@ Validation:
 - `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
 - `scripts/recovery/preflight.sh --quick --skip-status`: passed.
 
+## 2026-06-07 08:18 EDT - Story Lab Genesis UI Job Migration
+
+Actions:
+
+- Moved the primary Story Lab genesis Generate flow from the old direct `beginStory` call to `createStoryLabJob({ kind: 'genesis', blueprint })`.
+- Wired genesis progress, completion, cancellation, and failed-provider handling through Story Lab job snapshots/events.
+- Kept the local staged progress timer only as a bridge until real job snapshots arrive, so the progress bar no longer fights backend job percentages.
+- Added focused Angular specs proving:
+  - invalid genesis input does not create a job;
+  - valid genesis creates a Story Lab job and does not call `beginStory`;
+  - job snapshots update the visible progress state;
+  - failed jobs surface the existing friendly Grok configuration message;
+  - saved-project loading still works when genesis returns through the job response shape.
+- Updated `STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md` to mark genesis job-driven progress complete while keeping reload-safe polling and browser-smoke coverage pending.
+
+Validation:
+
+- `git diff --check`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"`: passed with `16 SUCCESS`.
+- `npx -p node@20 -c "npm run build"` from `story-generator/`: passed; Angular reported bundle budget warnings for the 506.06 kB initial browser bundle and 12.56 kB `app.css`.
+- `npx tsx tests/story-lab-job-contracts.test.ts`: passed.
+- `npx tsx tests/story-lab-job-routes.test.ts`: passed.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
+
+Self-review:
+
+- Good: The Generate button now exercises the job API seam added in PR #104, which reduces dependence on the legacy direct genesis path.
+- Good: The UI handles running, completed, failed, and cancelled terminal job states without inventing new backend contracts.
+- Remaining risk: Jobs are still `non_durable_memory`; reload-safe resume needs persisted job ids or polling support in a follow-up slice.
+- Remaining risk: The browser smoke still needs to assert queued -> running -> terminal visible job progress before the old stream route can be retired.
+
 Self-review:
 
 - Good: The new job URLs carry only opaque `job_<uuid>` ids and do not place blueprint text in status/events paths.

--- a/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
+++ b/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
@@ -61,6 +61,10 @@ The key product goal is not "more features." The key product goal is a story stu
   - [x] added a `non_durable_memory` in-process job store and replaying SSE snapshots;
   - [x] added Angular `StoryService` job seam methods without migrating the visible progress UI yet;
   - [x] left the Vercel function-count guard at `10/12`.
+- [x] Started the Phase D visible UI migration on `feature/story-lab-job-ui`:
+  - [x] moved the primary genesis Generate flow from direct `beginStory` calls to `POST /api/story-lab/jobs`;
+  - [x] wired genesis progress, completion, and failure handling to Story Lab job snapshots/events;
+  - [x] kept reload-safe job resume and browser smoke coverage as explicit pending follow-up work.
 - [ ] Leave final handoff describing what remains and what requires external provisioning.
 
 ## Surprises & Discoveries
@@ -124,10 +128,10 @@ The key product goal is not "more features." The key product goal is a story stu
   - Future Story Lab job streaming now has an opaque `job_<uuid>` contract and path builder that keeps blueprint/story/private fields out of status and events URLs.
   - Story Lab job routes now create opaque jobs, replay queued/running/terminal snapshots, and label the in-process store as `non_durable_memory`.
 - What was intentionally deferred:
-  - Accounts, cloud storage, durable Workflow execution, owner-scoped job persistence, visible job progress/reload UI, Blob export, email, and audio runtime.
+  - Accounts, cloud storage, durable Workflow execution, owner-scoped job persistence, reload-safe job resume UI, Blob export, email, and audio runtime.
 - What hostile review still objected to:
-  - The current staged progress UI is not real durable progress.
-  - The legacy direct Story Lab stream route still accepts blueprint fields in an EventSource URL until the visible UI is migrated to POST-created job ids.
+  - The genesis UI now uses job snapshots/events, but the in-memory scaffold is still not real durable Workflow/database-backed progress.
+  - The legacy direct Story Lab stream route still exists for compatibility; future work should retire it after job UI smoke coverage and reload-safe resume are in place.
   - Existing `/api/export/save` is safer for mock server export, but it is still not a durable Blob/email export path.
   - Full Angular build and Karma browser spec validation must be rerun under a stable local/CI environment because Node v23 Angular build/Karma runners hung here.
 - What validation proved:
@@ -136,6 +140,7 @@ The key product goal is not "more features." The key product goal is a story stu
   - Phase B2-B4 focused tests passed: `npx tsx tests/cors-policy.test.ts`, `npx tsx tests/export-sanitizer.test.ts`, `npx tsx tests/story-lab-job-contracts.test.ts`, `npx tsx tests/log-redaction.test.ts`, `npx tsx tests/story-lab-blueprint-parser.test.ts`, `npx tsx tests/story-lab-auth.test.ts`, `npx tsx tests/story-lab-stream-parse.test.ts`, `npx tsx tests/story-lab-real-engine.test.ts`, `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`, `scripts/recovery/check-vercel-function-count.sh`, and `scripts/recovery/preflight.sh --quick --skip-status`.
   - Route-budget consolidation focused checks passed: `git diff --check`, `scripts/recovery/check-vercel-function-count.sh` at `9/12`, `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`, and `scripts/recovery/preflight.sh --quick --skip-status`.
   - Phase D backend job-route focused checks passed: `git diff --check`, `npx tsx tests/story-lab-job-contracts.test.ts`, `npx tsx tests/story-lab-job-routes.test.ts`, `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`, `scripts/recovery/check-vercel-function-count.sh` at `10/12`, and `scripts/recovery/preflight.sh --quick --skip-status`.
+  - Phase D genesis UI job migration focused checks passed: `git diff --check`, app/spec TypeScript compiles, targeted Angular `app.spec.ts` Karma run, `npx tsx tests/story-lab-job-contracts.test.ts`, `npx tsx tests/story-lab-job-routes.test.ts`, and `scripts/recovery/check-vercel-function-count.sh` at `10/12`.
 
 ## Context and Orientation
 
@@ -602,7 +607,8 @@ Files:
 - [x] Created `api/story-lab/jobs.ts`.
 - [x] Added `vercel.json` rewrites for `/api/story-lab/jobs/:jobId` and `/api/story-lab/jobs/:jobId/events`.
 - [x] Modified `story-generator/src/app/story.service.ts`.
-- [ ] Modify `story-generator/src/app/app.ts` to use job routes for visible progress.
+- [x] Modified `story-generator/src/app/app.ts` to use job routes for genesis visible progress.
+- [x] Modified `story-generator/src/app/app.spec.ts` for genesis job creation, event progress, completion, and failed-job handling.
 - [ ] Modify `story-generator/src/app/app.html` for reload-safe job progress.
 - [ ] Modify `scripts/recovery/story-lab-browser-smoke.mjs` for queued -> running -> terminal job progress.
 
@@ -632,7 +638,8 @@ Acceptance:
 - [x] Production missing key creates a failed job with `AI_UNAVAILABLE`, not mock prose.
 - [x] Function count stays within the repo's allow-list before and after the API route change.
 - [x] Non-Workflow fallback is labeled non-durable.
-- [ ] UI can start a job and survive reload by polling job id.
+- [x] UI can start a genesis job and complete/fail from job snapshots/events.
+- [ ] UI can survive reload by polling job id.
 - [ ] Mocked browser smoke sees queued -> running -> completed through the visible UI.
 
 ### Phase E: Account Sync

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -6,6 +6,7 @@ import { App } from './app';
 import { StoryService } from './story.service';
 import { ErrorLoggingService } from './error-logging';
 import {
+  ApiResponse,
   StoryIterationPayload,
   StoryLabJobCreationResponse,
   StoryLabJobEvent,
@@ -16,6 +17,7 @@ import {
 
 const STORAGE_KEY = 'fairytales_story_lab_projects_v1';
 const SKIN_STORAGE_KEY = 'fairytales_story_lab_skin_v1';
+type GenesisJobOverrides = Partial<StoryLabJobCreationResponse<StoryIterationPayload>['job']>;
 
 function createChapter(overrides: Partial<GeneratedChapter> = {}): GeneratedChapter {
   return {
@@ -156,6 +158,41 @@ describe('App', () => {
     localStorage.removeItem(SKIN_STORAGE_KEY);
   });
 
+  function configureValidBlueprint(logline: string) {
+    component.blueprint.set({
+      ...component.blueprint(),
+      logline,
+      themes: [{ id: 'forbidden_love', label: 'Forbidden Love', description: 'Forbidden romance.' }],
+      heatContract: confirmedHeatContract
+    });
+  }
+
+  function stubRunningGenesisJob(
+    events$: Subject<StoryLabJobEvent<StoryIterationPayload>>,
+    overrides: GenesisJobOverrides = {}
+  ) {
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createGenesisJobResponse(undefined, {
+        status: 'running',
+        currentStep: 'generating_story',
+        progressPercent: 32,
+        ...overrides
+      })
+    }));
+    storyService.streamStoryLabJobEvents.and.returnValue(events$.asObservable());
+  }
+
+  function startGenesisJobFlow(
+    logline: string,
+    events$: Subject<StoryLabJobEvent<StoryIterationPayload>>,
+    initialJobOverrides: GenesisJobOverrides = {}
+  ) {
+    stubRunningGenesisJob(events$, initialJobOverrides);
+    configureValidBlueprint(logline);
+    component.startGenesis();
+  }
+
   it('creates the workbench with default blueprint values', () => {
     expect(component.blueprint().creature).toBe('vampire');
     expect(component.blueprint().tone).toBe('dark_romance');
@@ -242,23 +279,7 @@ describe('App', () => {
     };
     const events$ = new Subject<StoryLabJobEvent<StoryIterationPayload>>();
 
-    storyService.createStoryLabJob.and.returnValue(of({
-      success: true,
-      data: createGenesisJobResponse(undefined, {
-        status: 'running',
-        currentStep: 'generating_story',
-        progressPercent: 32
-      })
-    }));
-    storyService.streamStoryLabJobEvents.and.returnValue(events$.asObservable());
-
-    component.blueprint.set({
-      ...component.blueprint(),
-      logline: 'A vampire princess bound by forbidden vows.',
-      themes: [{ id: 'forbidden_love', label: 'Forbidden Love', description: 'Forbidden romance.' }],
-      heatContract: confirmedHeatContract
-    });
-    component.startGenesis();
+    startGenesisJobFlow('A vampire princess bound by forbidden vows.', events$);
 
     expect(storyService.beginStory).not.toHaveBeenCalled();
     expect(storyService.createStoryLabJob).toHaveBeenCalled();
@@ -288,23 +309,15 @@ describe('App', () => {
 
   it('updates genesis progress from Story Lab job snapshots', () => {
     const events$ = new Subject<StoryLabJobEvent<StoryIterationPayload>>();
-    storyService.createStoryLabJob.and.returnValue(of({
-      success: true,
-      data: createGenesisJobResponse(undefined, {
+    startGenesisJobFlow(
+      'A siren archivist bargains with a moonlit duke.',
+      events$,
+      {
         status: 'running',
         currentStep: 'queued',
         progressPercent: 10
-      })
-    }));
-    storyService.streamStoryLabJobEvents.and.returnValue(events$.asObservable());
-
-    component.blueprint.set({
-      ...component.blueprint(),
-      logline: 'A siren archivist bargains with a moonlit duke.',
-      themes: [{ id: 'forbidden_love', label: 'Forbidden Love', description: 'Forbidden romance.' }],
-      heatContract: confirmedHeatContract
-    });
-    component.startGenesis();
+      }
+    );
 
     events$.next(createGenesisJobEvent(createGenesisJobResponse(undefined, {
       status: 'running',
@@ -320,23 +333,8 @@ describe('App', () => {
 
   it('shows a friendly AI configuration error when a genesis job cannot use Grok', () => {
     const events$ = new Subject<StoryLabJobEvent<StoryIterationPayload>>();
-    storyService.createStoryLabJob.and.returnValue(of({
-      success: true,
-      data: createGenesisJobResponse(undefined, {
-        status: 'running',
-        currentStep: 'generating_story',
-        progressPercent: 32
-      })
-    }));
-    storyService.streamStoryLabJobEvents.and.returnValue(events$.asObservable());
 
-    component.blueprint.set({
-      ...component.blueprint(),
-      logline: 'A dragon guardian bargains for one night of forbidden mercy.',
-      themes: [{ id: 'forbidden_love', label: 'Forbidden Love', description: 'Forbidden romance.' }],
-      heatContract: confirmedHeatContract
-    });
-    component.startGenesis();
+    startGenesisJobFlow('A dragon guardian bargains for one night of forbidden mercy.', events$);
     events$.next(createGenesisJobEvent(createGenesisJobResponse(undefined, {
       status: 'failed',
       currentStep: 'failed',
@@ -349,6 +347,18 @@ describe('App', () => {
 
     expect(component.statusMessage()).toContain('missing its Grok configuration');
     expect(component.activeBatchQueue().at(-1)?.status).toBe('failed');
+  });
+
+  it('cancels an in-flight genesis job creation subscription on destroy', () => {
+    const creation$ = new Subject<ApiResponse<StoryLabJobCreationResponse<StoryIterationPayload>>>();
+    storyService.createStoryLabJob.and.returnValue(creation$.asObservable());
+    configureValidBlueprint('A witch queen bargains with a haunted mirror.');
+
+    component.startGenesis();
+
+    expect(creation$.observed).toBeTrue();
+    component.ngOnDestroy();
+    expect(creation$.observed).toBeFalse();
   });
 
   it('loads a saved browser-local project into the workbench', () => {

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -1,12 +1,14 @@
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ActivatedRoute, convertToParamMap, ParamMap } from '@angular/router';
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject, of, Subject } from 'rxjs';
 import { App } from './app';
 import { StoryService } from './story.service';
 import { ErrorLoggingService } from './error-logging';
 import {
   StoryIterationPayload,
+  StoryLabJobCreationResponse,
+  StoryLabJobEvent,
   StoryStateSnapshot,
   StorySummary,
   GeneratedChapter
@@ -63,6 +65,49 @@ function createState(overrides: Partial<StoryStateSnapshot> = {}): StoryStateSna
   };
 }
 
+function createGenesisJobResponse(
+  payload?: StoryIterationPayload,
+  overrides: Partial<StoryLabJobCreationResponse<StoryIterationPayload>['job']> = {}
+): StoryLabJobCreationResponse<StoryIterationPayload> {
+  const now = new Date().toISOString();
+  const jobId = overrides.jobId ?? 'job_123e4567-e89b-12d3-a456-426614174000';
+
+  return {
+    job: {
+      jobId,
+      kind: 'genesis',
+      status: overrides.status ?? 'completed',
+      currentStep: overrides.currentStep ?? 'completed',
+      progressPercent: overrides.progressPercent ?? 100,
+      createdAt: overrides.createdAt ?? now,
+      updatedAt: overrides.updatedAt ?? now,
+      result: payload,
+      error: overrides.error,
+      ...overrides
+    },
+    paths: {
+      statusPath: `/api/story-lab/jobs/${jobId}`,
+      eventsPath: `/api/story-lab/jobs/${jobId}/events`
+    },
+    durability: {
+      mode: 'non_durable_memory',
+      durable: false,
+      warning: 'Jobs are held in memory for this deployment.'
+    }
+  };
+}
+
+function createGenesisJobEvent(
+  response: StoryLabJobCreationResponse<StoryIterationPayload>
+): StoryLabJobEvent<StoryIterationPayload> {
+  return {
+    eventId: `event-${response.job.status}`,
+    type: 'snapshot',
+    emittedAt: response.job.updatedAt,
+    job: response.job
+  };
+}
+
 const confirmedHeatContract = {
   adultOnlyConfirmed: true,
   tensionMode: 'slow_burn' as const,
@@ -83,6 +128,9 @@ describe('App', () => {
     const storyServiceSpy = jasmine.createSpyObj<StoryService>('StoryService', [
       'beginStory',
       'continueStory',
+      'createStoryLabJob',
+      'getStoryLabJob',
+      'streamStoryLabJobEvents',
       'streamStoryGeneration'
     ]);
     const errorLoggingSpy = jasmine.createSpyObj<ErrorLoggingService>('ErrorLoggingService', [
@@ -172,9 +220,10 @@ describe('App', () => {
   it('prevents genesis without a logline', () => {
     component.startGenesis();
     expect(storyService.beginStory).not.toHaveBeenCalled();
+    expect(storyService.createStoryLabJob).not.toHaveBeenCalled();
   });
 
-  it('starts genesis and hydrates the workbench on success', () => {
+  it('starts genesis through a Story Lab job and hydrates the workbench on completion', () => {
     const payload: StoryIterationPayload = {
       summary: createSummary(),
       batch: {
@@ -191,8 +240,17 @@ describe('App', () => {
         retryCount: 0
       }
     };
+    const events$ = new Subject<StoryLabJobEvent<StoryIterationPayload>>();
 
-    storyService.beginStory.and.returnValue(of({ success: true, data: payload }));
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createGenesisJobResponse(undefined, {
+        status: 'running',
+        currentStep: 'generating_story',
+        progressPercent: 32
+      })
+    }));
+    storyService.streamStoryLabJobEvents.and.returnValue(events$.asObservable());
 
     component.blueprint.set({
       ...component.blueprint(),
@@ -202,7 +260,23 @@ describe('App', () => {
     });
     component.startGenesis();
 
-    expect(storyService.beginStory).toHaveBeenCalled();
+    expect(storyService.beginStory).not.toHaveBeenCalled();
+    expect(storyService.createStoryLabJob).toHaveBeenCalled();
+    expect(storyService.createStoryLabJob.calls.mostRecent().args[0]).toEqual(jasmine.objectContaining({
+      kind: 'genesis',
+      blueprint: jasmine.objectContaining({
+        logline: 'A vampire princess bound by forbidden vows.',
+        chapterBatchSize: 1
+      })
+    }));
+    expect(storyService.streamStoryLabJobEvents).toHaveBeenCalledWith(
+      'job_123e4567-e89b-12d3-a456-426614174000',
+      jasmine.any(Function)
+    );
+
+    events$.next(createGenesisJobEvent(createGenesisJobResponse(payload)));
+    events$.complete();
+
     expect(component.workbench().story?.storyId).toBe('story-123');
     expect(component.workbench().chapterHistory.length).toBe(2);
     expect(component.selectedChapter()?.chapterNumber).toBe(2);
@@ -212,14 +286,49 @@ describe('App', () => {
     expect(component.workspaceSaveStatus()).toBe('Saved in this browser.');
   });
 
-  it('shows a friendly AI configuration error when generation cannot use Grok', () => {
-    storyService.beginStory.and.returnValue(of({
-      success: false,
-      error: {
-        code: 'AI_UNAVAILABLE',
-        message: 'The AI story engine is not configured for this deployment.'
-      }
+  it('updates genesis progress from Story Lab job snapshots', () => {
+    const events$ = new Subject<StoryLabJobEvent<StoryIterationPayload>>();
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createGenesisJobResponse(undefined, {
+        status: 'running',
+        currentStep: 'queued',
+        progressPercent: 10
+      })
     }));
+    storyService.streamStoryLabJobEvents.and.returnValue(events$.asObservable());
+
+    component.blueprint.set({
+      ...component.blueprint(),
+      logline: 'A siren archivist bargains with a moonlit duke.',
+      themes: [{ id: 'forbidden_love', label: 'Forbidden Love', description: 'Forbidden romance.' }],
+      heatContract: confirmedHeatContract
+    });
+    component.startGenesis();
+
+    events$.next(createGenesisJobEvent(createGenesisJobResponse(undefined, {
+      status: 'running',
+      currentStep: 'generating_story',
+      progressPercent: 47
+    })));
+
+    expect(component.generationProgress().active).toBeTrue();
+    expect(component.generationProgress().percent).toBe(47);
+    expect(component.generationProgress().stage).toContain('Grok');
+    expect(component.statusMessage()).toContain('Grok');
+  });
+
+  it('shows a friendly AI configuration error when a genesis job cannot use Grok', () => {
+    const events$ = new Subject<StoryLabJobEvent<StoryIterationPayload>>();
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createGenesisJobResponse(undefined, {
+        status: 'running',
+        currentStep: 'generating_story',
+        progressPercent: 32
+      })
+    }));
+    storyService.streamStoryLabJobEvents.and.returnValue(events$.asObservable());
 
     component.blueprint.set({
       ...component.blueprint(),
@@ -228,6 +337,15 @@ describe('App', () => {
       heatContract: confirmedHeatContract
     });
     component.startGenesis();
+    events$.next(createGenesisJobEvent(createGenesisJobResponse(undefined, {
+      status: 'failed',
+      currentStep: 'failed',
+      progressPercent: 100,
+      error: {
+        code: 'AI_UNAVAILABLE',
+        message: 'The AI story engine is not configured for this deployment.'
+      }
+    })));
 
     expect(component.statusMessage()).toContain('missing its Grok configuration');
     expect(component.activeBatchQueue().at(-1)?.status).toBe('failed');
@@ -252,7 +370,10 @@ describe('App', () => {
       }
     };
 
-    storyService.beginStory.and.returnValue(of({ success: true, data: payload }));
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createGenesisJobResponse(payload)
+    }));
     component.blueprint.set({
       ...component.blueprint(),
       logline: 'A vampire princess bound by forbidden vows.',

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -101,6 +101,7 @@ export class App implements OnDestroy {
   private progressTimer: ReturnType<typeof setInterval> | null = null;
   private progressStartedAt = 0;
   private jobDrivenProgress = false;
+  private jobCreationSubscription: Subscription | null = null;
   private jobEventSubscription: Subscription | null = null;
 
   readonly skinOptions: StorySkinOption[] = [
@@ -327,7 +328,7 @@ export class App implements OnDestroy {
   }
 
   ngOnDestroy() {
-    this.closeJobEventSubscription();
+    this.closeJobSubscriptions();
     this.stopProgress();
   }
 
@@ -397,10 +398,10 @@ export class App implements OnDestroy {
     this.statusMessage.set('Sending your story ingredients to Grok...');
     this.startProgress('genesis');
     this.setBatchQueue([]);
-    this.closeJobEventSubscription();
+    this.closeJobSubscriptions();
     const batchId = this.enqueueBatch('Genesis', blueprint.chapterBatchSize);
 
-    this.storyService.createStoryLabJob<StoryIterationPayload>({
+    const jobCreationSubscription = this.storyService.createStoryLabJob<StoryIterationPayload>({
       kind: 'genesis',
       blueprint
     }).subscribe({
@@ -417,11 +418,16 @@ export class App implements OnDestroy {
         }
       },
       error: error => {
+        this.jobCreationSubscription = null;
         this.errorLogging.logError(error, 'App.startGenesis');
         const message = this.formatHttpError(error, 'Story generation failed. Please try again in a moment.');
         this.failGenesisJob(batchId, message);
+      },
+      complete: () => {
+        this.jobCreationSubscription = null;
       }
     });
+    this.jobCreationSubscription = jobCreationSubscription.closed ? null : jobCreationSubscription;
   }
 
   async continueSaga(brief?: string) {
@@ -676,6 +682,7 @@ ${chapters}
         `Generated ${job.result.batch.chapters.length} chapter${job.result.batch.chapters.length === 1 ? '' : 's'}.`
       );
       this.isGenerating.set(false);
+      this.closeJobEventSubscription();
       this.stopProgress();
       return true;
     }
@@ -730,6 +737,7 @@ ${chapters}
   }
 
   private failGenesisJob(batchId: string, message: string) {
+    this.closeJobEventSubscription();
     this.statusMessage.set(message);
     this.markBatchFailed(batchId, message);
     this.notificationService.error('Generation failed', message);
@@ -742,6 +750,15 @@ ${chapters}
       this.jobEventSubscription.unsubscribe();
       this.jobEventSubscription = null;
     }
+  }
+
+  private closeJobSubscriptions() {
+    if (this.jobCreationSubscription) {
+      this.jobCreationSubscription.unsubscribe();
+      this.jobCreationSubscription = null;
+    }
+
+    this.closeJobEventSubscription();
   }
 
   private formatJobStage(currentStep: string, status: StoryLabJobStatus): string {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -4,7 +4,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { DomSanitizer } from '@angular/platform-browser';
 import { ActivatedRoute, RouterLink } from '@angular/router';
-import { map } from 'rxjs';
+import { Subscription, map } from 'rxjs';
 import { BlueprintValidationField, FormValidationService } from './form-validation.service';
 import {
   BatchProgressState,
@@ -20,6 +20,8 @@ import {
   SpicyLevel,
   StoryBlueprint,
   StoryIterationPayload,
+  StoryLabJob,
+  StoryLabJobStatus,
   StoryWorkbenchSession,
   ThemeSeed
 } from './contracts';
@@ -98,6 +100,8 @@ export class App implements OnDestroy {
   private readonly skinStorageKey = 'fairytales_story_lab_skin_v1';
   private progressTimer: ReturnType<typeof setInterval> | null = null;
   private progressStartedAt = 0;
+  private jobDrivenProgress = false;
+  private jobEventSubscription: Subscription | null = null;
 
   readonly skinOptions: StorySkinOption[] = [
     { id: 'bookshop', label: 'Enchanted Bookshop', mood: 'Warm, nostalgic, whimsical' },
@@ -323,6 +327,7 @@ export class App implements OnDestroy {
   }
 
   ngOnDestroy() {
+    this.closeJobEventSubscription();
     this.stopProgress();
   }
 
@@ -392,37 +397,29 @@ export class App implements OnDestroy {
     this.statusMessage.set('Sending your story ingredients to Grok...');
     this.startProgress('genesis');
     this.setBatchQueue([]);
+    this.closeJobEventSubscription();
     const batchId = this.enqueueBatch('Genesis', blueprint.chapterBatchSize);
 
-    this.storyService.beginStory(blueprint).subscribe({
+    this.storyService.createStoryLabJob<StoryIterationPayload>({
+      kind: 'genesis',
+      blueprint
+    }).subscribe({
       next: response => {
         if (!response.success || !response.data) {
           const message = this.formatApiError(response.error, 'Unknown error while generating story.');
-          this.statusMessage.set(message);
-          this.markBatchFailed(batchId, message);
-          this.notificationService.error('Generation failed', message);
-          this.isGenerating.set(false);
-          this.stopProgress();
+          this.failGenesisJob(batchId, message);
           return;
         }
 
-        this.applyIteration(response.data, blueprint.chapterBatchSize, batchId);
-        this.statusMessage.set('Your first chapter is ready. Choose where the story goes next.');
-        this.notificationService.success(
-          'Genesis complete',
-          `Generated ${response.data.batch.chapters.length} chapter${response.data.batch.chapters.length === 1 ? '' : 's'}.`
-        );
-        this.isGenerating.set(false);
-        this.stopProgress();
+        const isTerminal = this.handleGenesisJobSnapshot(response.data.job, batchId, blueprint.chapterBatchSize);
+        if (!isTerminal) {
+          this.openGenesisJobEventStream(response.data.job.jobId, batchId, blueprint.chapterBatchSize);
+        }
       },
       error: error => {
         this.errorLogging.logError(error, 'App.startGenesis');
         const message = this.formatHttpError(error, 'Story generation failed. Please try again in a moment.');
-        this.statusMessage.set(message);
-        this.markBatchFailed(batchId, message);
-        this.notificationService.error('Generation failed', message);
-        this.isGenerating.set(false);
-        this.stopProgress();
+        this.failGenesisJob(batchId, message);
       }
     });
   }
@@ -659,6 +656,119 @@ ${chapters}
     }
   }
 
+  private handleGenesisJobSnapshot(
+    job: StoryLabJob<StoryIterationPayload>,
+    batchId: string,
+    batchSize: ChapterBatchSize
+  ): boolean {
+    this.updateProgressFromJob(job);
+
+    if (job.status === 'completed') {
+      if (!job.result) {
+        this.failGenesisJob(batchId, 'Story generation finished without a story payload. Please try again.');
+        return true;
+      }
+
+      this.applyIteration(job.result, batchSize, batchId);
+      this.statusMessage.set('Your first chapter is ready. Choose where the story goes next.');
+      this.notificationService.success(
+        'Genesis complete',
+        `Generated ${job.result.batch.chapters.length} chapter${job.result.batch.chapters.length === 1 ? '' : 's'}.`
+      );
+      this.isGenerating.set(false);
+      this.stopProgress();
+      return true;
+    }
+
+    if (job.status === 'failed') {
+      this.failGenesisJob(
+        batchId,
+        this.formatApiError(job.error, 'Story generation failed. Please try again in a moment.')
+      );
+      return true;
+    }
+
+    if (job.status === 'cancelled') {
+      this.failGenesisJob(batchId, 'Story generation was cancelled before it finished.');
+      return true;
+    }
+
+    return false;
+  }
+
+  private openGenesisJobEventStream(jobId: string, batchId: string, batchSize: ChapterBatchSize) {
+    this.closeJobEventSubscription();
+    this.jobEventSubscription = this.storyService.streamStoryLabJobEvents<StoryIterationPayload>(
+      jobId,
+      () => undefined
+    ).subscribe({
+      next: event => {
+        this.handleGenesisJobSnapshot(event.job, batchId, batchSize);
+      },
+      error: error => {
+        this.errorLogging.logError(error, 'App.openGenesisJobEventStream');
+        const message = this.formatHttpError(error, 'Story generation updates stopped. Please try again in a moment.');
+        this.failGenesisJob(batchId, message);
+      },
+      complete: () => {
+        this.jobEventSubscription = null;
+      }
+    });
+  }
+
+  private updateProgressFromJob(job: StoryLabJob<StoryIterationPayload>) {
+    const stage = this.formatJobStage(job.currentStep, job.status);
+    const progressPercent = Math.max(0, Math.min(100, Math.round(job.progressPercent)));
+    this.jobDrivenProgress = true;
+    this.statusMessage.set(stage);
+    this.generationProgress.update(current => ({
+      active: true,
+      percent: progressPercent,
+      stage,
+      elapsedSeconds: current.elapsedSeconds
+    }));
+  }
+
+  private failGenesisJob(batchId: string, message: string) {
+    this.statusMessage.set(message);
+    this.markBatchFailed(batchId, message);
+    this.notificationService.error('Generation failed', message);
+    this.isGenerating.set(false);
+    this.stopProgress();
+  }
+
+  private closeJobEventSubscription() {
+    if (this.jobEventSubscription) {
+      this.jobEventSubscription.unsubscribe();
+      this.jobEventSubscription = null;
+    }
+  }
+
+  private formatJobStage(currentStep: string, status: StoryLabJobStatus): string {
+    if (status === 'queued') {
+      return 'Story job queued.';
+    }
+
+    if (status === 'waiting_for_review') {
+      return 'Story job is waiting for review.';
+    }
+
+    switch (currentStep) {
+      case 'queued':
+        return 'Story job queued.';
+      case 'generating_story':
+        return 'Grok is writing your first chapter.';
+      case 'continuing_story':
+        return 'Grok is continuing the saga.';
+      case 'completed':
+        return 'Binding the pages.';
+      case 'failed':
+        return 'Generation failed.';
+      default:
+        return this.humanizeIdentifier(currentStep);
+    }
+  }
+
   private enqueueBatch(label: string, batchSize: ChapterBatchSize): string {
     const id = `batch-${Date.now()}-${this.batchIdSequence++}`;
     const entry: BatchProgressState = {
@@ -761,6 +871,7 @@ ${chapters}
         ];
 
     this.stopProgress();
+    this.jobDrivenProgress = false;
     this.progressStartedAt = Date.now();
     this.generationProgress.set({
       active: true,
@@ -774,8 +885,10 @@ ${chapters}
       const stageIndex = Math.min(stages.length - 1, Math.floor(elapsedSeconds / 6));
       this.generationProgress.update(current => ({
         active: true,
-        percent: Math.min(92, current.percent + (current.percent < 55 ? 7 : 3)),
-        stage: stages[stageIndex],
+        percent: this.jobDrivenProgress
+          ? current.percent
+          : Math.min(92, current.percent + (current.percent < 55 ? 7 : 3)),
+        stage: this.jobDrivenProgress ? current.stage : stages[stageIndex],
         elapsedSeconds
       }));
     }, 1000);
@@ -792,6 +905,7 @@ ${chapters}
       active: false,
       percent: current.percent > 0 ? 100 : 0
     }));
+    this.jobDrivenProgress = false;
   }
 
   private formatApiError(error: { code?: string; message?: string; details?: unknown } | undefined, fallback: string): string {
@@ -918,6 +1032,11 @@ ${chapters}
     }
 
     return normalized.trim();
+  }
+
+  private humanizeIdentifier(value: string): string {
+    const normalized = this.normalizeInlineWhitespace(value.replace(/[_-]+/g, ' '));
+    return normalized ? `${normalized.charAt(0).toUpperCase()}${normalized.slice(1)}.` : 'Story job is running.';
   }
 
   private isWhitespace(char: string): boolean {


### PR DESCRIPTION
## Summary
- Move the primary Story Lab genesis Generate flow from the direct `beginStory` call to `createStoryLabJob({ kind: 'genesis', blueprint })`.
- Apply genesis progress, completion, cancellation, and failed-provider handling from Story Lab job snapshots/events.
- Update Story Lab handoff docs to mark genesis job-driven progress complete while keeping reload-safe polling and browser-smoke coverage pending.

## Test Plan
- [x] `git diff --check`
- [x] `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`
- [x] `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`
- [x] `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"` (`16 SUCCESS`)
- [x] `npx -p node@20 -c "npm run build"` from `story-generator/` (passed with Angular budget warnings: initial browser bundle 506.06 kB vs 500 kB, `app.css` 12.56 kB vs 12 kB)
- [x] `npx tsx tests/story-lab-job-contracts.test.ts`
- [x] `npx tsx tests/story-lab-job-routes.test.ts`
- [x] `scripts/recovery/check-vercel-function-count.sh` (`10/12`)

## Still Pending
- Reload-safe job resume/polling after page refresh.
- Browser smoke assertion for queued -> running -> terminal visible job progress.
