### PR TITLE
Add Story Lab job resume smoke

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -1927,6 +1927,33 @@ Validation:
 - `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
 - `scripts/recovery/preflight.sh --quick --skip-status`: passed.
 
+## 2026-06-07 08:38 EDT - Story Lab Reload-Safe Genesis Job Smoke
+
+Actions:
+
+- Added `STORY_LAB_JOB_RESUME_SMOKE_EXEC_PLAN.md` with a hostile-review checklist for the reload-safe genesis job UI slice.
+- Added a browser-session active genesis job marker in the Angular app.
+- Restored active genesis job progress after reload by reading `getStoryLabJob(jobId)` and reopening job events when the job is still non-terminal.
+- Cleared active job markers on completed, failed, cancelled, malformed, unknown, and reset paths.
+- Added focused Angular specs for active job marker persistence, running-job recovery, completed-job recovery, malformed storage cleanup, and in-flight subscription cleanup.
+- Updated the mocked Story Lab browser smoke so genesis must use `POST /api/story-lab/jobs` plus job SSE events; the old direct `/api/story-lab/stories` mock now fails if used for genesis.
+- Updated `STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md` to mark browser-session reload recovery and mocked job-progress smoke complete.
+
+Validation:
+
+- RED check: targeted `app.spec.ts` failed with 4 expected failures before implementation: missing active marker storage, missing recovery call, missing completed-job hydration, and malformed storage cleanup.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"`: passed with `21 SUCCESS`.
+- `npm run smoke:story-lab-ui`: passed in mock mode; build completed with Angular budget warnings for the initial browser bundle and `app.css`.
+
+Self-review:
+
+- Good: Mock smoke now proves the primary genesis UI uses the job route family, not the legacy direct genesis route.
+- Good: Reload recovery handles browser refresh inside the current in-memory job scaffold without claiming database or Workflow durability.
+- Remaining risk: A Vercel cold start can still lose the non-durable job map; true durability still requires Workflow/database/account ownership.
+- Remaining risk: Continuation still uses the direct route and should be migrated in a separate job slice.
+
 ## 2026-06-07 08:18 EDT - Story Lab Genesis UI Job Migration
 
 Actions:

--- a/STORY_LAB_JOB_RESUME_SMOKE_EXEC_PLAN.md
+++ b/STORY_LAB_JOB_RESUME_SMOKE_EXEC_PLAN.md
@@ -1,0 +1,161 @@
+# Story Lab Job Resume Smoke Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Story Lab genesis job UI recover visible job progress after a browser reload and prove the mocked browser smoke uses the job route flow.
+
+**Architecture:** Keep the slice small and honest: persist only the active anonymous job handle in browser storage, recover it with `getStoryLabJob()`, and reopen the SSE stream only when the recovered job is not terminal. This is reload-safe inside the current non-durable memory scaffold, not durable across Vercel cold starts or account boundaries.
+
+**Tech Stack:** Angular 20 signals and RxJS in `story-generator/src/app/app.ts`, existing Story Lab job contracts/service methods, Playwright smoke script in `scripts/recovery/story-lab-browser-smoke.mjs`, TypeScript/Karma focused specs, `tsx` backend route tests, and the Vercel function-count guard.
+
+---
+
+## Scope
+
+This slice does:
+
+- Persist the active genesis job id, submitted batch id, and batch size in browser storage while a genesis job is running.
+- Restore visible job progress after reload by calling `getStoryLabJob(jobId)`.
+- Resume event streaming for non-terminal recovered jobs.
+- Clear the active job marker when the job completes, fails, or is cancelled.
+- Convert the mocked browser smoke genesis path from `/api/story-lab/stories` to `/api/story-lab/jobs` plus `/events`.
+
+This slice does not:
+
+- Add database-backed jobs.
+- Add account ownership.
+- Make jobs survive Vercel cold starts.
+- Migrate continuation to jobs.
+- Remove the old direct generation route.
+
+## Files
+
+- Modify `story-generator/src/app/app.ts`
+  - Add a small `ActiveStoryLabJobState` type.
+  - Store/recover active genesis job state with `sessionStorage`.
+  - Use `getStoryLabJob()` on startup when an active job marker exists.
+  - Reuse existing job snapshot handling for recovered jobs.
+- Modify `story-generator/src/app/app.html`
+  - Add a compact recovered-job cue inside the existing progress panel if needed.
+- Modify `story-generator/src/app/app.spec.ts`
+  - Add failing specs for active job persistence, recovery after reload, non-terminal stream resume, terminal cleanup, and malformed storage cleanup.
+- Modify `scripts/recovery/story-lab-browser-smoke.mjs`
+  - Mock `POST /api/story-lab/jobs`.
+  - Mock `GET /api/story-lab/jobs/:jobId`.
+  - Mock `GET /api/story-lab/jobs/:jobId/events` with queued, running, completed snapshots.
+  - Assert the visible progress text sees a running job state before the story panel appears.
+- Modify `STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md`
+  - Mark reload-safe job resume and smoke coverage complete only if tests/smoke prove them.
+- Modify `PR70_RECOVERY_CHANGELOG.md`
+  - Record actions, validation, and remaining non-durable limitations.
+
+## Hostile Review Before Implementation
+
+- Objection: "Session storage is not durable job storage."
+  - Response: Correct. This only restores the anonymous browser's active job handle after a page reload. The plan must keep durable Workflow/database/account storage pending.
+- Objection: "Reloading a Vercel preview may lose the in-memory job."
+  - Response: Correct. The UI should handle `404`/missing job by clearing the active marker and showing a friendly message. It must not pretend cold-start survival.
+- Objection: "The smoke could pass without proving job routes."
+  - Response: The smoke must fail if the app calls `/api/story-lab/stories` for genesis in mock mode. It should fulfill only job creation/status/events for genesis.
+- Objection: "Adding a second progress UI creates design churn."
+  - Response: Reuse the existing progress panel and status message. Do not redesign the UI in this slice.
+- Objection: "Continuation still uses direct calls."
+  - Response: Keep continuation out of scope. The previous slice migrated genesis only; this one makes genesis reload-safe enough to smoke.
+
+## Task 1: Active Job State Tests
+
+**Files:**
+- Modify `story-generator/src/app/app.spec.ts`
+
+- [ ] Write a failing spec that starts a running genesis job and expects `sessionStorage` to contain an active job marker with `jobId`, `kind: 'genesis'`, and `batchSize`.
+- [ ] Write a failing spec that creates a new component with the stored marker, stubs `getStoryLabJob()` to return a running job, and expects progress to resume from that snapshot.
+- [ ] Write a failing spec that recovers a completed job and expects the story workbench to hydrate and the active job marker to be cleared.
+- [ ] Write a failing spec that stores malformed JSON and expects startup to clear the marker without throwing.
+
+Run:
+
+```bash
+npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"
+```
+
+Expected before implementation: targeted failures around missing active-job storage/recovery behavior.
+
+## Task 2: Active Job State Implementation
+
+**Files:**
+- Modify `story-generator/src/app/app.ts`
+
+- [ ] Add a private storage key, for example `fairytales_story_lab_active_job_v1`.
+- [ ] Add `ActiveStoryLabJobState` with `jobId`, `kind`, `batchId`, `batchSize`, `startedAt`, and `statusPath`.
+- [ ] Persist the marker immediately after `createStoryLabJob()` returns a non-terminal genesis job.
+- [ ] Clear the marker on completed, failed, cancelled, malformed storage, unknown job, and reset workbench.
+- [ ] Call `restoreActiveStoryLabJob()` from the constructor after saved-project restore.
+- [ ] On restore, call `getStoryLabJob<StoryIterationPayload>(jobId)`, update progress from the returned snapshot, and reopen event streaming when the job is still running/queued.
+
+Run:
+
+```bash
+npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"
+npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"
+```
+
+Expected after implementation: compile exits 0 and targeted app specs pass.
+
+## Task 3: Browser Smoke Job Mocks
+
+**Files:**
+- Modify `scripts/recovery/story-lab-browser-smoke.mjs`
+
+- [ ] Remove the mock-mode genesis fulfillment for `POST /api/story-lab/stories`.
+- [ ] Add `POST /api/story-lab/jobs` mock that validates `kind === 'genesis'`, creates one job id, and returns a running job response.
+- [ ] Add `GET /api/story-lab/jobs/:jobId/events` mock that sends queued, running, and completed SSE snapshots.
+- [ ] Add `GET /api/story-lab/jobs/:jobId` mock that returns the latest stored snapshot.
+- [ ] Assert visible progress contains a running job phrase such as `Grok is writing your first chapter` before waiting for the story panel.
+- [ ] Keep continuation mocked through `/stories/:id/continue` for this slice.
+
+Run:
+
+```bash
+STORY_LAB_SMOKE_SKIP_BUILD=1 npm run smoke:story-lab-ui
+```
+
+Expected after implementation: mock smoke passes and would fail if genesis tries the old `/api/story-lab/stories` route.
+
+## Task 4: Docs and Final Verification
+
+**Files:**
+- Modify `STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md`
+- Modify `PR70_RECOVERY_CHANGELOG.md`
+
+- [ ] Update Phase D file checklist and acceptance only after tests and smoke pass.
+- [ ] Record the non-durable limitation in the changelog.
+- [ ] Run final verification:
+
+```bash
+git diff --check
+npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"
+npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"
+npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"
+npx tsx tests/story-lab-job-contracts.test.ts
+npx tsx tests/story-lab-job-routes.test.ts
+scripts/recovery/check-vercel-function-count.sh
+npx -p node@20 -c "npm run build"
+STORY_LAB_SMOKE_SKIP_BUILD=1 npm run smoke:story-lab-ui
+```
+
+Expected: all commands exit 0. Angular budget warnings are acceptable only if they remain warnings, not errors.
+
+## Stop Conditions
+
+- Stop and fix if the app can call the old direct genesis route in mock smoke.
+- Stop and fix if recovered terminal jobs can duplicate chapters.
+- Stop and fix if malformed storage crashes app construction.
+- Stop and fix if job ids, blueprint loglines, or private story text are written into URLs.
+- Stop and fix if the function-count guard rises above `10/12` for this no-route slice.
+
+## Self-Critique After Plan
+
+- Spec coverage: The plan covers reload-safe active-job marker, recovery, event-stream resume, terminal cleanup, browser smoke proof, docs, and verification. Durable storage, auth, and continuation jobs are intentionally excluded.
+- Placeholder scan: No task uses TBD/TODO/fill-in language. Every task has files, specific behavior, and commands.
+- Type consistency: The planned active job state uses existing `StoryLabJob`/`StoryIterationPayload`/`ChapterBatchSize` concepts already present in `app.ts`.
+- Risk: The smoke SSE mock must be written carefully because Playwright route fulfillment needs a valid `text/event-stream` body. If one-shot SSE replay is flaky in the browser, fall back to status polling in the smoke only after proving the UI still opens the job events path.

--- a/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
+++ b/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
@@ -65,6 +65,10 @@ The key product goal is not "more features." The key product goal is a story stu
   - [x] moved the primary genesis Generate flow from direct `beginStory` calls to `POST /api/story-lab/jobs`;
   - [x] wired genesis progress, completion, and failure handling to Story Lab job snapshots/events;
   - [x] kept reload-safe job resume and browser smoke coverage as explicit pending follow-up work.
+- [x] Continued Phase D reload-safe genesis progress on `feature/story-lab-job-resume-smoke`:
+  - [x] added browser-session active genesis job recovery through `getStoryLabJob`;
+  - [x] cleared malformed, completed, failed, and cancelled active job markers;
+  - [x] moved mocked browser smoke genesis coverage to `/api/story-lab/jobs` plus SSE job events.
 - [ ] Leave final handoff describing what remains and what requires external provisioning.
 
 ## Surprises & Discoveries
@@ -609,8 +613,8 @@ Files:
 - [x] Modified `story-generator/src/app/story.service.ts`.
 - [x] Modified `story-generator/src/app/app.ts` to use job routes for genesis visible progress.
 - [x] Modified `story-generator/src/app/app.spec.ts` for genesis job creation, event progress, completion, and failed-job handling.
-- [ ] Modify `story-generator/src/app/app.html` for reload-safe job progress.
-- [ ] Modify `scripts/recovery/story-lab-browser-smoke.mjs` for queued -> running -> terminal job progress.
+- [x] Reused `story-generator/src/app/app.html` existing progress panel for reload-safe job progress.
+- [x] Modified `scripts/recovery/story-lab-browser-smoke.mjs` for queued -> running -> terminal job progress.
 
 Contracts:
 
@@ -639,8 +643,8 @@ Acceptance:
 - [x] Function count stays within the repo's allow-list before and after the API route change.
 - [x] Non-Workflow fallback is labeled non-durable.
 - [x] UI can start a genesis job and complete/fail from job snapshots/events.
-- [ ] UI can survive reload by polling job id.
-- [ ] Mocked browser smoke sees queued -> running -> completed through the visible UI.
+- [x] UI can survive reload by polling job id inside the current browser session.
+- [x] Mocked browser smoke sees queued -> running -> completed through the visible UI.
 
 ### Phase E: Account Sync
 

--- a/scripts/recovery/story-lab-browser-smoke.mjs
+++ b/scripts/recovery/story-lab-browser-smoke.mjs
@@ -355,6 +355,9 @@ async function runSmoke() {
 
     await page.locator(smokeSelectors.generateButton).click();
     await page.locator(smokeSelectors.progress).waitFor({ timeout: 20_000 });
+    if (!liveMode) {
+      await expectText(page.locator(smokeSelectors.progress), 'Grok is writing your first chapter');
+    }
     await page.locator(smokeSelectors.storyPanel).waitFor({ timeout: liveMode ? 90_000 : 20_000 });
     await expectNonEmptyText(page.locator(smokeSelectors.storyTitle), 'story title');
     await page.locator(smokeSelectors.chapterView(1)).waitFor({ timeout: 20_000 });
@@ -398,6 +401,9 @@ async function runSmoke() {
 }
 
 async function installMockStoryLabRoutes(page) {
+  const smokeJobId = 'job_00000000-0000-4000-8000-000000000105';
+  let latestGenesisJob = null;
+
   await page.route('**/api/health', async route => {
     await route.fulfill({
       status: 200,
@@ -425,11 +431,119 @@ async function installMockStoryLabRoutes(page) {
       await route.fallback();
       return;
     }
+    await route.fulfill({
+      status: 410,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: false,
+        error: {
+          code: 'LEGACY_GENESIS_ROUTE_USED',
+          message: 'Smoke mode expects genesis to use /api/story-lab/jobs.'
+        }
+      })
+    });
+  });
+
+  await page.route('**/api/story-lab/jobs', async route => {
+    if (route.request().method() !== 'POST') {
+      await route.fallback();
+      return;
+    }
+
+    let body = null;
+    try {
+      body = route.request().postDataJSON();
+    } catch {
+      body = null;
+    }
+
+    if (body?.kind !== 'genesis') {
+      await route.fulfill({
+        status: 400,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: false,
+          error: {
+            code: 'SMOKE_EXPECTED_GENESIS_JOB',
+            message: 'Smoke expected a genesis Story Lab job request.'
+          }
+        })
+      });
+      return;
+    }
+
+    latestGenesisJob = buildJobSnapshot(smokeJobId, 'running', 'generating_story', 38);
     await delay(250);
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ success: true, data: buildPayload([buildChapter(1)], 1) })
+      body: JSON.stringify(buildJobResponse(latestGenesisJob))
+    });
+  });
+
+  await page.route('**/api/story-lab/jobs/*/events', async route => {
+    const jobId = extractJobId(route.request().url(), '/events');
+    if (jobId !== smokeJobId || !latestGenesisJob) {
+      await route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: false,
+          error: {
+            code: 'JOB_NOT_FOUND',
+            message: 'Smoke job was not created.'
+          }
+        })
+      });
+      return;
+    }
+
+    const completedJob = buildJobSnapshot(
+      smokeJobId,
+      'completed',
+      'completed',
+      100,
+      buildPayload([buildChapter(1)], 1)
+    );
+    const events = [
+      buildJobSnapshot(smokeJobId, 'queued', 'queued', 8),
+      latestGenesisJob,
+      completedJob
+    ];
+    latestGenesisJob = completedJob;
+
+    await delay(500);
+    await route.fulfill({
+      status: 200,
+      headers: {
+        'content-type': 'text/event-stream; charset=utf-8',
+        'cache-control': 'no-cache'
+      },
+      body: events.map((job, index) => `data: ${JSON.stringify(buildJobEvent(job, index + 1))}\n\n`).join('')
+    });
+  });
+
+  await page.route('**/api/story-lab/jobs/*', async route => {
+    const jobId = extractJobId(route.request().url());
+    if (jobId !== smokeJobId || !latestGenesisJob) {
+      await route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: false,
+          error: {
+            code: 'JOB_NOT_FOUND',
+            message: 'Smoke job was not created.'
+          }
+        })
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(buildJobResponse(latestGenesisJob))
     });
   });
 
@@ -461,6 +575,55 @@ async function installMockStoryLabRoutes(page) {
       body: JSON.stringify({ success: true, data: { ...buildPayload([buildChapter(2)], 2), appendedChapterNumbers: [2] } })
     });
   });
+}
+
+function buildJobSnapshot(jobId, status, currentStep, progressPercent, result) {
+  const now = new Date().toISOString();
+  return {
+    jobId,
+    kind: 'genesis',
+    status,
+    currentStep,
+    progressPercent,
+    createdAt: now,
+    updatedAt: now,
+    result
+  };
+}
+
+function buildJobResponse(job) {
+  return {
+    success: true,
+    data: {
+      job,
+      paths: {
+        statusPath: `/api/story-lab/jobs/${job.jobId}`,
+        eventsPath: `/api/story-lab/jobs/${job.jobId}/events`
+      },
+      durability: {
+        mode: 'non_durable_memory',
+        durable: false,
+        warning: 'Smoke jobs are held in memory for this mocked browser run.'
+      }
+    }
+  };
+}
+
+function buildJobEvent(job, eventIndex) {
+  return {
+    eventId: `event-${eventIndex}`,
+    type: 'snapshot',
+    emittedAt: job.updatedAt,
+    job
+  };
+}
+
+function extractJobId(rawUrl, suffix = '') {
+  const url = new URL(rawUrl);
+  const path = suffix && url.pathname.endsWith(suffix)
+    ? url.pathname.slice(0, -suffix.length)
+    : url.pathname;
+  return path.split('/').at(-1);
 }
 
 function buildPayload(chapters, revision) {

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -17,6 +17,7 @@ import {
 
 const STORAGE_KEY = 'fairytales_story_lab_projects_v1';
 const SKIN_STORAGE_KEY = 'fairytales_story_lab_skin_v1';
+const ACTIVE_JOB_STORAGE_KEY = 'fairytales_story_lab_active_job_v1';
 type GenesisJobOverrides = Partial<StoryLabJobCreationResponse<StoryIterationPayload>['job']>;
 
 function createChapter(overrides: Partial<GeneratedChapter> = {}): GeneratedChapter {
@@ -110,6 +111,22 @@ function createGenesisJobEvent(
   };
 }
 
+function createActiveJobMarker(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    jobId: 'job_123e4567-e89b-12d3-a456-426614174000',
+    kind: 'genesis',
+    batchId: 'batch-recovered',
+    batchSize: 1,
+    statusPath: '/api/story-lab/jobs/job_123e4567-e89b-12d3-a456-426614174000',
+    startedAt: new Date().toISOString(),
+    ...overrides
+  };
+}
+
+function storeActiveJobMarker(overrides: Partial<Record<string, unknown>> = {}) {
+  sessionStorage.setItem(ACTIVE_JOB_STORAGE_KEY, JSON.stringify(createActiveJobMarker(overrides)));
+}
+
 const confirmedHeatContract = {
   adultOnlyConfirmed: true,
   tensionMode: 'slow_burn' as const,
@@ -126,6 +143,7 @@ describe('App', () => {
     queryParamMap$ = new BehaviorSubject<ParamMap>(convertToParamMap({}));
     localStorage.removeItem(STORAGE_KEY);
     localStorage.removeItem(SKIN_STORAGE_KEY);
+    sessionStorage.removeItem(ACTIVE_JOB_STORAGE_KEY);
 
     const storyServiceSpy = jasmine.createSpyObj<StoryService>('StoryService', [
       'beginStory',
@@ -156,6 +174,7 @@ describe('App', () => {
   afterEach(() => {
     localStorage.removeItem(STORAGE_KEY);
     localStorage.removeItem(SKIN_STORAGE_KEY);
+    sessionStorage.removeItem(ACTIVE_JOB_STORAGE_KEY);
   });
 
   function configureValidBlueprint(logline: string) {
@@ -359,6 +378,85 @@ describe('App', () => {
     expect(creation$.observed).toBeTrue();
     component.ngOnDestroy();
     expect(creation$.observed).toBeFalse();
+  });
+
+  it('stores an active genesis job marker while job snapshots are running', () => {
+    const events$ = new Subject<StoryLabJobEvent<StoryIterationPayload>>();
+
+    startGenesisJobFlow('A siren spy steals a vow from a forbidden archive.', events$);
+
+    const marker = JSON.parse(sessionStorage.getItem(ACTIVE_JOB_STORAGE_KEY) ?? '{}');
+    expect(marker).toEqual(jasmine.objectContaining({
+      jobId: 'job_123e4567-e89b-12d3-a456-426614174000',
+      kind: 'genesis',
+      batchSize: 1,
+      statusPath: '/api/story-lab/jobs/job_123e4567-e89b-12d3-a456-426614174000'
+    }));
+    expect(marker.batchId).toMatch(/^batch-/);
+  });
+
+  it('recovers a running genesis job from browser storage and resumes events', () => {
+    const events$ = new Subject<StoryLabJobEvent<StoryIterationPayload>>();
+    storeActiveJobMarker();
+    storyService.getStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createGenesisJobResponse(undefined, {
+        status: 'running',
+        currentStep: 'generating_story',
+        progressPercent: 41
+      })
+    }));
+    storyService.streamStoryLabJobEvents.and.returnValue(events$.asObservable());
+
+    const recovered = TestBed.createComponent(App).componentInstance;
+
+    expect(storyService.getStoryLabJob).toHaveBeenCalledWith('job_123e4567-e89b-12d3-a456-426614174000');
+    expect(storyService.streamStoryLabJobEvents).toHaveBeenCalledWith(
+      'job_123e4567-e89b-12d3-a456-426614174000',
+      jasmine.any(Function)
+    );
+    expect(recovered.generationProgress().active).toBeTrue();
+    expect(recovered.generationProgress().percent).toBe(41);
+    expect(recovered.statusMessage()).toContain('Grok');
+  });
+
+  it('recovers a completed genesis job and clears the active job marker', () => {
+    const payload: StoryIterationPayload = {
+      summary: createSummary({ title: 'Recovered Pact' }),
+      batch: {
+        chapters: [createChapter()],
+        totalWordCount: 900,
+        suggestedNextPrompts: []
+      },
+      state: createState(),
+      telemetry: {
+        engine: 'grok',
+        model: 'grok-4.3',
+        totalLatencyMs: 1200,
+        averageChapterLatencyMs: 1200,
+        tokensConsumed: 900,
+        retryCount: 0
+      }
+    };
+    storeActiveJobMarker();
+    storyService.getStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createGenesisJobResponse(payload)
+    }));
+
+    const recovered = TestBed.createComponent(App).componentInstance;
+
+    expect(recovered.workbench().story?.title).toBe('Recovered Pact');
+    expect(recovered.workbench().chapterHistory.length).toBe(1);
+    expect(sessionStorage.getItem(ACTIVE_JOB_STORAGE_KEY)).toBeNull();
+  });
+
+  it('clears malformed active job storage without crashing startup', () => {
+    sessionStorage.setItem(ACTIVE_JOB_STORAGE_KEY, '{not-json');
+
+    expect(() => TestBed.createComponent(App).componentInstance).not.toThrow();
+    expect(sessionStorage.getItem(ACTIVE_JOB_STORAGE_KEY)).toBeNull();
+    expect(storyService.getStoryLabJob).not.toHaveBeenCalled();
   });
 
   it('loads a saved browser-local project into the workbench', () => {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -81,6 +81,15 @@ type GenerationProgressState = {
   elapsedSeconds: number;
 };
 
+type ActiveStoryLabJobState = {
+  jobId: string;
+  kind: 'genesis';
+  batchId: string;
+  batchSize: ChapterBatchSize;
+  statusPath: string;
+  startedAt: string;
+};
+
 @Component({
   selector: 'app-story-lab',
   standalone: true,
@@ -98,6 +107,7 @@ export class App implements OnDestroy {
   private readonly route = inject(ActivatedRoute);
   private batchIdSequence = 0;
   private readonly skinStorageKey = 'fairytales_story_lab_skin_v1';
+  private readonly activeJobStorageKey = 'fairytales_story_lab_active_job_v1';
   private progressTimer: ReturnType<typeof setInterval> | null = null;
   private progressStartedAt = 0;
   private jobDrivenProgress = false;
@@ -325,6 +335,7 @@ export class App implements OnDestroy {
   constructor() {
     this.restoreSkin();
     this.restoreLatestProject();
+    this.restoreActiveStoryLabJob();
   }
 
   ngOnDestroy() {
@@ -414,6 +425,14 @@ export class App implements OnDestroy {
 
         const isTerminal = this.handleGenesisJobSnapshot(response.data.job, batchId, blueprint.chapterBatchSize);
         if (!isTerminal) {
+          this.storeActiveStoryLabJob({
+            jobId: response.data.job.jobId,
+            kind: 'genesis',
+            batchId,
+            batchSize: blueprint.chapterBatchSize,
+            statusPath: response.data.paths.statusPath,
+            startedAt: response.data.job.createdAt
+          });
           this.openGenesisJobEventStream(response.data.job.jobId, batchId, blueprint.chapterBatchSize);
         }
       },
@@ -511,6 +530,7 @@ export class App implements OnDestroy {
   }
 
   resetWorkbench() {
+    this.clearActiveStoryLabJob();
     this.workbench.set({
       story: null,
       state: null,
@@ -682,6 +702,7 @@ ${chapters}
         `Generated ${job.result.batch.chapters.length} chapter${job.result.batch.chapters.length === 1 ? '' : 's'}.`
       );
       this.isGenerating.set(false);
+      this.clearActiveStoryLabJob();
       this.closeJobEventSubscription();
       this.stopProgress();
       return true;
@@ -737,6 +758,7 @@ ${chapters}
   }
 
   private failGenesisJob(batchId: string, message: string) {
+    this.clearActiveStoryLabJob();
     this.closeJobEventSubscription();
     this.statusMessage.set(message);
     this.markBatchFailed(batchId, message);
@@ -759,6 +781,124 @@ ${chapters}
     }
 
     this.closeJobEventSubscription();
+  }
+
+  private restoreActiveStoryLabJob() {
+    const activeJob = this.readActiveStoryLabJob();
+    if (!activeJob) {
+      return;
+    }
+
+    this.isGenerating.set(true);
+    this.statusMessage.set('Restoring your story job...');
+    this.startProgress('genesis');
+    this.ensureRecoveredBatch(activeJob);
+
+    this.storyService.getStoryLabJob<StoryIterationPayload>(activeJob.jobId).subscribe({
+      next: response => {
+        if (!response.success || !response.data) {
+          const message = this.formatApiError(response.error, 'That story job is no longer available.');
+          this.failGenesisJob(activeJob.batchId, message);
+          return;
+        }
+
+        const isTerminal = this.handleGenesisJobSnapshot(response.data.job, activeJob.batchId, activeJob.batchSize);
+        if (!isTerminal) {
+          this.openGenesisJobEventStream(activeJob.jobId, activeJob.batchId, activeJob.batchSize);
+        }
+      },
+      error: error => {
+        this.errorLogging.logError(error, 'App.restoreActiveStoryLabJob');
+        const message = this.formatHttpError(error, 'That story job is no longer available.');
+        this.failGenesisJob(activeJob.batchId, message);
+      }
+    });
+  }
+
+  private ensureRecoveredBatch(activeJob: ActiveStoryLabJobState) {
+    if (this.activeBatchQueue().some(item => item.id === activeJob.batchId)) {
+      return;
+    }
+
+    this.setBatchQueue([
+      ...this.activeBatchQueue(),
+      {
+        id: activeJob.batchId,
+        label: 'Genesis',
+        batchSize: activeJob.batchSize,
+        status: 'in_progress',
+        chaptersGenerated: 0,
+        totalChapters: activeJob.batchSize,
+        submittedAt: activeJob.startedAt
+      }
+    ]);
+  }
+
+  private storeActiveStoryLabJob(activeJob: ActiveStoryLabJobState) {
+    if (typeof sessionStorage === 'undefined') {
+      return;
+    }
+
+    try {
+      sessionStorage.setItem(this.activeJobStorageKey, JSON.stringify(activeJob));
+    } catch {
+      this.workspaceSaveStatus.set('Story job progress will last until this tab closes.');
+    }
+  }
+
+  private readActiveStoryLabJob(): ActiveStoryLabJobState | null {
+    if (typeof sessionStorage === 'undefined') {
+      return null;
+    }
+
+    let rawJob: string | null = null;
+    try {
+      rawJob = sessionStorage.getItem(this.activeJobStorageKey);
+      if (!rawJob) {
+        return null;
+      }
+
+      const parsed = JSON.parse(rawJob) as Partial<ActiveStoryLabJobState>;
+      if (
+        typeof parsed.jobId === 'string'
+        && parsed.kind === 'genesis'
+        && typeof parsed.batchId === 'string'
+        && this.isChapterBatchSize(parsed.batchSize)
+        && typeof parsed.statusPath === 'string'
+        && typeof parsed.startedAt === 'string'
+      ) {
+        return {
+          jobId: parsed.jobId,
+          kind: parsed.kind,
+          batchId: parsed.batchId,
+          batchSize: parsed.batchSize,
+          statusPath: parsed.statusPath,
+          startedAt: parsed.startedAt
+        };
+      }
+    } catch {
+      this.clearActiveStoryLabJob();
+      return null;
+    }
+
+    this.clearActiveStoryLabJob();
+    return null;
+  }
+
+  private clearActiveStoryLabJob() {
+    if (typeof sessionStorage === 'undefined') {
+      return;
+    }
+
+    try {
+      sessionStorage.removeItem(this.activeJobStorageKey);
+    } catch {
+      // Ignore storage cleanup failures; the job state is only a reload hint.
+    }
+  }
+
+  private isChapterBatchSize(value: unknown): value is ChapterBatchSize {
+    return value === 1 || value === 2 || value === 3;
   }
 
   private formatJobStage(currentStep: string, status: StoryLabJobStatus): string {


### PR DESCRIPTION
## Summary
- Add browser-session recovery for an active genesis Story Lab job using the existing `getStoryLabJob` and job event stream seam.
- Persist and clear an anonymous active-job marker for running, completed, failed, cancelled, malformed, and reset paths.
- Update the mocked Story Lab browser smoke so genesis must use `/api/story-lab/jobs` plus job SSE events instead of the legacy direct `/stories` route.

## Test Plan
- [x] RED: targeted `app.spec.ts` failed with 4 expected failures before implementation: missing active marker storage, missing recovery call, missing completed-job hydration, and malformed storage cleanup.
- [x] `git diff --check`
- [x] `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`
- [x] `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`
- [x] `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"` (`21 SUCCESS`)
- [x] `npx tsx tests/story-lab-job-contracts.test.ts`
- [x] `npx tsx tests/story-lab-job-routes.test.ts`
- [x] `scripts/recovery/check-vercel-function-count.sh` (`10/12`)
- [x] `npm run smoke:story-lab-ui` (mock mode passed; Angular build emitted existing budget warnings)

## Still Pending
- Durable Workflow/database-backed job execution.
- Account-scoped job ownership.
- Continuation job UI migration.
