### PR TITLE
Wire Story Lab continuation UI to jobs

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -89,6 +89,24 @@ Validation:
 - `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`: passed.
 - `npm run smoke:story-lab-ui`: passed in mock mode; Angular build reported the existing budget warnings for the 510.13 kB initial browser bundle and 12.56 kB `app.css`.
 
+## 2026-06-07 09:11 EDT - PR107 Remaining Sonar Duplication Cleanup
+
+Problem:
+
+- After the first Sonar cleanup and Gemini review-fix commit, SonarCloud still failed the quality gate with `6.5% Duplication on New Code`.
+- Sonar duplication details pointed to the genesis and continuation job-response helpers in `story-generator/src/app/app.spec.ts`.
+
+Fix:
+
+- Replaced duplicated genesis/continuation job-response helper bodies with one generic `createJobResponse()` test helper.
+- Kept the small genesis/continuation wrapper helpers so tests still read in domain language.
+
+Validation:
+
+- `git diff --check`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"`: passed with `25 SUCCESS`.
+
 ## 2026-05-26 00:12 EDT - Recovery Tracking Started
 
 Actions:

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -65,6 +65,30 @@ Validation:
 - `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"`: passed with `23 SUCCESS`.
 - `npm run smoke:story-lab-ui`: passed in mock mode; Angular build reported the existing budget warnings for the 509.99 kB initial browser bundle and 12.56 kB `app.css`.
 
+## 2026-06-07 09:08 EDT - PR107 Gemini Review Fixes
+
+Problem:
+
+- Gemini Code Assist left two actionable continuation-job UI comments:
+  - completed continuation jobs should defensively reject malformed result payloads before using `job.result.batch.chapters`;
+  - continuation event streams that complete synchronously should not leave a stale closed subscription reference.
+
+Fix:
+
+- Added regression specs for malformed completed continuation payloads and synchronous continuation stream completion.
+- Added a `hasRenderableIterationPayload()` guard before applying completed continuation job results.
+- Updated `openContinuationJobEventStream()` to assign the stream subscription through a local variable and store `null` when it is already closed.
+
+Validation:
+
+- RED: focused Angular app spec failed with the expected malformed-payload and stale-subscription failures before implementation.
+- GREEN: `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"` passed with `25 SUCCESS`.
+- `git diff --check`: passed.
+- `node --check scripts/recovery/story-lab-browser-smoke.mjs`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`: passed.
+- `npm run smoke:story-lab-ui`: passed in mock mode; Angular build reported the existing budget warnings for the 510.13 kB initial browser bundle and 12.56 kB `app.css`.
+
 ## 2026-05-26 00:12 EDT - Recovery Tracking Started
 
 Actions:

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -4,6 +4,43 @@ Created: 2026-05-26 00:12 EDT
 
 This is the chronological work log for the PR #70 recovery. It should capture commands, decisions, self-review notes, validation results, and anything that changes the plan.
 
+## 2026-06-07 08:58 EDT - Story Lab Continuation UI Job Migration
+
+Actions:
+
+- Created `feature/story-lab-continuation-jobs` from current `main`.
+- Added `STORY_LAB_CONTINUATION_JOB_UI_EXEC_PLAN.md` for the UI slice and hostile-review risks.
+- Changed the Continue Saga UI from the old direct `continueStory()` call to `createStoryLabJob({ kind: 'continuation', continuation })`.
+- Wired continuation job snapshots/events into the existing visible progress/status panel.
+- Added continuation terminal handling:
+  - completed jobs append the returned chapters to the current saga;
+  - failed jobs show the existing friendly Grok configuration message when appropriate;
+  - cancelled jobs fail the active continuation batch without removing existing chapters.
+- Kept active browser-session job recovery limited to genesis for this slice so the UI does not imply durable continuation recovery before storage/Workflow exists.
+- Updated the mocked browser smoke so continuation uses `/api/story-lab/jobs` and the legacy `/api/story-lab/stories/:storyId/continue` path returns `410 LEGACY_CONTINUATION_ROUTE_USED` in smoke mode.
+- Updated `STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md` to mark visible continuation job migration complete while keeping durable/account-backed job persistence deferred.
+
+Validation:
+
+- RED: `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"` failed with 4 expected continuation failures proving the UI still called `continueStory` and did not stream continuation job events.
+- GREEN: the same focused Angular command passed with `23 SUCCESS` after the UI migration.
+- `node --check scripts/recovery/story-lab-browser-smoke.mjs`: passed.
+- `git diff --check`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`: passed.
+- `npx tsx tests/story-lab-job-contracts.test.ts`: passed.
+- `npx tsx tests/story-lab-job-routes.test.ts`: passed.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
+- `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"`: passed with `23 SUCCESS`.
+- `npm run smoke:story-lab-ui`: passed in mock mode; Angular build reported the existing budget warnings for the 509.99 kB initial browser bundle and 12.56 kB `app.css`.
+
+Self-review:
+
+- Good: Both visible writing actions now use the same Story Lab job route family.
+- Good: Smoke mode now fails fast if the UI tries the old direct genesis or continuation endpoints.
+- Remaining risk: Continuation jobs do not yet have browser-session reload recovery; adding that should wait for a deliberate state/durability slice because continuation recovery needs an existing story/session snapshot.
+- Remaining risk: The job store is still `non_durable_memory`, so this is UI/contract progress, not durable Workflow/database-backed background execution.
+
 ## 2026-05-26 00:12 EDT - Recovery Tracking Started
 
 Actions:

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -41,6 +41,30 @@ Self-review:
 - Remaining risk: Continuation jobs do not yet have browser-session reload recovery; adding that should wait for a deliberate state/durability slice because continuation recovery needs an existing story/session snapshot.
 - Remaining risk: The job store is still `non_durable_memory`, so this is UI/contract progress, not durable Workflow/database-backed background execution.
 
+## 2026-06-07 09:05 EDT - PR107 Sonar Cleanup
+
+Problem:
+
+- PR #107 SonarCloud Code Analysis failed the quality gate with `7.2% Duplication on New Code` where the gate requires `<= 3%`.
+- Sonar also reported:
+  - duplicated app-spec job event helper implementation;
+  - a redundant jump in the mocked browser smoke route handler;
+  - a nested ternary in mocked smoke job lookup.
+
+Fix:
+
+- Replaced separate genesis/continuation spec event helpers with one generic `createJobEvent()` helper.
+- Removed the redundant return from the smoke script.
+- Replaced the nested smoke job lookup ternary with explicit `if`/`else if` branches.
+
+Validation:
+
+- `git diff --check`: passed.
+- `node --check scripts/recovery/story-lab-browser-smoke.mjs`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"`: passed with `23 SUCCESS`.
+- `npm run smoke:story-lab-ui`: passed in mock mode; Angular build reported the existing budget warnings for the 509.99 kB initial browser bundle and 12.56 kB `app.css`.
+
 ## 2026-05-26 00:12 EDT - Recovery Tracking Started
 
 Actions:

--- a/STORY_LAB_CONTINUATION_JOB_UI_EXEC_PLAN.md
+++ b/STORY_LAB_CONTINUATION_JOB_UI_EXEC_PLAN.md
@@ -1,0 +1,69 @@
+# Story Lab Continuation Job UI ExecPlan
+
+Created: 2026-06-07 EDT
+
+## Goal
+
+Move the visible Story Lab Continue Saga UI from the legacy direct continuation request to the Story Lab job route, matching the already-merged genesis job UI behavior.
+
+## Why This Matters
+
+Generate now behaves like a job-backed product flow. Continue Saga still behaves like an older one-shot request. That split makes progress handling inconsistent and keeps the second main writing action outside the job seam needed for future durable Workflow/database-backed generation.
+
+After this slice:
+
+- Continue Saga creates a `kind: 'continuation'` Story Lab job.
+- The UI updates progress from continuation job snapshots/events.
+- Completed continuation jobs append chapters to the current story.
+- Failed or cancelled continuation jobs fail the active batch cleanly without losing existing chapters.
+- Tests prove the UI no longer calls the direct continuation endpoint for user-facing continuation.
+
+## Files
+
+- Modify: `story-generator/src/app/app.ts`
+  - Replace direct `continueStory()` usage in `continueSaga()` with `createStoryLabJob({ kind: 'continuation', continuation: request })`.
+  - Add continuation job snapshot/event handling.
+  - Keep browser-session active job restore limited to genesis for this slice.
+- Modify: `story-generator/src/app/app.spec.ts`
+  - Change continuation UI specs to require job creation.
+  - Add a running-job progress/event test.
+  - Add a failed continuation job test.
+- Modify: `scripts/recovery/story-lab-browser-smoke.mjs`
+  - Make mocked smoke reject legacy continuation route usage.
+  - Let continuation flow use `/api/story-lab/jobs` with `kind: 'continuation'`.
+- Modify: `STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md`
+  - Mark continuation visible UI migration progress.
+- Modify: `PR70_RECOVERY_CHANGELOG.md`
+  - Record branch actions and verification.
+
+## Hostile Reviewer Critique
+
+- Product risk: if Continue only changes internally, the user still cannot tell anything improved. Mitigation: wire continuation job status into the existing visible progress/status text and smoke-check progress.
+- Architecture risk: storing continuation jobs in browser session could imply durability the app does not have. Mitigation: do not add continuation reload recovery in this slice; keep that as a later explicit durable-state gate.
+- Testing risk: only checking a happy path could allow the old direct continuation endpoint to remain active. Mitigation: unit specs assert `continueStory` is not called, and smoke mocks return an error if legacy continuation route is used.
+- Scope risk: broad refactor of genesis helpers could regress already-merged Generate behavior. Mitigation: use the smallest shared helper or continuation-specific helper needed, then run existing genesis specs too.
+
+## Checklist
+
+- [x] Write failing Angular specs proving Continue Saga should create a continuation job instead of calling `continueStory`.
+- [x] Run targeted Angular spec and confirm the new tests fail for the expected reason.
+- [x] Implement the minimal UI changes in `app.ts`.
+- [x] Run targeted Angular spec and confirm genesis plus continuation UI specs pass.
+- [x] Update mocked browser smoke so legacy continuation route fails.
+- [x] Run job contract/route checks and browser smoke.
+- [x] Update platform/changelog docs.
+- [x] Run final verification.
+- [ ] Commit, push, create PR, inspect checks/comments, address actionable feedback, and merge if clean.
+
+## Verification Commands
+
+```bash
+git diff --check
+npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"
+npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"
+npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"
+npx tsx tests/story-lab-job-contracts.test.ts
+npx tsx tests/story-lab-job-routes.test.ts
+scripts/recovery/check-vercel-function-count.sh
+npm run smoke:story-lab-ui
+```

--- a/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
+++ b/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
@@ -69,6 +69,10 @@ The key product goal is not "more features." The key product goal is a story stu
   - [x] added browser-session active genesis job recovery through `getStoryLabJob`;
   - [x] cleared malformed, completed, failed, and cancelled active job markers;
   - [x] moved mocked browser smoke genesis coverage to `/api/story-lab/jobs` plus SSE job events.
+- [x] Continued Phase D visible continuation UI migration on `feature/story-lab-continuation-jobs`:
+  - [x] moved the Continue Saga UI from direct `continueStory` calls to `POST /api/story-lab/jobs` with `kind: 'continuation'`;
+  - [x] wired continuation progress, completion, cancellation, and failed-provider handling to Story Lab job snapshots/events;
+  - [x] moved mocked browser smoke continuation coverage to `/api/story-lab/jobs` and made the legacy direct continuation route fail in smoke mode.
 - [ ] Leave final handoff describing what remains and what requires external provisioning.
 
 ## Surprises & Discoveries
@@ -132,9 +136,9 @@ The key product goal is not "more features." The key product goal is a story stu
   - Future Story Lab job streaming now has an opaque `job_<uuid>` contract and path builder that keeps blueprint/story/private fields out of status and events URLs.
   - Story Lab job routes now create opaque jobs, replay queued/running/terminal snapshots, and label the in-process store as `non_durable_memory`.
 - What was intentionally deferred:
-  - Accounts, cloud storage, durable Workflow execution, owner-scoped job persistence, reload-safe job resume UI, Blob export, email, and audio runtime.
+  - Accounts, cloud storage, durable Workflow execution, owner-scoped job persistence, continuation reload-safe job resume UI, Blob export, email, and audio runtime.
 - What hostile review still objected to:
-  - The genesis UI now uses job snapshots/events, but the in-memory scaffold is still not real durable Workflow/database-backed progress.
+  - The genesis and continuation UI now use job snapshots/events, but the in-memory scaffold is still not real durable Workflow/database-backed progress.
   - The legacy direct Story Lab stream route still exists for compatibility; future work should retire it after job UI smoke coverage and reload-safe resume are in place.
   - Existing `/api/export/save` is safer for mock server export, but it is still not a durable Blob/email export path.
   - Full Angular build and Karma browser spec validation must be rerun under a stable local/CI environment because Node v23 Angular build/Karma runners hung here.
@@ -612,9 +616,12 @@ Files:
 - [x] Added `vercel.json` rewrites for `/api/story-lab/jobs/:jobId` and `/api/story-lab/jobs/:jobId/events`.
 - [x] Modified `story-generator/src/app/story.service.ts`.
 - [x] Modified `story-generator/src/app/app.ts` to use job routes for genesis visible progress.
+- [x] Modified `story-generator/src/app/app.ts` to use job routes for continuation visible progress.
 - [x] Modified `story-generator/src/app/app.spec.ts` for genesis job creation, event progress, completion, and failed-job handling.
+- [x] Modified `story-generator/src/app/app.spec.ts` for continuation job creation, event progress, completion, and failed-job handling.
 - [x] Reused `story-generator/src/app/app.html` existing progress panel for reload-safe job progress.
 - [x] Modified `scripts/recovery/story-lab-browser-smoke.mjs` for queued -> running -> terminal job progress.
+- [x] Modified `scripts/recovery/story-lab-browser-smoke.mjs` so mock continuation uses jobs and rejects the legacy direct continuation route.
 
 Contracts:
 
@@ -643,7 +650,8 @@ Acceptance:
 - [x] Function count stays within the repo's allow-list before and after the API route change.
 - [x] Non-Workflow fallback is labeled non-durable.
 - [x] UI can start a genesis job and complete/fail from job snapshots/events.
-- [x] UI can survive reload by polling job id inside the current browser session.
+- [x] UI can start a continuation job and complete/fail from job snapshots/events.
+- [x] UI can survive reload for active genesis jobs by polling job id inside the current browser session.
 - [x] Mocked browser smoke sees queued -> running -> completed through the visible UI.
 
 ### Phase E: Account Sync

--- a/scripts/recovery/story-lab-browser-smoke.mjs
+++ b/scripts/recovery/story-lab-browser-smoke.mjs
@@ -581,17 +581,17 @@ async function installMockStoryLabRoutes(page) {
           }
         })
       });
-      return;
     }
   });
 
   await page.route('**/api/story-lab/jobs/*', async route => {
     const jobId = extractJobId(route.request().url());
-    const job = jobId === genesisJobId
-      ? latestGenesisJob
-      : jobId === continuationJobId
-        ? latestContinuationJob
-        : null;
+    let job = null;
+    if (jobId === genesisJobId) {
+      job = latestGenesisJob;
+    } else if (jobId === continuationJobId) {
+      job = latestContinuationJob;
+    }
     if (!job) {
       await route.fulfill({
         status: 404,

--- a/scripts/recovery/story-lab-browser-smoke.mjs
+++ b/scripts/recovery/story-lab-browser-smoke.mjs
@@ -364,6 +364,9 @@ async function runSmoke() {
 
     await page.locator(smokeSelectors.continuationDirection('Raise the danger')).click();
     await page.locator(smokeSelectors.progress).waitFor({ timeout: 20_000 });
+    if (!liveMode) {
+      await expectText(page.locator(smokeSelectors.progress), 'Grok is continuing the saga');
+    }
     await page.locator(smokeSelectors.chapterView(2)).waitFor({ timeout: liveMode ? 90_000 : 20_000 });
 
     await page.locator(smokeSelectors.copyStory).click();
@@ -401,8 +404,10 @@ async function runSmoke() {
 }
 
 async function installMockStoryLabRoutes(page) {
-  const smokeJobId = 'job_00000000-0000-4000-8000-000000000105';
+  const genesisJobId = 'job_00000000-0000-4000-8000-000000000105';
+  const continuationJobId = 'job_00000000-0000-4000-8000-000000000106';
   let latestGenesisJob = null;
+  let latestContinuationJob = null;
 
   await page.route('**/api/health', async route => {
     await route.fulfill({
@@ -457,33 +462,114 @@ async function installMockStoryLabRoutes(page) {
       body = null;
     }
 
-    if (body?.kind !== 'genesis') {
+    if (body?.kind === 'genesis') {
+      latestGenesisJob = buildJobSnapshot(genesisJobId, 'running', 'generating_story', 38);
+      await delay(250);
       await route.fulfill({
-        status: 400,
+        status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({
-          success: false,
-          error: {
-            code: 'SMOKE_EXPECTED_GENESIS_JOB',
-            message: 'Smoke expected a genesis Story Lab job request.'
-          }
-        })
+        body: JSON.stringify(buildJobResponse(latestGenesisJob))
       });
       return;
     }
 
-    latestGenesisJob = buildJobSnapshot(smokeJobId, 'running', 'generating_story', 38);
-    await delay(250);
+    if (body?.kind === 'continuation') {
+      if (!body?.continuation?.continuationBrief?.includes('danger')) {
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: false,
+            error: {
+              code: 'MISSING_DIRECTION',
+              message: 'Smoke expected a continuation direction brief.'
+            }
+          })
+        });
+        return;
+      }
+
+      latestContinuationJob = buildJobSnapshot(continuationJobId, 'running', 'continuing_story', 42, undefined, 'continuation');
+      await delay(250);
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(buildJobResponse(latestContinuationJob))
+      });
+      return;
+    }
+
     await route.fulfill({
-      status: 200,
+      status: 400,
       contentType: 'application/json',
-      body: JSON.stringify(buildJobResponse(latestGenesisJob))
+      body: JSON.stringify({
+        success: false,
+        error: {
+          code: 'SMOKE_UNSUPPORTED_JOB',
+          message: 'Smoke expected a genesis or continuation Story Lab job request.'
+        }
+      })
     });
   });
 
   await page.route('**/api/story-lab/jobs/*/events', async route => {
     const jobId = extractJobId(route.request().url(), '/events');
-    if (jobId !== smokeJobId || !latestGenesisJob) {
+    if (jobId === genesisJobId && latestGenesisJob) {
+      const completedJob = buildJobSnapshot(
+        genesisJobId,
+        'completed',
+        'completed',
+        100,
+        buildPayload([buildChapter(1)], 1)
+      );
+      const events = [
+        buildJobSnapshot(genesisJobId, 'queued', 'queued', 8),
+        latestGenesisJob,
+        completedJob
+      ];
+      latestGenesisJob = completedJob;
+
+      await delay(500);
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'content-type': 'text/event-stream; charset=utf-8',
+          'cache-control': 'no-cache'
+        },
+        body: events.map((job, index) => `data: ${JSON.stringify(buildJobEvent(job, index + 1))}\n\n`).join('')
+      });
+      return;
+    }
+
+    if (jobId === continuationJobId && latestContinuationJob) {
+      const completedJob = buildJobSnapshot(
+        continuationJobId,
+        'completed',
+        'completed',
+        100,
+        { ...buildPayload([buildChapter(2)], 2), appendedChapterNumbers: [2] },
+        'continuation'
+      );
+      const events = [
+        buildJobSnapshot(continuationJobId, 'queued', 'queued', 8, undefined, 'continuation'),
+        latestContinuationJob,
+        completedJob
+      ];
+      latestContinuationJob = completedJob;
+
+      await delay(500);
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'content-type': 'text/event-stream; charset=utf-8',
+          'cache-control': 'no-cache'
+        },
+        body: events.map((job, index) => `data: ${JSON.stringify(buildJobEvent(job, index + 1))}\n\n`).join('')
+      });
+      return;
+    }
+
+    if (jobId !== genesisJobId || !latestGenesisJob) {
       await route.fulfill({
         status: 404,
         contentType: 'application/json',
@@ -497,35 +583,16 @@ async function installMockStoryLabRoutes(page) {
       });
       return;
     }
-
-    const completedJob = buildJobSnapshot(
-      smokeJobId,
-      'completed',
-      'completed',
-      100,
-      buildPayload([buildChapter(1)], 1)
-    );
-    const events = [
-      buildJobSnapshot(smokeJobId, 'queued', 'queued', 8),
-      latestGenesisJob,
-      completedJob
-    ];
-    latestGenesisJob = completedJob;
-
-    await delay(500);
-    await route.fulfill({
-      status: 200,
-      headers: {
-        'content-type': 'text/event-stream; charset=utf-8',
-        'cache-control': 'no-cache'
-      },
-      body: events.map((job, index) => `data: ${JSON.stringify(buildJobEvent(job, index + 1))}\n\n`).join('')
-    });
   });
 
   await page.route('**/api/story-lab/jobs/*', async route => {
     const jobId = extractJobId(route.request().url());
-    if (jobId !== smokeJobId || !latestGenesisJob) {
+    const job = jobId === genesisJobId
+      ? latestGenesisJob
+      : jobId === continuationJobId
+        ? latestContinuationJob
+        : null;
+    if (!job) {
       await route.fulfill({
         status: 404,
         contentType: 'application/json',
@@ -543,45 +610,34 @@ async function installMockStoryLabRoutes(page) {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify(buildJobResponse(latestGenesisJob))
+      body: JSON.stringify(buildJobResponse(job))
     });
   });
 
   await page.route('**/api/story-lab/stories/*/continue', async route => {
-    let body = null;
-    try {
-      body = route.request().postDataJSON();
-    } catch {
-      body = null;
-    }
-    if (!body?.continuationBrief?.includes('danger')) {
-      await route.fulfill({
-        status: 400,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          success: false,
-          error: {
-            code: 'MISSING_DIRECTION',
-            message: 'Smoke expected a continuation direction brief.'
-          }
-        })
-      });
+    if (route.request().method() !== 'POST') {
+      await route.fallback();
       return;
     }
-    await delay(250);
     await route.fulfill({
-      status: 200,
+      status: 410,
       contentType: 'application/json',
-      body: JSON.stringify({ success: true, data: { ...buildPayload([buildChapter(2)], 2), appendedChapterNumbers: [2] } })
+      body: JSON.stringify({
+        success: false,
+        error: {
+          code: 'LEGACY_CONTINUATION_ROUTE_USED',
+          message: 'Smoke mode expects continuation to use /api/story-lab/jobs.'
+        }
+      })
     });
   });
 }
 
-function buildJobSnapshot(jobId, status, currentStep, progressPercent, result) {
+function buildJobSnapshot(jobId, status, currentStep, progressPercent, result, kind = 'genesis') {
   const now = new Date().toISOString();
   return {
     jobId,
-    kind: 'genesis',
+    kind,
     status,
     currentStep,
     progressPercent,

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -19,6 +19,8 @@ const STORAGE_KEY = 'fairytales_story_lab_projects_v1';
 const SKIN_STORAGE_KEY = 'fairytales_story_lab_skin_v1';
 const ACTIVE_JOB_STORAGE_KEY = 'fairytales_story_lab_active_job_v1';
 type GenesisJobOverrides = Partial<StoryLabJobCreationResponse<StoryIterationPayload>['job']>;
+type ContinuationJobResult = StoryIterationPayload & { appendedChapterNumbers: number[] };
+type ContinuationJobOverrides = Partial<StoryLabJobCreationResponse<ContinuationJobResult>['job']>;
 
 function createChapter(overrides: Partial<GeneratedChapter> = {}): GeneratedChapter {
   return {
@@ -103,6 +105,73 @@ function createGenesisJobResponse(
 function createGenesisJobEvent(
   response: StoryLabJobCreationResponse<StoryIterationPayload>
 ): StoryLabJobEvent<StoryIterationPayload> {
+  return {
+    eventId: `event-${response.job.status}`,
+    type: 'snapshot',
+    emittedAt: response.job.updatedAt,
+    job: response.job
+  };
+}
+
+function createContinuationPayload(
+  genesisPayload: StoryIterationPayload,
+  overrides: Partial<ContinuationJobResult> = {}
+): ContinuationJobResult {
+  return {
+    ...genesisPayload,
+    state: createState({ revision: 2 }),
+    batch: {
+      chapters: [createChapter({ chapterId: 'chapter-2', chapterNumber: 2 })],
+      totalWordCount: 900,
+      suggestedNextPrompts: []
+    },
+    telemetry: {
+      engine: 'gpt',
+      totalLatencyMs: 1700,
+      averageChapterLatencyMs: 850,
+      tokensConsumed: 880,
+      retryCount: 0
+    },
+    appendedChapterNumbers: [2],
+    ...overrides
+  };
+}
+
+function createContinuationJobResponse(
+  payload?: ContinuationJobResult,
+  overrides: ContinuationJobOverrides = {}
+): StoryLabJobCreationResponse<ContinuationJobResult> {
+  const now = new Date().toISOString();
+  const jobId = overrides.jobId ?? 'job_223e4567-e89b-12d3-a456-426614174000';
+
+  return {
+    job: {
+      jobId,
+      kind: 'continuation',
+      status: overrides.status ?? 'completed',
+      currentStep: overrides.currentStep ?? 'completed',
+      progressPercent: overrides.progressPercent ?? 100,
+      createdAt: overrides.createdAt ?? now,
+      updatedAt: overrides.updatedAt ?? now,
+      result: payload,
+      error: overrides.error,
+      ...overrides
+    },
+    paths: {
+      statusPath: `/api/story-lab/jobs/${jobId}`,
+      eventsPath: `/api/story-lab/jobs/${jobId}/events`
+    },
+    durability: {
+      mode: 'non_durable_memory',
+      durable: false,
+      warning: 'Jobs are held in memory for this deployment.'
+    }
+  };
+}
+
+function createContinuationJobEvent(
+  response: StoryLabJobCreationResponse<ContinuationJobResult>
+): StoryLabJobEvent<ContinuationJobResult> {
   return {
     eventId: `event-${response.job.status}`,
     type: 'snapshot',
@@ -210,6 +279,36 @@ describe('App', () => {
     stubRunningGenesisJob(events$, initialJobOverrides);
     configureValidBlueprint(logline);
     component.startGenesis();
+  }
+
+  function seedWorkbenchForContinuation(overrides: Partial<StoryIterationPayload> = {}): StoryIterationPayload {
+    const payload: StoryIterationPayload = {
+      summary: createSummary(),
+      batch: {
+        chapters: [createChapter()],
+        totalWordCount: 900,
+        suggestedNextPrompts: []
+      },
+      state: createState(),
+      telemetry: {
+        engine: 'gpt',
+        totalLatencyMs: 1800,
+        averageChapterLatencyMs: 900,
+        tokensConsumed: 900,
+        retryCount: 0
+      },
+      ...overrides
+    };
+
+    component.workbench.set({
+      story: payload.summary,
+      state: payload.state,
+      chapterHistory: payload.batch.chapters,
+      activeBatchSize: 1,
+      lastTelemetry: payload.telemetry
+    });
+
+    return payload;
   }
 
   it('creates the workbench with default blueprint values', () => {
@@ -498,100 +597,105 @@ describe('App', () => {
   });
 
   it('continues an existing saga and appends chapters', () => {
-    const genesisPayload: StoryIterationPayload = {
-      summary: createSummary(),
-      batch: {
-        chapters: [createChapter()],
-        totalWordCount: 900,
-        suggestedNextPrompts: []
-      },
-      state: createState(),
-      telemetry: {
-        engine: 'gpt',
-        totalLatencyMs: 1800,
-        averageChapterLatencyMs: 900,
-        tokensConsumed: 900,
-        retryCount: 0
-      }
-    };
-
-    component.workbench.set({
-      story: genesisPayload.summary,
-      state: genesisPayload.state,
-      chapterHistory: genesisPayload.batch.chapters,
-      activeBatchSize: 1,
-      lastTelemetry: genesisPayload.telemetry
-    });
-
-    const continuationPayload: StoryIterationPayload & { appendedChapterNumbers: number[] } = {
-      ...genesisPayload,
-      state: createState({ revision: 2 }),
-      batch: {
-        chapters: [createChapter({ chapterId: 'chapter-2', chapterNumber: 2 })],
-        totalWordCount: 900,
-        suggestedNextPrompts: []
-      },
-      telemetry: {
-        engine: 'gpt',
-        totalLatencyMs: 1700,
-        averageChapterLatencyMs: 850,
-        tokensConsumed: 880,
-        retryCount: 0
-      },
-      appendedChapterNumbers: [2]
-    };
-
+    const genesisPayload = seedWorkbenchForContinuation();
+    const continuationPayload = createContinuationPayload(genesisPayload);
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(continuationPayload)
+    }));
     storyService.continueStory.and.returnValue(of({ success: true, data: continuationPayload }));
 
     component.continueSaga('Focus on the betrayal arc.');
 
-    const request = storyService.continueStory.calls.mostRecent().args[0];
-    expect(request.storyId).toBe('story-123');
+    expect(storyService.continueStory).not.toHaveBeenCalled();
+    expect(storyService.createStoryLabJob).toHaveBeenCalledWith(jasmine.objectContaining({
+      kind: 'continuation',
+      continuation: jasmine.objectContaining({
+        storyId: 'story-123',
+        continuationBrief: 'Focus on the betrayal arc.'
+      })
+    }));
     expect(component.workbench().chapterHistory.length).toBe(2);
     expect(component.selectedChapter()?.chapterNumber).toBe(2);
     expect(component.activeBatchQueue().at(-1)?.status).toBe('completed');
   });
 
   it('continues with a selected direction brief', () => {
-    const genesisPayload: StoryIterationPayload = {
-      summary: createSummary(),
-      batch: {
-        chapters: [createChapter()],
-        totalWordCount: 900,
-        suggestedNextPrompts: []
-      },
-      state: createState(),
-      telemetry: {
-        engine: 'gpt',
-        totalLatencyMs: 1800,
-        averageChapterLatencyMs: 900,
-        tokensConsumed: 900,
-        retryCount: 0
-      }
-    };
-    const continuationPayload: StoryIterationPayload & { appendedChapterNumbers: number[] } = {
-      ...genesisPayload,
-      state: createState({ revision: 2 }),
-      batch: {
-        chapters: [createChapter({ chapterId: 'chapter-2', chapterNumber: 2 })],
-        totalWordCount: 900,
-        suggestedNextPrompts: []
-      },
-      appendedChapterNumbers: [2]
-    };
-    component.workbench.set({
-      story: genesisPayload.summary,
-      state: genesisPayload.state,
-      chapterHistory: genesisPayload.batch.chapters,
-      activeBatchSize: 1,
-      lastTelemetry: genesisPayload.telemetry
-    });
+    const genesisPayload = seedWorkbenchForContinuation();
+    const continuationPayload = createContinuationPayload(genesisPayload);
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(continuationPayload)
+    }));
     storyService.continueStory.and.returnValue(of({ success: true, data: continuationPayload }));
 
     component.continueWithDirection(component.continuationDirections[1]);
 
-    expect(storyService.continueStory.calls.mostRecent().args[0].continuationBrief)
+    expect(storyService.continueStory).not.toHaveBeenCalled();
+    const jobRequest = storyService.createStoryLabJob.calls.mostRecent().args[0] as {
+      kind: 'continuation';
+      continuation: { continuationBrief?: string };
+    };
+    expect(jobRequest.kind).toBe('continuation');
+    expect(jobRequest.continuation.continuationBrief)
       .toContain('external danger');
+  });
+
+  it('updates continuation progress from Story Lab job snapshots', () => {
+    const genesisPayload = seedWorkbenchForContinuation();
+    const continuationPayload = createContinuationPayload(genesisPayload);
+    const events$ = new Subject<StoryLabJobEvent<ContinuationJobResult>>();
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(undefined, {
+        status: 'running',
+        currentStep: 'continuing_story',
+        progressPercent: 28
+      })
+    }));
+    storyService.streamStoryLabJobEvents.and.returnValue(events$.asObservable());
+    storyService.continueStory.and.returnValue(of({ success: true, data: continuationPayload }));
+
+    component.continueSaga('Make the rival reveal dangerous.');
+
+    expect(storyService.continueStory).not.toHaveBeenCalled();
+    expect(storyService.streamStoryLabJobEvents).toHaveBeenCalledWith(
+      'job_223e4567-e89b-12d3-a456-426614174000',
+      jasmine.any(Function)
+    );
+    expect(component.generationProgress().percent).toBe(28);
+    expect(component.statusMessage()).toContain('Grok');
+
+    events$.next(createContinuationJobEvent(createContinuationJobResponse(continuationPayload)));
+    events$.complete();
+
+    expect(component.workbench().chapterHistory.length).toBe(2);
+    expect(component.selectedChapter()?.chapterNumber).toBe(2);
+    expect(component.activeBatchQueue().at(-1)?.status).toBe('completed');
+  });
+
+  it('keeps existing chapters when a continuation job fails', () => {
+    const genesisPayload = seedWorkbenchForContinuation();
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(undefined, {
+        status: 'failed',
+        currentStep: 'failed',
+        progressPercent: 100,
+        error: {
+          code: 'AI_UNAVAILABLE',
+          message: 'The AI story engine is not configured for this deployment.'
+        }
+      })
+    }));
+    storyService.continueStory.and.returnValue(of({ success: true, data: createContinuationPayload(genesisPayload) }));
+
+    component.continueSaga();
+
+    expect(storyService.continueStory).not.toHaveBeenCalled();
+    expect(component.workbench().chapterHistory).toEqual(genesisPayload.batch.chapters);
+    expect(component.activeBatchQueue().at(-1)?.status).toBe('failed');
+    expect(component.statusMessage()).toContain('missing its Grok configuration');
   });
 
   it('copies generated story text to the clipboard', async () => {

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -21,6 +21,7 @@ const ACTIVE_JOB_STORAGE_KEY = 'fairytales_story_lab_active_job_v1';
 type GenesisJobOverrides = Partial<StoryLabJobCreationResponse<StoryIterationPayload>['job']>;
 type ContinuationJobResult = StoryIterationPayload & { appendedChapterNumbers: number[] };
 type ContinuationJobOverrides = Partial<StoryLabJobCreationResponse<ContinuationJobResult>['job']>;
+type JobKindForTest = StoryLabJobCreationResponse<unknown>['job']['kind'];
 
 function createChapter(overrides: Partial<GeneratedChapter> = {}): GeneratedChapter {
   return {
@@ -74,13 +75,32 @@ function createGenesisJobResponse(
   payload?: StoryIterationPayload,
   overrides: Partial<StoryLabJobCreationResponse<StoryIterationPayload>['job']> = {}
 ): StoryLabJobCreationResponse<StoryIterationPayload> {
+  return createJobResponse({
+    kind: 'genesis',
+    defaultJobId: 'job_123e4567-e89b-12d3-a456-426614174000',
+    payload,
+    overrides
+  });
+}
+
+function createJobResponse<TResult>({
+  kind,
+  defaultJobId,
+  payload,
+  overrides = {}
+}: {
+  kind: JobKindForTest;
+  defaultJobId: string;
+  payload?: TResult;
+  overrides?: Partial<StoryLabJobCreationResponse<TResult>['job']>;
+}): StoryLabJobCreationResponse<TResult> {
   const now = new Date().toISOString();
-  const jobId = overrides.jobId ?? 'job_123e4567-e89b-12d3-a456-426614174000';
+  const jobId = overrides.jobId ?? defaultJobId;
 
   return {
     job: {
       jobId,
-      kind: 'genesis',
+      kind,
       status: overrides.status ?? 'completed',
       currentStep: overrides.currentStep ?? 'completed',
       progressPercent: overrides.progressPercent ?? 100,
@@ -130,32 +150,12 @@ function createContinuationJobResponse(
   payload?: ContinuationJobResult,
   overrides: ContinuationJobOverrides = {}
 ): StoryLabJobCreationResponse<ContinuationJobResult> {
-  const now = new Date().toISOString();
-  const jobId = overrides.jobId ?? 'job_223e4567-e89b-12d3-a456-426614174000';
-
-  return {
-    job: {
-      jobId,
-      kind: 'continuation',
-      status: overrides.status ?? 'completed',
-      currentStep: overrides.currentStep ?? 'completed',
-      progressPercent: overrides.progressPercent ?? 100,
-      createdAt: overrides.createdAt ?? now,
-      updatedAt: overrides.updatedAt ?? now,
-      result: payload,
-      error: overrides.error,
-      ...overrides
-    },
-    paths: {
-      statusPath: `/api/story-lab/jobs/${jobId}`,
-      eventsPath: `/api/story-lab/jobs/${jobId}/events`
-    },
-    durability: {
-      mode: 'non_durable_memory',
-      durable: false,
-      warning: 'Jobs are held in memory for this deployment.'
-    }
-  };
+  return createJobResponse({
+    kind: 'continuation',
+    defaultJobId: 'job_223e4567-e89b-12d3-a456-426614174000',
+    payload,
+    overrides
+  });
 }
 
 function createJobEvent<TResult>(

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -102,17 +102,6 @@ function createGenesisJobResponse(
   };
 }
 
-function createGenesisJobEvent(
-  response: StoryLabJobCreationResponse<StoryIterationPayload>
-): StoryLabJobEvent<StoryIterationPayload> {
-  return {
-    eventId: `event-${response.job.status}`,
-    type: 'snapshot',
-    emittedAt: response.job.updatedAt,
-    job: response.job
-  };
-}
-
 function createContinuationPayload(
   genesisPayload: StoryIterationPayload,
   overrides: Partial<ContinuationJobResult> = {}
@@ -169,9 +158,9 @@ function createContinuationJobResponse(
   };
 }
 
-function createContinuationJobEvent(
-  response: StoryLabJobCreationResponse<ContinuationJobResult>
-): StoryLabJobEvent<ContinuationJobResult> {
+function createJobEvent<TResult>(
+  response: StoryLabJobCreationResponse<TResult>
+): StoryLabJobEvent<TResult> {
   return {
     eventId: `event-${response.job.status}`,
     type: 'snapshot',
@@ -413,7 +402,7 @@ describe('App', () => {
       jasmine.any(Function)
     );
 
-    events$.next(createGenesisJobEvent(createGenesisJobResponse(payload)));
+    events$.next(createJobEvent(createGenesisJobResponse(payload)));
     events$.complete();
 
     expect(component.workbench().story?.storyId).toBe('story-123');
@@ -437,7 +426,7 @@ describe('App', () => {
       }
     );
 
-    events$.next(createGenesisJobEvent(createGenesisJobResponse(undefined, {
+    events$.next(createJobEvent(createGenesisJobResponse(undefined, {
       status: 'running',
       currentStep: 'generating_story',
       progressPercent: 47
@@ -453,7 +442,7 @@ describe('App', () => {
     const events$ = new Subject<StoryLabJobEvent<StoryIterationPayload>>();
 
     startGenesisJobFlow('A dragon guardian bargains for one night of forbidden mercy.', events$);
-    events$.next(createGenesisJobEvent(createGenesisJobResponse(undefined, {
+    events$.next(createJobEvent(createGenesisJobResponse(undefined, {
       status: 'failed',
       currentStep: 'failed',
       progressPercent: 100,
@@ -666,7 +655,7 @@ describe('App', () => {
     expect(component.generationProgress().percent).toBe(28);
     expect(component.statusMessage()).toContain('Grok');
 
-    events$.next(createContinuationJobEvent(createContinuationJobResponse(continuationPayload)));
+    events$.next(createJobEvent(createContinuationJobResponse(continuationPayload)));
     events$.complete();
 
     expect(component.workbench().chapterHistory.length).toBe(2);

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -687,6 +687,45 @@ describe('App', () => {
     expect(component.statusMessage()).toContain('missing its Grok configuration');
   });
 
+  it('keeps existing chapters when a completed continuation job has a malformed story payload', () => {
+    const genesisPayload = seedWorkbenchForContinuation();
+    const malformedPayload = {
+      ...createContinuationPayload(genesisPayload),
+      batch: undefined
+    } as unknown as ContinuationJobResult;
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(malformedPayload)
+    }));
+
+    expect(() => component.continueSaga()).not.toThrow();
+    expect(storyService.continueStory).not.toHaveBeenCalled();
+    expect(component.workbench().chapterHistory).toEqual(genesisPayload.batch.chapters);
+    expect(component.activeBatchQueue().at(-1)?.status).toBe('failed');
+    expect(component.statusMessage()).toContain('valid story payload');
+  });
+
+  it('clears a continuation event subscription that completes synchronously', () => {
+    const genesisPayload = seedWorkbenchForContinuation();
+    const continuationPayload = createContinuationPayload(genesisPayload);
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(undefined, {
+        status: 'running',
+        currentStep: 'continuing_story',
+        progressPercent: 28
+      })
+    }));
+    storyService.streamStoryLabJobEvents.and.returnValue(of(
+      createJobEvent(createContinuationJobResponse(continuationPayload))
+    ));
+
+    component.continueSaga('Make the rival reveal dangerous.');
+
+    expect(component.workbench().chapterHistory.length).toBe(2);
+    expect((component as unknown as { jobEventSubscription: unknown }).jobEventSubscription).toBeNull();
+  });
+
   it('copies generated story text to the clipboard', async () => {
     const writeText = jasmine.createSpy('writeText').and.resolveTo();
     spyOnProperty(navigator, 'clipboard', 'get').and.returnValue({ writeText } as unknown as Clipboard);

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -90,6 +90,8 @@ type ActiveStoryLabJobState = {
   startedAt: string;
 };
 
+type ContinuationJobResult = StoryIterationPayload & { appendedChapterNumbers: number[] };
+
 @Component({
   selector: 'app-story-lab',
   standalone: true,
@@ -465,6 +467,7 @@ export class App implements OnDestroy {
     this.isGenerating.set(true);
     this.statusMessage.set('Asking Grok to continue the next chapter...');
     this.startProgress('continuation');
+    this.closeJobSubscriptions();
     const batchId = this.enqueueBatch('Continuation', this.blueprint().chapterBatchSize);
 
     const request = {
@@ -477,37 +480,33 @@ export class App implements OnDestroy {
       heatContract: this.activeHeatContract()
     } as const;
 
-    this.storyService.continueStory(request).subscribe({
+    const jobCreationSubscription = this.storyService.createStoryLabJob<ContinuationJobResult>({
+      kind: 'continuation',
+      continuation: request
+    }).subscribe({
       next: response => {
         if (!response.success || !response.data) {
           const message = this.formatApiError(response.error, 'Continuation request failed.');
-          this.statusMessage.set(message);
-          this.markBatchFailed(batchId, message);
-          this.notificationService.error('Continuation failed', message);
-          this.isGenerating.set(false);
-          this.stopProgress();
+          this.failContinuationJob(batchId, message);
           return;
         }
 
-        this.applyIteration(response.data, request.chapterBatchSize, batchId);
-        this.statusMessage.set('Continuation batch ready. Select a chapter to explore.');
-        this.notificationService.success(
-          'Continuation ready',
-          `Added ${response.data.batch.chapters.length} chapter${response.data.batch.chapters.length === 1 ? '' : 's'} to the saga.`
-        );
-        this.isGenerating.set(false);
-        this.stopProgress();
+        const isTerminal = this.handleContinuationJobSnapshot(response.data.job, batchId, request.chapterBatchSize);
+        if (!isTerminal) {
+          this.openContinuationJobEventStream(response.data.job.jobId, batchId, request.chapterBatchSize);
+        }
       },
       error: error => {
+        this.jobCreationSubscription = null;
         this.errorLogging.logError(error, 'App.continueSaga');
         const message = this.formatHttpError(error, 'Continuation failed. Your existing chapters are still available.');
-        this.statusMessage.set(message);
-        this.markBatchFailed(batchId, message);
-        this.notificationService.error('Continuation failed', message);
-        this.isGenerating.set(false);
-        this.stopProgress();
+        this.failContinuationJob(batchId, message);
+      },
+      complete: () => {
+        this.jobCreationSubscription = null;
       }
     });
+    this.jobCreationSubscription = jobCreationSubscription.closed ? null : jobCreationSubscription;
   }
 
   continueWithDirection(direction: ContinuationDirection) {
@@ -744,7 +743,68 @@ ${chapters}
     });
   }
 
-  private updateProgressFromJob(job: StoryLabJob<StoryIterationPayload>) {
+  private handleContinuationJobSnapshot(
+    job: StoryLabJob<ContinuationJobResult>,
+    batchId: string,
+    batchSize: ChapterBatchSize
+  ): boolean {
+    this.updateProgressFromJob(job);
+
+    if (job.status === 'completed') {
+      if (!job.result) {
+        this.failContinuationJob(batchId, 'Continuation finished without a story payload. Please try again.');
+        return true;
+      }
+
+      this.applyIteration(job.result, batchSize, batchId);
+      this.statusMessage.set('Continuation batch ready. Select a chapter to explore.');
+      this.notificationService.success(
+        'Continuation ready',
+        `Added ${job.result.batch.chapters.length} chapter${job.result.batch.chapters.length === 1 ? '' : 's'} to the saga.`
+      );
+      this.isGenerating.set(false);
+      this.closeJobEventSubscription();
+      this.stopProgress();
+      return true;
+    }
+
+    if (job.status === 'failed') {
+      this.failContinuationJob(
+        batchId,
+        this.formatApiError(job.error, 'Continuation failed. Your existing chapters are still available.')
+      );
+      return true;
+    }
+
+    if (job.status === 'cancelled') {
+      this.failContinuationJob(batchId, 'Continuation was cancelled before it finished.');
+      return true;
+    }
+
+    return false;
+  }
+
+  private openContinuationJobEventStream(jobId: string, batchId: string, batchSize: ChapterBatchSize) {
+    this.closeJobEventSubscription();
+    this.jobEventSubscription = this.storyService.streamStoryLabJobEvents<ContinuationJobResult>(
+      jobId,
+      () => undefined
+    ).subscribe({
+      next: event => {
+        this.handleContinuationJobSnapshot(event.job, batchId, batchSize);
+      },
+      error: error => {
+        this.errorLogging.logError(error, 'App.openContinuationJobEventStream');
+        const message = this.formatHttpError(error, 'Continuation updates stopped. Your existing chapters are still available.');
+        this.failContinuationJob(batchId, message);
+      },
+      complete: () => {
+        this.jobEventSubscription = null;
+      }
+    });
+  }
+
+  private updateProgressFromJob(job: StoryLabJob<unknown>) {
     const stage = this.formatJobStage(job.currentStep, job.status);
     const progressPercent = Math.max(0, Math.min(100, Math.round(job.progressPercent)));
     this.jobDrivenProgress = true;
@@ -763,6 +823,15 @@ ${chapters}
     this.statusMessage.set(message);
     this.markBatchFailed(batchId, message);
     this.notificationService.error('Generation failed', message);
+    this.isGenerating.set(false);
+    this.stopProgress();
+  }
+
+  private failContinuationJob(batchId: string, message: string) {
+    this.closeJobEventSubscription();
+    this.statusMessage.set(message);
+    this.markBatchFailed(batchId, message);
+    this.notificationService.error('Continuation failed', message);
     this.isGenerating.set(false);
     this.stopProgress();
   }

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -751,8 +751,8 @@ ${chapters}
     this.updateProgressFromJob(job);
 
     if (job.status === 'completed') {
-      if (!job.result) {
-        this.failContinuationJob(batchId, 'Continuation finished without a story payload. Please try again.');
+      if (!this.hasRenderableIterationPayload(job.result)) {
+        this.failContinuationJob(batchId, 'Continuation finished without a valid story payload. Please try again.');
         return true;
       }
 
@@ -786,7 +786,7 @@ ${chapters}
 
   private openContinuationJobEventStream(jobId: string, batchId: string, batchSize: ChapterBatchSize) {
     this.closeJobEventSubscription();
-    this.jobEventSubscription = this.storyService.streamStoryLabJobEvents<ContinuationJobResult>(
+    const jobEventSubscription = this.storyService.streamStoryLabJobEvents<ContinuationJobResult>(
       jobId,
       () => undefined
     ).subscribe({
@@ -802,6 +802,7 @@ ${chapters}
         this.jobEventSubscription = null;
       }
     });
+    this.jobEventSubscription = jobEventSubscription.closed ? null : jobEventSubscription;
   }
 
   private updateProgressFromJob(job: StoryLabJob<unknown>) {
@@ -825,6 +826,10 @@ ${chapters}
     this.notificationService.error('Generation failed', message);
     this.isGenerating.set(false);
     this.stopProgress();
+  }
+
+  private hasRenderableIterationPayload(payload: StoryIterationPayload | undefined): payload is StoryIterationPayload {
+    return Array.isArray(payload?.batch?.chapters);
   }
 
   private failContinuationJob(batchId: string, message: string) {


### PR DESCRIPTION
## Summary
- Move Continue Saga from the legacy direct continuation request to `createStoryLabJob({ kind: 'continuation' })`.
- Wire continuation job snapshots/events into the existing visible progress, completion, failure, and cancellation UI.
- Update mocked browser smoke so continuation uses `/api/story-lab/jobs` and the legacy continuation route fails in smoke mode.

## Test Plan
- RED: `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"` failed with 4 expected continuation failures before implementation.
- `node --check scripts/recovery/story-lab-browser-smoke.mjs`
- `git diff --check`
- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`
- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`
- `npx tsx tests/story-lab-job-contracts.test.ts`
- `npx tsx tests/story-lab-job-routes.test.ts`
- `scripts/recovery/check-vercel-function-count.sh` at `10/12`
- `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"` passed with `23 SUCCESS`
- `npm run smoke:story-lab-ui` passed in mock mode; Angular reported existing budget warnings.

## Notes
- Continuation reload recovery remains intentionally deferred. Genesis has browser-session recovery, but continuation recovery needs a deliberate state/durability slice because it depends on an existing story/session snapshot.
- The job store remains `non_durable_memory`; this PR is UI/job-seam migration, not durable Workflow/database-backed execution.
