### PR TITLE
Add Story Lab continuation job resume

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -138,6 +138,32 @@ Remaining risk:
 
 - This is still browser-session recovery over a process-local job scaffold. Vercel cold starts, cross-device resume, account-owned jobs, and Workflow/database durability remain future platform gates.
 
+## 2026-06-07 09:26 EDT - PR108 Story-Bound Continuation Resume Review Fix
+
+Problem:
+
+- Gemini Code Assist and Codex both flagged that active continuation markers did not include the originating `storyId`.
+- Without that binding, reload recovery could use whichever saved project auto-loaded first, then append the recovered continuation onto the wrong context or drop the earlier chapter history when story ids differed.
+
+Fix:
+
+- Added regression specs proving active continuation markers store `storyId` and reload recovery loads the matching saved story instead of the newest saved project.
+- Stored `storyId` in active continuation markers.
+- Required continuation markers to include `storyId`.
+- Added matching saved-project lookup by story id before resuming continuation jobs.
+- Refused continuation recovery when the saved story context cannot be found.
+
+Validation:
+
+- RED: focused Angular app spec failed with the expected missing-`storyId` and wrong-project recovery failures.
+- GREEN: `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"` passed with `30 SUCCESS`.
+- `git diff --check`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`: passed.
+- `npx tsx tests/story-lab-job-contracts.test.ts`: passed.
+- `npx tsx tests/story-lab-job-routes.test.ts`: passed.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
+
 ## 2026-05-26 00:12 EDT - Recovery Tracking Started
 
 Actions:

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -107,6 +107,37 @@ Validation:
 - `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
 - `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"`: passed with `25 SUCCESS`.
 
+## 2026-06-07 09:18 EDT - Story Lab Continuation Browser-Session Resume
+
+Actions:
+
+- Created `feature/story-lab-continuation-resume` from current `main` after PR #107 merged.
+- Added `STORY_LAB_CONTINUATION_RESUME_UI_EXEC_PLAN.md` to scope the slice to browser-session UI recovery only.
+- Expanded active Story Lab job markers from genesis-only to `genesis | continuation`.
+- Stored active continuation job markers while continuation jobs are still running.
+- Made `restoreActiveStoryLabJob()` route by job kind:
+  - genesis recovery keeps the existing path;
+  - continuation recovery requires an already-restored saved local story/state before calling `getStoryLabJob`;
+  - missing saved story context clears the marker and avoids appending chapters into an empty workbench.
+- Added recovered continuation batch labeling, terminal marker cleanup, and completed continuation application to the restored local story.
+- Updated `STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md` to mark browser-session continuation recovery complete while keeping cold-start-safe durable job recovery deferred.
+
+Validation:
+
+- RED: `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"` failed with 4 expected continuation-resume failures proving active continuation markers were not stored or restored.
+- GREEN: the same focused Angular command passed with `29 SUCCESS` after the implementation.
+- `git diff --check`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`: passed.
+- `npx tsx tests/story-lab-job-contracts.test.ts`: passed.
+- `npx tsx tests/story-lab-job-routes.test.ts`: passed.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
+- `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"`: passed with `29 SUCCESS`.
+
+Remaining risk:
+
+- This is still browser-session recovery over a process-local job scaffold. Vercel cold starts, cross-device resume, account-owned jobs, and Workflow/database durability remain future platform gates.
+
 ## 2026-05-26 00:12 EDT - Recovery Tracking Started
 
 Actions:

--- a/STORY_LAB_CONTINUATION_RESUME_UI_EXEC_PLAN.md
+++ b/STORY_LAB_CONTINUATION_RESUME_UI_EXEC_PLAN.md
@@ -1,0 +1,65 @@
+# Story Lab Continuation Resume UI ExecPlan
+
+Created: 2026-06-07 EDT
+
+## Goal
+
+Extend the existing browser-session active job recovery so in-flight Continue Saga jobs can survive a browser reload when the current story is already saved in local browser storage.
+
+## Why This Matters
+
+Generate already stores an active job marker and can recover progress after reload. Continue Saga now uses jobs too, but if the browser reloads while a continuation job is running, the app forgets that active continuation job. This slice closes that UI gap without pretending the backend job store is durable.
+
+## Scope
+
+- Store a continuation active-job marker when a continuation job is still running.
+- Restore a running continuation job after reload if a saved local story is available.
+- Apply a completed recovered continuation job to the restored local story.
+- Clear continuation markers on malformed storage, missing local story context, completion, failure, and cancellation.
+- Keep the same `non_durable_memory` warning: this is browser-session recovery only, not Vercel Workflow/database durability.
+
+## Files
+
+- Modify: `story-generator/src/app/app.ts`
+  - Expand `ActiveStoryLabJobState.kind` from genesis-only to `genesis | continuation`.
+  - Store active continuation jobs from `continueSaga()`.
+  - Route `restoreActiveStoryLabJob()` by job kind.
+  - Label recovered batches as `Genesis` or `Continuation`.
+  - Clear continuation markers on terminal continuation states.
+- Modify: `story-generator/src/app/app.spec.ts`
+  - Add failing specs for storing active continuation markers.
+  - Add failing specs for running and completed continuation recovery.
+  - Add failing spec for clearing continuation markers when no saved story context exists.
+- Modify: `STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md`
+  - Mark browser-session continuation recovery complete.
+- Modify: `PR70_RECOVERY_CHANGELOG.md`
+  - Record red/green validation and remaining durability limitation.
+
+## Hostile Reviewer Critique
+
+- Product risk: users may think reload recovery means durable cloud recovery. Mitigation: changelog/platform docs explicitly keep this browser-session only.
+- Data risk: continuation recovery without a restored story would append chapters into an empty workbench. Mitigation: do not call the job API for continuation recovery unless a saved story and state are loaded first.
+- Regression risk: generic active-job parsing could break existing genesis recovery. Mitigation: keep existing genesis specs and add continuation-specific specs.
+- Scope risk: this could drift into database/Workflow storage. Mitigation: no new routes, storage providers, schemas, or external dependencies in this slice.
+
+## Checklist
+
+- [x] Write failing Angular specs for active continuation marker storage and recovery.
+- [x] Run focused Angular spec and confirm expected failures.
+- [x] Implement continuation active-job storage and kind-aware restore.
+- [x] Run focused Angular spec and confirm genesis plus continuation recovery pass.
+- [x] Update docs/changelog.
+- [x] Run final verification.
+- [ ] Commit, push, create PR, inspect checks/comments, address feedback, and merge if clean.
+
+## Verification Commands
+
+```bash
+git diff --check
+npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"
+npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"
+npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"
+npx tsx tests/story-lab-job-contracts.test.ts
+npx tsx tests/story-lab-job-routes.test.ts
+scripts/recovery/check-vercel-function-count.sh
+```

--- a/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
+++ b/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
@@ -73,6 +73,10 @@ The key product goal is not "more features." The key product goal is a story stu
   - [x] moved the Continue Saga UI from direct `continueStory` calls to `POST /api/story-lab/jobs` with `kind: 'continuation'`;
   - [x] wired continuation progress, completion, cancellation, and failed-provider handling to Story Lab job snapshots/events;
   - [x] moved mocked browser smoke continuation coverage to `/api/story-lab/jobs` and made the legacy direct continuation route fail in smoke mode.
+- [x] Continued Phase D browser-session continuation recovery on `feature/story-lab-continuation-resume`:
+  - [x] stored active continuation job markers while continuation snapshots are still running;
+  - [x] restored running continuation jobs after reload when a saved browser-local story is available;
+  - [x] applied completed recovered continuation jobs to the restored local story and cleared unusable markers.
 - [ ] Leave final handoff describing what remains and what requires external provisioning.
 
 ## Surprises & Discoveries
@@ -136,7 +140,7 @@ The key product goal is not "more features." The key product goal is a story stu
   - Future Story Lab job streaming now has an opaque `job_<uuid>` contract and path builder that keeps blueprint/story/private fields out of status and events URLs.
   - Story Lab job routes now create opaque jobs, replay queued/running/terminal snapshots, and label the in-process store as `non_durable_memory`.
 - What was intentionally deferred:
-  - Accounts, cloud storage, durable Workflow execution, owner-scoped job persistence, continuation reload-safe job resume UI, Blob export, email, and audio runtime.
+  - Accounts, cloud storage, durable Workflow execution, owner-scoped job persistence, cold-start-safe job resume, Blob export, email, and audio runtime.
 - What hostile review still objected to:
   - The genesis and continuation UI now use job snapshots/events, but the in-memory scaffold is still not real durable Workflow/database-backed progress.
   - The legacy direct Story Lab stream route still exists for compatibility; future work should retire it after job UI smoke coverage and reload-safe resume are in place.
@@ -652,6 +656,7 @@ Acceptance:
 - [x] UI can start a genesis job and complete/fail from job snapshots/events.
 - [x] UI can start a continuation job and complete/fail from job snapshots/events.
 - [x] UI can survive reload for active genesis jobs by polling job id inside the current browser session.
+- [x] UI can survive reload for active continuation jobs when the local saved story context is available.
 - [x] Mocked browser smoke sees queued -> running -> completed through the visible UI.
 
 ### Phase E: Account Sync

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -185,6 +185,18 @@ function storeActiveJobMarker(overrides: Partial<Record<string, unknown>> = {}) 
   sessionStorage.setItem(ACTIVE_JOB_STORAGE_KEY, JSON.stringify(createActiveJobMarker(overrides)));
 }
 
+function makePayloadForStory(storyId: string, title: string): Partial<StoryIterationPayload> {
+  return {
+    summary: createSummary({ storyId, title }),
+    state: createState({ storyId }),
+    batch: {
+      chapters: [createChapter({ chapterId: `${storyId}-chapter-1` })],
+      totalWordCount: 900,
+      suggestedNextPrompts: []
+    }
+  };
+}
+
 const confirmedHeatContract = {
   adultOnlyConfirmed: true,
   tensionMode: 'slow_burn' as const,
@@ -559,7 +571,8 @@ describe('App', () => {
       jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
       kind: 'continuation',
       batchSize: 1,
-      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000'
+      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000',
+      storyId: 'story-123'
     }));
     expect(marker.batchId).toMatch(/^batch-/);
   });
@@ -572,7 +585,8 @@ describe('App', () => {
       jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
       kind: 'continuation',
       batchId: 'batch-continuation-recovered',
-      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000'
+      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000',
+      storyId: genesisPayload.summary.storyId
     });
     storyService.getStoryLabJob.calls.reset();
     storyService.getStoryLabJob.and.returnValue(of({
@@ -607,7 +621,8 @@ describe('App', () => {
       jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
       kind: 'continuation',
       batchId: 'batch-continuation-recovered',
-      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000'
+      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000',
+      storyId: genesisPayload.summary.storyId
     });
     storyService.getStoryLabJob.calls.reset();
     storyService.getStoryLabJob.and.returnValue(of({
@@ -622,12 +637,40 @@ describe('App', () => {
     expect(sessionStorage.getItem(ACTIVE_JOB_STORAGE_KEY)).toBeNull();
   });
 
+  it('loads the continuation marker story instead of the newest saved project on recovery', () => {
+    const originalPayload = seedWorkbenchForContinuation(makePayloadForStory('story-original', 'Original Pact'));
+    component.saveActiveProject();
+    seedWorkbenchForContinuation(makePayloadForStory('story-newer', 'Newer Pact'));
+    component.saveActiveProject();
+    const continuationPayload = createContinuationPayload(originalPayload);
+    storeActiveJobMarker({
+      jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
+      kind: 'continuation',
+      batchId: 'batch-continuation-recovered',
+      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000',
+      storyId: 'story-original'
+    });
+    storyService.getStoryLabJob.calls.reset();
+    storyService.getStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(continuationPayload)
+    }));
+
+    const recovered = TestBed.createComponent(App).componentInstance;
+
+    expect(recovered.workbench().story?.storyId).toBe('story-original');
+    expect(recovered.workbench().chapterHistory.length).toBe(2);
+    expect(recovered.workbench().chapterHistory[0].chapterId).toBe('story-original-chapter-1');
+    expect(recovered.selectedChapter()?.chapterNumber).toBe(2);
+  });
+
   it('clears a continuation active job marker when no saved story context exists', () => {
     storeActiveJobMarker({
       jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
       kind: 'continuation',
       batchId: 'batch-continuation-recovered',
-      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000'
+      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000',
+      storyId: 'story-123'
     });
     storyService.getStoryLabJob.calls.reset();
 

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -539,6 +539,105 @@ describe('App', () => {
     expect(sessionStorage.getItem(ACTIVE_JOB_STORAGE_KEY)).toBeNull();
   });
 
+  it('stores an active continuation job marker while job snapshots are running', () => {
+    seedWorkbenchForContinuation();
+    const events$ = new Subject<StoryLabJobEvent<ContinuationJobResult>>();
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(undefined, {
+        status: 'running',
+        currentStep: 'continuing_story',
+        progressPercent: 28
+      })
+    }));
+    storyService.streamStoryLabJobEvents.and.returnValue(events$.asObservable());
+
+    component.continueSaga('Make the betrayal more dangerous.');
+
+    const marker = JSON.parse(sessionStorage.getItem(ACTIVE_JOB_STORAGE_KEY) ?? '{}');
+    expect(marker).toEqual(jasmine.objectContaining({
+      jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
+      kind: 'continuation',
+      batchSize: 1,
+      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000'
+    }));
+    expect(marker.batchId).toMatch(/^batch-/);
+  });
+
+  it('recovers a running continuation job from browser storage and resumes events', () => {
+    const genesisPayload = seedWorkbenchForContinuation();
+    component.saveActiveProject();
+    const events$ = new Subject<StoryLabJobEvent<ContinuationJobResult>>();
+    storeActiveJobMarker({
+      jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
+      kind: 'continuation',
+      batchId: 'batch-continuation-recovered',
+      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000'
+    });
+    storyService.getStoryLabJob.calls.reset();
+    storyService.getStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(undefined, {
+        status: 'running',
+        currentStep: 'continuing_story',
+        progressPercent: 44
+      })
+    }));
+    storyService.streamStoryLabJobEvents.and.returnValue(events$.asObservable());
+
+    const recovered = TestBed.createComponent(App).componentInstance;
+
+    expect(storyService.getStoryLabJob).toHaveBeenCalledWith('job_223e4567-e89b-12d3-a456-426614174000');
+    expect(storyService.streamStoryLabJobEvents).toHaveBeenCalledWith(
+      'job_223e4567-e89b-12d3-a456-426614174000',
+      jasmine.any(Function)
+    );
+    expect(recovered.workbench().story?.storyId).toBe(genesisPayload.summary.storyId);
+    expect(recovered.generationProgress().active).toBeTrue();
+    expect(recovered.generationProgress().percent).toBe(44);
+    expect(recovered.statusMessage()).toContain('Grok');
+    expect(recovered.activeBatchQueue().at(-1)?.label).toBe('Continuation');
+  });
+
+  it('recovers a completed continuation job and clears the active job marker', () => {
+    const genesisPayload = seedWorkbenchForContinuation();
+    const continuationPayload = createContinuationPayload(genesisPayload);
+    component.saveActiveProject();
+    storeActiveJobMarker({
+      jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
+      kind: 'continuation',
+      batchId: 'batch-continuation-recovered',
+      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000'
+    });
+    storyService.getStoryLabJob.calls.reset();
+    storyService.getStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(continuationPayload)
+    }));
+
+    const recovered = TestBed.createComponent(App).componentInstance;
+
+    expect(recovered.workbench().chapterHistory.length).toBe(2);
+    expect(recovered.selectedChapter()?.chapterNumber).toBe(2);
+    expect(sessionStorage.getItem(ACTIVE_JOB_STORAGE_KEY)).toBeNull();
+  });
+
+  it('clears a continuation active job marker when no saved story context exists', () => {
+    storeActiveJobMarker({
+      jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
+      kind: 'continuation',
+      batchId: 'batch-continuation-recovered',
+      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000'
+    });
+    storyService.getStoryLabJob.calls.reset();
+
+    const recovered = TestBed.createComponent(App).componentInstance;
+
+    expect(storyService.getStoryLabJob).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem(ACTIVE_JOB_STORAGE_KEY)).toBeNull();
+    expect(recovered.statusMessage()).toContain('saved story');
+  });
+
   it('clears malformed active job storage without crashing startup', () => {
     sessionStorage.setItem(ACTIVE_JOB_STORAGE_KEY, '{not-json');
 

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -88,6 +88,7 @@ type ActiveStoryLabJobState = {
   batchSize: ChapterBatchSize;
   statusPath: string;
   startedAt: string;
+  storyId?: string;
 };
 
 type ContinuationJobResult = StoryIterationPayload & { appendedChapterNumbers: number[] };
@@ -499,7 +500,8 @@ export class App implements OnDestroy {
             batchId,
             batchSize: request.chapterBatchSize,
             statusPath: response.data.paths.statusPath,
-            startedAt: response.data.job.createdAt
+            startedAt: response.data.job.createdAt,
+            storyId: request.storyId
           });
           this.openContinuationJobEventStream(response.data.job.jobId, batchId, request.chapterBatchSize);
         }
@@ -907,8 +909,15 @@ ${chapters}
   }
 
   private restoreActiveContinuationJob(activeJob: ActiveStoryLabJobState) {
+    if (activeJob.storyId && this.workbench().story?.storyId !== activeJob.storyId) {
+      const matchingProject = this.findSavedProjectByStoryId(activeJob.storyId);
+      if (matchingProject) {
+        this.hydrateSavedProject(matchingProject, false);
+      }
+    }
+
     const session = this.workbench();
-    if (!session.story || !session.state) {
+    if (!session.story || !session.state || session.story.storyId !== activeJob.storyId) {
       const message = 'That continuation job needs a saved story before it can be restored.';
       this.statusMessage.set(message);
       this.markBatchFailed(activeJob.batchId, message);
@@ -991,6 +1000,7 @@ ${chapters}
         && this.isChapterBatchSize(parsed.batchSize)
         && typeof parsed.statusPath === 'string'
         && typeof parsed.startedAt === 'string'
+        && (parsed.kind === 'genesis' || typeof parsed.storyId === 'string')
       ) {
         return {
           jobId: parsed.jobId,
@@ -998,7 +1008,8 @@ ${chapters}
           batchId: parsed.batchId,
           batchSize: parsed.batchSize,
           statusPath: parsed.statusPath,
-          startedAt: parsed.startedAt
+          startedAt: parsed.startedAt,
+          storyId: parsed.kind === 'continuation' ? parsed.storyId : undefined
         };
       }
     } catch {
@@ -1122,6 +1133,12 @@ ${chapters}
     if (shouldNotify) {
       this.notificationService.info('Story loaded', project.title);
     }
+  }
+
+  private findSavedProjectByStoryId(storyId: string): SavedStoryProject | null {
+    return this.workspaceStorage.loadProject(storyId)
+      ?? this.workspaceStorage.listProjects().find(project => project.storyId === storyId)
+      ?? null;
   }
 
   private restoreSkin() {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -83,7 +83,7 @@ type GenerationProgressState = {
 
 type ActiveStoryLabJobState = {
   jobId: string;
-  kind: 'genesis';
+  kind: 'genesis' | 'continuation';
   batchId: string;
   batchSize: ChapterBatchSize;
   statusPath: string;
@@ -493,6 +493,14 @@ export class App implements OnDestroy {
 
         const isTerminal = this.handleContinuationJobSnapshot(response.data.job, batchId, request.chapterBatchSize);
         if (!isTerminal) {
+          this.storeActiveStoryLabJob({
+            jobId: response.data.job.jobId,
+            kind: 'continuation',
+            batchId,
+            batchSize: request.chapterBatchSize,
+            statusPath: response.data.paths.statusPath,
+            startedAt: response.data.job.createdAt
+          });
           this.openContinuationJobEventStream(response.data.job.jobId, batchId, request.chapterBatchSize);
         }
       },
@@ -763,6 +771,7 @@ ${chapters}
         `Added ${job.result.batch.chapters.length} chapter${job.result.batch.chapters.length === 1 ? '' : 's'} to the saga.`
       );
       this.isGenerating.set(false);
+      this.clearActiveStoryLabJob();
       this.closeJobEventSubscription();
       this.stopProgress();
       return true;
@@ -833,6 +842,7 @@ ${chapters}
   }
 
   private failContinuationJob(batchId: string, message: string) {
+    this.clearActiveStoryLabJob();
     this.closeJobEventSubscription();
     this.statusMessage.set(message);
     this.markBatchFailed(batchId, message);
@@ -864,9 +874,16 @@ ${chapters}
     }
 
     this.isGenerating.set(true);
-    this.statusMessage.set('Restoring your story job...');
-    this.startProgress('genesis');
+    this.statusMessage.set(activeJob.kind === 'genesis'
+      ? 'Restoring your story job...'
+      : 'Restoring your continuation job...');
+    this.startProgress(activeJob.kind);
     this.ensureRecoveredBatch(activeJob);
+
+    if (activeJob.kind === 'continuation') {
+      this.restoreActiveContinuationJob(activeJob);
+      return;
+    }
 
     this.storyService.getStoryLabJob<StoryIterationPayload>(activeJob.jobId).subscribe({
       next: response => {
@@ -889,6 +906,40 @@ ${chapters}
     });
   }
 
+  private restoreActiveContinuationJob(activeJob: ActiveStoryLabJobState) {
+    const session = this.workbench();
+    if (!session.story || !session.state) {
+      const message = 'That continuation job needs a saved story before it can be restored.';
+      this.statusMessage.set(message);
+      this.markBatchFailed(activeJob.batchId, message);
+      this.notificationService.warning('Continuation not restored', message);
+      this.clearActiveStoryLabJob();
+      this.isGenerating.set(false);
+      this.stopProgress();
+      return;
+    }
+
+    this.storyService.getStoryLabJob<ContinuationJobResult>(activeJob.jobId).subscribe({
+      next: response => {
+        if (!response.success || !response.data) {
+          const message = this.formatApiError(response.error, 'That continuation job is no longer available.');
+          this.failContinuationJob(activeJob.batchId, message);
+          return;
+        }
+
+        const isTerminal = this.handleContinuationJobSnapshot(response.data.job, activeJob.batchId, activeJob.batchSize);
+        if (!isTerminal) {
+          this.openContinuationJobEventStream(activeJob.jobId, activeJob.batchId, activeJob.batchSize);
+        }
+      },
+      error: error => {
+        this.errorLogging.logError(error, 'App.restoreActiveContinuationJob');
+        const message = this.formatHttpError(error, 'That continuation job is no longer available.');
+        this.failContinuationJob(activeJob.batchId, message);
+      }
+    });
+  }
+
   private ensureRecoveredBatch(activeJob: ActiveStoryLabJobState) {
     if (this.activeBatchQueue().some(item => item.id === activeJob.batchId)) {
       return;
@@ -898,7 +949,7 @@ ${chapters}
       ...this.activeBatchQueue(),
       {
         id: activeJob.batchId,
-        label: 'Genesis',
+        label: activeJob.kind === 'genesis' ? 'Genesis' : 'Continuation',
         batchSize: activeJob.batchSize,
         status: 'in_progress',
         chaptersGenerated: 0,
@@ -935,7 +986,7 @@ ${chapters}
       const parsed = JSON.parse(rawJob) as Partial<ActiveStoryLabJobState>;
       if (
         typeof parsed.jobId === 'string'
-        && parsed.kind === 'genesis'
+        && (parsed.kind === 'genesis' || parsed.kind === 'continuation')
         && typeof parsed.batchId === 'string'
         && this.isChapterBatchSize(parsed.batchSize)
         && typeof parsed.statusPath === 'string'


### PR DESCRIPTION
## Summary
- Store active continuation job markers while continuation jobs are still running.
- Restore running and completed continuation jobs after browser reload when a saved local story context is available.
- Keep recovery honest: this is browser-session recovery over the existing non-durable job scaffold, not Workflow/database durability.

## Test Plan
- RED: `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"` failed with 4 expected continuation-resume failures before implementation.
- `git diff --check`
- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`
- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`
- `npx tsx tests/story-lab-job-contracts.test.ts`
- `npx tsx tests/story-lab-job-routes.test.ts`
- `scripts/recovery/check-vercel-function-count.sh` at `10/12`
- `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"` passed with `29 SUCCESS`

## Notes
- Continuation resume requires a saved browser-local story and state. If that local context is missing, the marker is cleared and the job API is not called.
- Vercel cold starts, cross-device resume, account-owned jobs, and Workflow/database durability remain future platform gates.
