### PR TITLE
Add Story Lab job status UI

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -4,6 +4,32 @@ Created: 2026-05-26 00:12 EDT
 
 This is the chronological work log for the PR #70 recovery. It should capture commands, decisions, self-review notes, validation results, and anything that changes the plan.
 
+## 2026-06-07 09:47 EDT - PR109 Review Follow-Up
+
+Problem:
+
+- SonarCloud failed the PR #109 quality gate with `7.3% Duplication on New Code`.
+- Gemini Code Assist flagged that a missing/null `job.progressPercent` could render `NaN%` in the new job status banner and the existing progress state.
+
+Fix:
+
+- Added a regression spec proving missing job progress falls back to `0%` instead of `NaN%`.
+- Added one `normalizeJobProgressPercent()` helper and used it for both the main progress bar and the new job status banner.
+- Reduced duplication by:
+  - extracting repeated continuation recovery marker setup in `app.spec.ts`;
+  - routing starting/running/recovered banner updates through one `setJobStatusPanel()` helper;
+  - centralizing banner label/title/description formatting.
+
+Validation:
+
+- RED: focused Angular app spec failed with the expected missing-progress regression: progress was `NaN` and the banner rendered `NaN%`.
+- GREEN: `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'"`: passed with `34 SUCCESS`.
+- `git diff --check`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`: passed.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
+- `npm run smoke:story-lab-ui`: passed in mock mode; Angular build reported the existing bundle budget warnings.
+
 ## 2026-06-07 09:37 EDT - Story Lab Job Status UI
 
 Actions:

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -4,6 +4,40 @@ Created: 2026-05-26 00:12 EDT
 
 This is the chronological work log for the PR #70 recovery. It should capture commands, decisions, self-review notes, validation results, and anything that changes the plan.
 
+## 2026-06-07 09:37 EDT - Story Lab Job Status UI
+
+Actions:
+
+- Created `feature/story-lab-job-status-ui` from current `main` after PR #108 merged.
+- Added `STORY_LAB_JOB_STATUS_UI_EXEC_PLAN.md` for the focused UI checklist.
+- Added a compact visible job status banner near the existing progress bar.
+- The banner now tells users when Story Lab is:
+  - starting a first-chapter job;
+  - running a first-chapter or continuation job;
+  - recovering a first-chapter or continuation job after browser reload.
+- The banner shows the current job stage, percent complete, and a shortened opaque job id without exposing story text, blueprint text, or long raw ids.
+- Added Angular DOM specs proving:
+  - running genesis jobs render the banner;
+  - recovered continuation jobs render the recovered banner after reload;
+  - unusable continuation recovery does not leave a stale banner behind.
+
+Validation:
+
+- RED: `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'"` failed with 2 expected banner failures because `[data-testid="job-status-panel"]` did not exist yet.
+- GREEN: the same focused Angular command passed with `33 SUCCESS` after the banner signal, template, and styles were added.
+- `git diff --check`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`: passed.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
+- `npm run smoke:story-lab-ui`: passed in mock mode; Angular build reported the existing budget warnings for the 517.26 kB initial browser bundle and 13.63 kB `app.css`.
+
+Self-review:
+
+- Good: Reload recovery is now visible to a normal user instead of only changing the progress bar/status line.
+- Good: The banner uses opaque job ids only, keeping private blueprint/story data out of UI paths and status text.
+- Remaining risk: This still does not make jobs cold-start safe; the underlying scaffold remains `non_durable_memory`.
+- Remaining risk: Browser-smoke coverage already checks job progress, but it does not yet assert the new banner copy specifically.
+
 ## 2026-06-07 08:58 EDT - Story Lab Continuation UI Job Migration
 
 Actions:

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -17,8 +17,9 @@ Fix:
 - Added one `normalizeJobProgressPercent()` helper and used it for both the main progress bar and the new job status banner.
 - Reduced duplication by:
   - extracting repeated continuation recovery marker setup in `app.spec.ts`;
+  - extracting repeated running continuation recovery job stubbing in `app.spec.ts`;
   - routing starting/running/recovered banner updates through one `setJobStatusPanel()` helper;
-  - centralizing banner label/title/description formatting.
+  - centralizing banner label/title/description formatting and flattening Sonar-flagged nested ternaries.
 
 Validation:
 

--- a/STORY_LAB_JOB_STATUS_UI_EXEC_PLAN.md
+++ b/STORY_LAB_JOB_STATUS_UI_EXEC_PLAN.md
@@ -1,0 +1,85 @@
+# Story Lab Job Status UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a compact visible Story Lab job status banner so generation, continuation, and reload recovery jobs are understandable while they run.
+
+**Architecture:** Keep the work in the Angular Story Lab component. Add a small signal-backed view model in `app.ts`, render it near the existing progress bar in `app.html`, and style it with the current Story Lab panel language in `app.css`.
+
+**Tech Stack:** Angular signals, Angular template bindings, Jasmine/Karma component specs, existing StoryService job APIs.
+
+---
+
+### Task 1: Failing UI Specs
+
+**Files:**
+- Modify: `story-generator/src/app/app.spec.ts`
+
+- [x] Add `ComponentFixture<App>` to the Angular testing imports and keep the fixture from `TestBed.createComponent(App)` in `beforeEach`.
+- [x] Add a helper that reads `[data-testid="job-status-panel"]` from the rendered fixture.
+- [x] Add a failing spec proving a running genesis job renders a visible job banner with the job label, progress percent, and short job id.
+- [x] Add a failing spec proving a recovered continuation job renders a visible recovered banner after reload.
+- [x] Add a failing spec proving the banner is hidden when a recovered continuation job cannot be restored because the saved story context is missing.
+- [x] Run:
+
+```bash
+npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'"
+```
+
+Result: failed with 2 expected banner failures because `[data-testid="job-status-panel"]` did not exist yet.
+
+### Task 2: Job Status View Model
+
+**Files:**
+- Modify: `story-generator/src/app/app.ts`
+
+- [x] Add a `JobStatusPanelState` type.
+- [x] Add a `jobStatusPanel` signal initialized to hidden.
+- [x] Add helpers to show starting, running, and recovering job state.
+- [x] Update genesis and continuation job creation to show the starting/running banner.
+- [x] Update reload recovery to show the recovered banner before reading the job snapshot.
+- [x] Clear the banner when a job completes, fails, is cancelled, or recovery is abandoned.
+- [x] Run the focused app spec command and confirm the new tests pass.
+
+### Task 3: Template And Styling
+
+**Files:**
+- Modify: `story-generator/src/app/app.html`
+- Modify: `story-generator/src/app/app.css`
+
+- [x] Render a `job-status-panel` section next to the existing progress UI when `jobStatusPanel().visible` is true.
+- [x] Include label, title, stage, progress percent, and job id without exposing long unwieldy IDs.
+- [x] Style the banner as a compact operational status block using existing Story Lab colors, 8px radius, responsive wrapping, and no nested cards.
+- [x] Run the focused app spec command again.
+
+### Task 4: Documentation And Verification
+
+**Files:**
+- Modify: `PR70_RECOVERY_CHANGELOG.md`
+- Modify: `STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md`
+
+- [x] Add a changelog note summarizing the job status banner and recovery UX.
+- [x] Update the platform plan acceptance checklist to include visible job/recovery status.
+- [x] Run:
+
+```bash
+git diff --check
+npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"
+npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"
+npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'"
+scripts/recovery/check-vercel-function-count.sh
+npm run smoke:story-lab-ui
+```
+
+Result: all commands passed; function count stayed at `10/12`. The smoke build reported the existing Angular budget warnings.
+
+### Task 5: PR
+
+**Files:**
+- All modified files above
+
+- [ ] Commit with `--no-verify` only after the verification commands pass, because local hooks still point at the stale removed path.
+- [ ] Push the branch and open a PR.
+- [ ] Inspect automated comments and checks.
+- [ ] Address actionable review feedback with follow-up commits.
+- [ ] Merge only after required checks are green and actionable review comments are handled.

--- a/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
+++ b/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
@@ -159,7 +159,7 @@ The key product goal is not "more features." The key product goal is a story stu
   - Route-budget consolidation focused checks passed: `git diff --check`, `scripts/recovery/check-vercel-function-count.sh` at `9/12`, `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`, and `scripts/recovery/preflight.sh --quick --skip-status`.
   - Phase D backend job-route focused checks passed: `git diff --check`, `npx tsx tests/story-lab-job-contracts.test.ts`, `npx tsx tests/story-lab-job-routes.test.ts`, `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`, `scripts/recovery/check-vercel-function-count.sh` at `10/12`, and `scripts/recovery/preflight.sh --quick --skip-status`.
   - Phase D genesis UI job migration focused checks passed: `git diff --check`, app/spec TypeScript compiles, targeted Angular `app.spec.ts` Karma run, `npx tsx tests/story-lab-job-contracts.test.ts`, `npx tsx tests/story-lab-job-routes.test.ts`, and `scripts/recovery/check-vercel-function-count.sh` at `10/12`.
-  - Phase D job status UI focused checks passed: RED targeted Angular app spec failed on missing rendered banner, then GREEN targeted Angular app spec passed with `33 SUCCESS`.
+  - Phase D job status UI focused checks passed: RED targeted Angular app spec failed on missing rendered banner, PR follow-up RED failed on missing progress rendering `NaN%`, then GREEN targeted Angular app spec passed with `34 SUCCESS`.
 
 ## Context and Orientation
 

--- a/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
+++ b/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
@@ -77,6 +77,10 @@ The key product goal is not "more features." The key product goal is a story stu
   - [x] stored active continuation job markers while continuation snapshots are still running;
   - [x] restored running continuation jobs after reload when a saved browser-local story is available;
   - [x] applied completed recovered continuation jobs to the restored local story and cleared unusable markers.
+- [x] Continued Phase D visible job status polish on `feature/story-lab-job-status-ui`:
+  - [x] added a compact job status banner for starting, running, and recovered Story Lab jobs;
+  - [x] showed current stage, percent complete, and shortened opaque job id without exposing story or blueprint text;
+  - [x] hid the banner when continuation recovery cannot safely reconnect to a saved browser-local story.
 - [ ] Leave final handoff describing what remains and what requires external provisioning.
 
 ## Surprises & Discoveries
@@ -128,6 +132,7 @@ The key product goal is not "more features." The key product goal is a story stu
   - New Charmed creatures now have dedicated creative style banks instead of borrowing from older creature voices.
   - Heat Contract v0 gives users visible adult-only/spice-boundary controls and carries those boundaries into generation.
   - The generated-story reader shows the active Heat Contract summary beside the story metadata.
+  - Story Lab now shows a visible job banner when generation/continuation starts, runs, or is recovered after reload.
 - What became better technically:
   - Story Lab stream parsing accepts the same expanded creature set as the Charmed UI.
   - Heat Contract data is typed in frontend contracts, mapped through the Story Lab engine, and preserved in the classic generation context.
@@ -139,11 +144,12 @@ The key product goal is not "more features." The key product goal is a story stu
   - Server export now sanitizes story HTML through a tiny allow-list, strips dangerous containers, escapes title/metadata/PDF strings, and avoids logging raw export errors.
   - Future Story Lab job streaming now has an opaque `job_<uuid>` contract and path builder that keeps blueprint/story/private fields out of status and events URLs.
   - Story Lab job routes now create opaque jobs, replay queued/running/terminal snapshots, and label the in-process store as `non_durable_memory`.
+  - The Angular UI now has signal-backed job status state that mirrors job lifecycle and recovery without adding routes or backend contracts.
 - What was intentionally deferred:
   - Accounts, cloud storage, durable Workflow execution, owner-scoped job persistence, cold-start-safe job resume, Blob export, email, and audio runtime.
 - What hostile review still objected to:
   - The genesis and continuation UI now use job snapshots/events, but the in-memory scaffold is still not real durable Workflow/database-backed progress.
-  - The legacy direct Story Lab stream route still exists for compatibility; future work should retire it after job UI smoke coverage and reload-safe resume are in place.
+  - The legacy direct Story Lab stream route still exists for compatibility; future work should retire or hard-deprecate it in a separate compatibility slice.
   - Existing `/api/export/save` is safer for mock server export, but it is still not a durable Blob/email export path.
   - Full Angular build and Karma browser spec validation must be rerun under a stable local/CI environment because Node v23 Angular build/Karma runners hung here.
 - What validation proved:
@@ -153,6 +159,7 @@ The key product goal is not "more features." The key product goal is a story stu
   - Route-budget consolidation focused checks passed: `git diff --check`, `scripts/recovery/check-vercel-function-count.sh` at `9/12`, `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`, and `scripts/recovery/preflight.sh --quick --skip-status`.
   - Phase D backend job-route focused checks passed: `git diff --check`, `npx tsx tests/story-lab-job-contracts.test.ts`, `npx tsx tests/story-lab-job-routes.test.ts`, `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`, `scripts/recovery/check-vercel-function-count.sh` at `10/12`, and `scripts/recovery/preflight.sh --quick --skip-status`.
   - Phase D genesis UI job migration focused checks passed: `git diff --check`, app/spec TypeScript compiles, targeted Angular `app.spec.ts` Karma run, `npx tsx tests/story-lab-job-contracts.test.ts`, `npx tsx tests/story-lab-job-routes.test.ts`, and `scripts/recovery/check-vercel-function-count.sh` at `10/12`.
+  - Phase D job status UI focused checks passed: RED targeted Angular app spec failed on missing rendered banner, then GREEN targeted Angular app spec passed with `33 SUCCESS`.
 
 ## Context and Orientation
 
@@ -621,6 +628,7 @@ Files:
 - [x] Modified `story-generator/src/app/story.service.ts`.
 - [x] Modified `story-generator/src/app/app.ts` to use job routes for genesis visible progress.
 - [x] Modified `story-generator/src/app/app.ts` to use job routes for continuation visible progress.
+- [x] Modified `story-generator/src/app/app.ts`, `story-generator/src/app/app.html`, and `story-generator/src/app/app.css` for a visible job status/recovery banner.
 - [x] Modified `story-generator/src/app/app.spec.ts` for genesis job creation, event progress, completion, and failed-job handling.
 - [x] Modified `story-generator/src/app/app.spec.ts` for continuation job creation, event progress, completion, and failed-job handling.
 - [x] Reused `story-generator/src/app/app.html` existing progress panel for reload-safe job progress.
@@ -657,6 +665,7 @@ Acceptance:
 - [x] UI can start a continuation job and complete/fail from job snapshots/events.
 - [x] UI can survive reload for active genesis jobs by polling job id inside the current browser session.
 - [x] UI can survive reload for active continuation jobs when the local saved story context is available.
+- [x] UI shows a compact job status/recovery banner with current stage, percent complete, and shortened opaque job id.
 - [x] Mocked browser smoke sees queued -> running -> completed through the visible UI.
 
 ### Phase E: Account Sync

--- a/story-generator/src/app/app.css
+++ b/story-generator/src/app/app.css
@@ -276,6 +276,7 @@
 .choice-block,
 .story-details,
 .generation-progress,
+.job-status-panel,
 .continue-panel,
 .chapter-timeline,
 .continuity-soft,
@@ -578,6 +579,59 @@ button:disabled {
   background: linear-gradient(90deg, var(--accent-2), var(--accent-3), var(--accent));
 }
 
+.job-status-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--accent) 36%, var(--line) 64%);
+  padding: 12px;
+  background: color-mix(in srgb, var(--paper-strong) 82%, var(--accent) 18%);
+}
+
+.job-status-panel--recovering {
+  border-color: color-mix(in srgb, var(--accent-2) 44%, var(--line) 56%);
+  background: color-mix(in srgb, var(--paper-strong) 80%, var(--accent-2) 20%);
+}
+
+.job-status-panel__header,
+.job-status-panel__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.job-status-panel__header h3 {
+  margin: 2px 0 0;
+  color: var(--ink);
+  font-size: 1rem;
+  line-height: 1.25;
+  letter-spacing: 0;
+}
+
+.job-status-panel__header strong {
+  flex: 0 0 auto;
+  min-width: 52px;
+  text-align: right;
+  color: var(--accent);
+  font-size: 1.05rem;
+}
+
+.job-status-panel p {
+  margin: 0;
+  color: var(--ink);
+  font-size: 0.88rem;
+  line-height: 1.4;
+}
+
+.job-status-panel__meta {
+  flex-wrap: wrap;
+  color: var(--muted);
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
 .reader-panel {
   min-height: 680px;
 }
@@ -852,8 +906,17 @@ button:disabled {
 
   .story-header,
   .chapter-view header,
-  .progress-copy {
+  .progress-copy,
+  .job-status-panel__header {
     flex-direction: column;
+  }
+
+  .job-status-panel__header {
+    align-items: flex-start;
+  }
+
+  .job-status-panel__header strong {
+    text-align: left;
   }
 
   .story-actions {

--- a/story-generator/src/app/app.html
+++ b/story-generator/src/app/app.html
@@ -339,6 +339,27 @@
           <span [style.width.%]="generationProgress().percent"></span>
         </div>
       </section>
+
+      <section
+        class="job-status-panel"
+        [class.job-status-panel--recovering]="jobStatusPanel().tone === 'recovering'"
+        data-testid="job-status-panel"
+        *ngIf="jobStatusPanel().visible"
+        aria-live="polite"
+      >
+        <div class="job-status-panel__header">
+          <div>
+            <p class="eyebrow">{{ jobStatusPanel().label }}</p>
+            <h3>{{ jobStatusPanel().title }}</h3>
+          </div>
+          <strong>{{ jobStatusPanel().progressPercent }}%</strong>
+        </div>
+        <p>{{ jobStatusPanel().description }}</p>
+        <div class="job-status-panel__meta">
+          <span>{{ jobStatusPanel().stage }}</span>
+          <span *ngIf="jobStatusPanel().jobId">Job {{ jobStatusPanel().jobId }}</span>
+        </div>
+      </section>
     </section>
 
     <section class="reader-panel" data-testid="story-panel" *ngIf="workbench().story as story; else emptyReader">

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -181,19 +181,39 @@ function createActiveJobMarker(overrides: Partial<Record<string, unknown>> = {})
   };
 }
 
-  function storeActiveJobMarker(overrides: Partial<Record<string, unknown>> = {}) {
-    sessionStorage.setItem(ACTIVE_JOB_STORAGE_KEY, JSON.stringify(createActiveJobMarker(overrides)));
-  }
+function storeActiveJobMarker(overrides: Partial<Record<string, unknown>> = {}) {
+  sessionStorage.setItem(ACTIVE_JOB_STORAGE_KEY, JSON.stringify(createActiveJobMarker(overrides)));
+}
 
-  function storeContinuationRecoveryMarker(storyId = 'story-123') {
-    storeActiveJobMarker({
-      jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
-      kind: 'continuation',
-      batchId: 'batch-continuation-recovered',
-      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000',
-      storyId
-    });
-  }
+function storeContinuationRecoveryMarker(storyId = 'story-123') {
+  storeActiveJobMarker({
+    jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
+    kind: 'continuation',
+    batchId: 'batch-continuation-recovered',
+    statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000',
+    storyId
+  });
+}
+
+function stubRunningContinuationRecovery(
+  storyService: jasmine.SpyObj<StoryService>,
+  storyId: string,
+  progressPercent = 44
+) {
+  const events$ = new Subject<StoryLabJobEvent<ContinuationJobResult>>();
+  storeContinuationRecoveryMarker(storyId);
+  storyService.getStoryLabJob.calls.reset();
+  storyService.getStoryLabJob.and.returnValue(of({
+    success: true,
+    data: createContinuationJobResponse(undefined, {
+      status: 'running',
+      currentStep: 'continuing_story',
+      progressPercent
+    })
+  }));
+  storyService.streamStoryLabJobEvents.and.returnValue(events$.asObservable());
+  return events$;
+}
 
 function makePayloadForStory(storyId: string, title: string): Partial<StoryIterationPayload> {
   return {
@@ -322,6 +342,13 @@ describe('App', () => {
     });
 
     return payload;
+  }
+
+  function prepareRunningContinuationRecovery(): StoryIterationPayload {
+    const genesisPayload = seedWorkbenchForContinuation();
+    component.saveActiveProject();
+    stubRunningContinuationRecovery(storyService, genesisPayload.summary.storyId);
+    return genesisPayload;
   }
 
   function renderedJobStatusText(targetFixture: ComponentFixture<App> = fixture): string | null {
@@ -627,20 +654,7 @@ describe('App', () => {
   });
 
   it('recovers a running continuation job from browser storage and resumes events', () => {
-    const genesisPayload = seedWorkbenchForContinuation();
-    component.saveActiveProject();
-    const events$ = new Subject<StoryLabJobEvent<ContinuationJobResult>>();
-    storeContinuationRecoveryMarker(genesisPayload.summary.storyId);
-    storyService.getStoryLabJob.calls.reset();
-    storyService.getStoryLabJob.and.returnValue(of({
-      success: true,
-      data: createContinuationJobResponse(undefined, {
-        status: 'running',
-        currentStep: 'continuing_story',
-        progressPercent: 44
-      })
-    }));
-    storyService.streamStoryLabJobEvents.and.returnValue(events$.asObservable());
+    const genesisPayload = prepareRunningContinuationRecovery();
 
     const recovered = TestBed.createComponent(App).componentInstance;
 
@@ -657,20 +671,7 @@ describe('App', () => {
   });
 
   it('renders a recovered continuation job status panel after reload', () => {
-    const genesisPayload = seedWorkbenchForContinuation();
-    component.saveActiveProject();
-    const events$ = new Subject<StoryLabJobEvent<ContinuationJobResult>>();
-    storeContinuationRecoveryMarker(genesisPayload.summary.storyId);
-    storyService.getStoryLabJob.calls.reset();
-    storyService.getStoryLabJob.and.returnValue(of({
-      success: true,
-      data: createContinuationJobResponse(undefined, {
-        status: 'running',
-        currentStep: 'continuing_story',
-        progressPercent: 44
-      })
-    }));
-    storyService.streamStoryLabJobEvents.and.returnValue(events$.asObservable());
+    prepareRunningContinuationRecovery();
 
     const recoveredFixture = TestBed.createComponent(App);
 

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ActivatedRoute, convertToParamMap, ParamMap } from '@angular/router';
 import { BehaviorSubject, of, Subject } from 'rxjs';
@@ -205,6 +205,7 @@ const confirmedHeatContract = {
 };
 
 describe('App', () => {
+  let fixture: ComponentFixture<App>;
   let component: App;
   let storyService: jasmine.SpyObj<StoryService>;
   let queryParamMap$: BehaviorSubject<ParamMap>;
@@ -237,7 +238,8 @@ describe('App', () => {
       ]
     }).compileComponents();
 
-    component = TestBed.createComponent(App).componentInstance;
+    fixture = TestBed.createComponent(App);
+    component = fixture.componentInstance;
     storyService = TestBed.inject(StoryService) as jasmine.SpyObj<StoryService>;
   });
 
@@ -310,6 +312,12 @@ describe('App', () => {
     });
 
     return payload;
+  }
+
+  function renderedJobStatusText(targetFixture: ComponentFixture<App> = fixture): string | null {
+    targetFixture.detectChanges();
+    const panel = targetFixture.nativeElement.querySelector('[data-testid="job-status-panel"]') as HTMLElement | null;
+    return panel?.textContent?.replace(/\s+/g, ' ').trim() ?? null;
   }
 
   it('creates the workbench with default blueprint values', () => {
@@ -448,6 +456,18 @@ describe('App', () => {
     expect(component.generationProgress().percent).toBe(47);
     expect(component.generationProgress().stage).toContain('Grok');
     expect(component.statusMessage()).toContain('Grok');
+  });
+
+  it('renders the active genesis job status panel while a story job is running', () => {
+    const events$ = new Subject<StoryLabJobEvent<StoryIterationPayload>>();
+
+    startGenesisJobFlow('A siren archivist bargains with a moonlit duke.', events$);
+
+    const statusText = renderedJobStatusText();
+    expect(statusText).toContain('First chapter job running');
+    expect(statusText).toContain('32%');
+    expect(statusText).toContain('job_123e...4000');
+    expect(statusText).toContain('Grok is writing your first chapter.');
   });
 
   it('shows a friendly AI configuration error when a genesis job cannot use Grok', () => {
@@ -613,6 +633,37 @@ describe('App', () => {
     expect(recovered.activeBatchQueue().at(-1)?.label).toBe('Continuation');
   });
 
+  it('renders a recovered continuation job status panel after reload', () => {
+    const genesisPayload = seedWorkbenchForContinuation();
+    component.saveActiveProject();
+    const events$ = new Subject<StoryLabJobEvent<ContinuationJobResult>>();
+    storeActiveJobMarker({
+      jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
+      kind: 'continuation',
+      batchId: 'batch-continuation-recovered',
+      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000',
+      storyId: genesisPayload.summary.storyId
+    });
+    storyService.getStoryLabJob.calls.reset();
+    storyService.getStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(undefined, {
+        status: 'running',
+        currentStep: 'continuing_story',
+        progressPercent: 44
+      })
+    }));
+    storyService.streamStoryLabJobEvents.and.returnValue(events$.asObservable());
+
+    const recoveredFixture = TestBed.createComponent(App);
+
+    const statusText = renderedJobStatusText(recoveredFixture);
+    expect(statusText).toContain('Continuation job recovered');
+    expect(statusText).toContain('44%');
+    expect(statusText).toContain('job_223e...4000');
+    expect(statusText).toContain('Grok is continuing the saga.');
+  });
+
   it('recovers a completed continuation job and clears the active job marker', () => {
     const genesisPayload = seedWorkbenchForContinuation();
     const continuationPayload = createContinuationPayload(genesisPayload);
@@ -679,6 +730,22 @@ describe('App', () => {
     expect(storyService.getStoryLabJob).not.toHaveBeenCalled();
     expect(sessionStorage.getItem(ACTIVE_JOB_STORAGE_KEY)).toBeNull();
     expect(recovered.statusMessage()).toContain('saved story');
+  });
+
+  it('does not render a job status panel when continuation recovery lacks saved story context', () => {
+    storeActiveJobMarker({
+      jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
+      kind: 'continuation',
+      batchId: 'batch-continuation-recovered',
+      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000',
+      storyId: 'story-123'
+    });
+    storyService.getStoryLabJob.calls.reset();
+
+    const recoveredFixture = TestBed.createComponent(App);
+
+    expect(renderedJobStatusText(recoveredFixture)).toBeNull();
+    expect(storyService.getStoryLabJob).not.toHaveBeenCalled();
   });
 
   it('clears malformed active job storage without crashing startup', () => {

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -181,9 +181,19 @@ function createActiveJobMarker(overrides: Partial<Record<string, unknown>> = {})
   };
 }
 
-function storeActiveJobMarker(overrides: Partial<Record<string, unknown>> = {}) {
-  sessionStorage.setItem(ACTIVE_JOB_STORAGE_KEY, JSON.stringify(createActiveJobMarker(overrides)));
-}
+  function storeActiveJobMarker(overrides: Partial<Record<string, unknown>> = {}) {
+    sessionStorage.setItem(ACTIVE_JOB_STORAGE_KEY, JSON.stringify(createActiveJobMarker(overrides)));
+  }
+
+  function storeContinuationRecoveryMarker(storyId = 'story-123') {
+    storeActiveJobMarker({
+      jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
+      kind: 'continuation',
+      batchId: 'batch-continuation-recovered',
+      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000',
+      storyId
+    });
+  }
 
 function makePayloadForStory(storyId: string, title: string): Partial<StoryIterationPayload> {
   return {
@@ -470,6 +480,25 @@ describe('App', () => {
     expect(statusText).toContain('Grok is writing your first chapter.');
   });
 
+  it('defaults missing job progress to zero instead of rendering NaN', () => {
+    const events$ = new Subject<StoryLabJobEvent<StoryIterationPayload>>();
+    const response = createGenesisJobResponse(undefined, {
+      status: 'running',
+      currentStep: 'generating_story'
+    });
+    delete (response.job as Partial<typeof response.job>).progressPercent;
+    storyService.createStoryLabJob.and.returnValue(of({ success: true, data: response }));
+    storyService.streamStoryLabJobEvents.and.returnValue(events$.asObservable());
+    configureValidBlueprint('A moonlit archivist bargains with a dangerous fae prince.');
+
+    component.startGenesis();
+
+    const statusText = renderedJobStatusText();
+    expect(component.generationProgress().percent).toBe(0);
+    expect(statusText).toContain('0%');
+    expect(statusText).not.toContain('NaN%');
+  });
+
   it('shows a friendly AI configuration error when a genesis job cannot use Grok', () => {
     const events$ = new Subject<StoryLabJobEvent<StoryIterationPayload>>();
 
@@ -601,13 +630,7 @@ describe('App', () => {
     const genesisPayload = seedWorkbenchForContinuation();
     component.saveActiveProject();
     const events$ = new Subject<StoryLabJobEvent<ContinuationJobResult>>();
-    storeActiveJobMarker({
-      jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
-      kind: 'continuation',
-      batchId: 'batch-continuation-recovered',
-      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000',
-      storyId: genesisPayload.summary.storyId
-    });
+    storeContinuationRecoveryMarker(genesisPayload.summary.storyId);
     storyService.getStoryLabJob.calls.reset();
     storyService.getStoryLabJob.and.returnValue(of({
       success: true,
@@ -637,13 +660,7 @@ describe('App', () => {
     const genesisPayload = seedWorkbenchForContinuation();
     component.saveActiveProject();
     const events$ = new Subject<StoryLabJobEvent<ContinuationJobResult>>();
-    storeActiveJobMarker({
-      jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
-      kind: 'continuation',
-      batchId: 'batch-continuation-recovered',
-      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000',
-      storyId: genesisPayload.summary.storyId
-    });
+    storeContinuationRecoveryMarker(genesisPayload.summary.storyId);
     storyService.getStoryLabJob.calls.reset();
     storyService.getStoryLabJob.and.returnValue(of({
       success: true,
@@ -668,13 +685,7 @@ describe('App', () => {
     const genesisPayload = seedWorkbenchForContinuation();
     const continuationPayload = createContinuationPayload(genesisPayload);
     component.saveActiveProject();
-    storeActiveJobMarker({
-      jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
-      kind: 'continuation',
-      batchId: 'batch-continuation-recovered',
-      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000',
-      storyId: genesisPayload.summary.storyId
-    });
+    storeContinuationRecoveryMarker(genesisPayload.summary.storyId);
     storyService.getStoryLabJob.calls.reset();
     storyService.getStoryLabJob.and.returnValue(of({
       success: true,
@@ -694,13 +705,7 @@ describe('App', () => {
     seedWorkbenchForContinuation(makePayloadForStory('story-newer', 'Newer Pact'));
     component.saveActiveProject();
     const continuationPayload = createContinuationPayload(originalPayload);
-    storeActiveJobMarker({
-      jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
-      kind: 'continuation',
-      batchId: 'batch-continuation-recovered',
-      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000',
-      storyId: 'story-original'
-    });
+    storeContinuationRecoveryMarker('story-original');
     storyService.getStoryLabJob.calls.reset();
     storyService.getStoryLabJob.and.returnValue(of({
       success: true,
@@ -716,13 +721,7 @@ describe('App', () => {
   });
 
   it('clears a continuation active job marker when no saved story context exists', () => {
-    storeActiveJobMarker({
-      jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
-      kind: 'continuation',
-      batchId: 'batch-continuation-recovered',
-      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000',
-      storyId: 'story-123'
-    });
+    storeContinuationRecoveryMarker();
     storyService.getStoryLabJob.calls.reset();
 
     const recovered = TestBed.createComponent(App).componentInstance;
@@ -733,13 +732,7 @@ describe('App', () => {
   });
 
   it('does not render a job status panel when continuation recovery lacks saved story context', () => {
-    storeActiveJobMarker({
-      jobId: 'job_223e4567-e89b-12d3-a456-426614174000',
-      kind: 'continuation',
-      batchId: 'batch-continuation-recovered',
-      statusPath: '/api/story-lab/jobs/job_223e4567-e89b-12d3-a456-426614174000',
-      storyId: 'story-123'
-    });
+    storeContinuationRecoveryMarker();
     storyService.getStoryLabJob.calls.reset();
 
     const recoveredFixture = TestBed.createComponent(App);

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -91,6 +91,20 @@ type ActiveStoryLabJobState = {
   storyId?: string;
 };
 
+type JobStatusPanelState = {
+  visible: boolean;
+  kind: ActiveStoryLabJobState['kind'];
+  tone: 'starting' | 'running' | 'recovering';
+  label: string;
+  title: string;
+  description: string;
+  progressPercent: number;
+  stage: string;
+  jobId?: string;
+  statusPath?: string;
+  startedAt?: string;
+};
+
 type ContinuationJobResult = StoryIterationPayload & { appendedChapterNumbers: number[] };
 
 @Component({
@@ -223,6 +237,7 @@ export class App implements OnDestroy {
     stage: 'Waiting for your story idea',
     elapsedSeconds: 0
   });
+  readonly jobStatusPanel = signal<JobStatusPanelState>(this.createHiddenJobStatusPanel());
   readonly showDebugPanel = toSignal(
     this.route.queryParamMap.pipe(map(params => params.get('debug') === '1')),
     { initialValue: false }
@@ -411,6 +426,7 @@ export class App implements OnDestroy {
     this.isGenerating.set(true);
     this.statusMessage.set('Sending your story ingredients to Grok...');
     this.startProgress('genesis');
+    this.showStartingJobStatus('genesis');
     this.setBatchQueue([]);
     this.closeJobSubscriptions();
     const batchId = this.enqueueBatch('Genesis', blueprint.chapterBatchSize);
@@ -468,6 +484,7 @@ export class App implements OnDestroy {
     this.isGenerating.set(true);
     this.statusMessage.set('Asking Grok to continue the next chapter...');
     this.startProgress('continuation');
+    this.showStartingJobStatus('continuation');
     this.closeJobSubscriptions();
     const batchId = this.enqueueBatch('Continuation', this.blueprint().chapterBatchSize);
 
@@ -697,6 +714,7 @@ ${chapters}
     batchSize: ChapterBatchSize
   ): boolean {
     this.updateProgressFromJob(job);
+    this.updateJobStatusFromJob(job);
 
     if (job.status === 'completed') {
       if (!job.result) {
@@ -712,6 +730,7 @@ ${chapters}
       );
       this.isGenerating.set(false);
       this.clearActiveStoryLabJob();
+      this.clearJobStatusPanel();
       this.closeJobEventSubscription();
       this.stopProgress();
       return true;
@@ -759,6 +778,7 @@ ${chapters}
     batchSize: ChapterBatchSize
   ): boolean {
     this.updateProgressFromJob(job);
+    this.updateJobStatusFromJob(job);
 
     if (job.status === 'completed') {
       if (!this.hasRenderableIterationPayload(job.result)) {
@@ -774,6 +794,7 @@ ${chapters}
       );
       this.isGenerating.set(false);
       this.clearActiveStoryLabJob();
+      this.clearJobStatusPanel();
       this.closeJobEventSubscription();
       this.stopProgress();
       return true;
@@ -831,6 +852,7 @@ ${chapters}
 
   private failGenesisJob(batchId: string, message: string) {
     this.clearActiveStoryLabJob();
+    this.clearJobStatusPanel();
     this.closeJobEventSubscription();
     this.statusMessage.set(message);
     this.markBatchFailed(batchId, message);
@@ -845,6 +867,7 @@ ${chapters}
 
   private failContinuationJob(batchId: string, message: string) {
     this.clearActiveStoryLabJob();
+    this.clearJobStatusPanel();
     this.closeJobEventSubscription();
     this.statusMessage.set(message);
     this.markBatchFailed(batchId, message);
@@ -881,6 +904,7 @@ ${chapters}
       : 'Restoring your continuation job...');
     this.startProgress(activeJob.kind);
     this.ensureRecoveredBatch(activeJob);
+    this.showRecoveringJobStatus(activeJob);
 
     if (activeJob.kind === 'continuation') {
       this.restoreActiveContinuationJob(activeJob);
@@ -923,6 +947,7 @@ ${chapters}
       this.markBatchFailed(activeJob.batchId, message);
       this.notificationService.warning('Continuation not restored', message);
       this.clearActiveStoryLabJob();
+      this.clearJobStatusPanel();
       this.isGenerating.set(false);
       this.stopProgress();
       return;
@@ -1060,6 +1085,113 @@ ${chapters}
       default:
         return this.humanizeIdentifier(currentStep);
     }
+  }
+
+  private createHiddenJobStatusPanel(): JobStatusPanelState {
+    return {
+      visible: false,
+      kind: 'genesis',
+      tone: 'starting',
+      label: '',
+      title: '',
+      description: '',
+      progressPercent: 0,
+      stage: ''
+    };
+  }
+
+  private showStartingJobStatus(kind: ActiveStoryLabJobState['kind']) {
+    this.jobStatusPanel.set({
+      visible: true,
+      kind,
+      tone: 'starting',
+      label: kind === 'genesis' ? 'Story generation' : 'Story continuation',
+      title: kind === 'genesis' ? 'First chapter job starting' : 'Continuation job starting',
+      description: kind === 'genesis'
+        ? 'Story Lab is creating a background job for the opening batch.'
+        : 'Story Lab is creating a background job for the next batch.',
+      progressPercent: 8,
+      stage: this.generationProgress().stage,
+      startedAt: new Date().toISOString()
+    });
+  }
+
+  private showRecoveringJobStatus(activeJob: ActiveStoryLabJobState) {
+    this.jobStatusPanel.set({
+      visible: true,
+      kind: activeJob.kind,
+      tone: 'recovering',
+      label: 'Recovered job',
+      title: activeJob.kind === 'genesis' ? 'First chapter job recovered' : 'Continuation job recovered',
+      description: activeJob.kind === 'genesis'
+        ? 'Resumed from this browser. Story Lab is reconnecting to the first chapter job.'
+        : 'Resumed from this browser. Story Lab found the saved story and reconnected to the continuation job.',
+      progressPercent: this.generationProgress().percent || 8,
+      stage: this.generationProgress().stage,
+      jobId: this.formatShortJobId(activeJob.jobId),
+      statusPath: activeJob.statusPath,
+      startedAt: activeJob.startedAt
+    });
+  }
+
+  private updateJobStatusFromJob(job: StoryLabJob<unknown>) {
+    const kind: ActiveStoryLabJobState['kind'] = job.kind === 'continuation' ? 'continuation' : 'genesis';
+    const current = this.jobStatusPanel();
+    const tone = current.visible && current.tone === 'recovering' ? 'recovering' : 'running';
+    const stage = this.formatJobStage(job.currentStep, job.status);
+    const progressPercent = Math.max(0, Math.min(100, Math.round(job.progressPercent)));
+
+    this.jobStatusPanel.set({
+      visible: true,
+      kind,
+      tone,
+      label: tone === 'recovering'
+        ? 'Recovered job'
+        : kind === 'genesis' ? 'Story generation' : 'Story continuation',
+      title: this.formatJobStatusTitle(kind, tone),
+      description: this.formatJobStatusDescription(kind, tone),
+      progressPercent,
+      stage,
+      jobId: this.formatShortJobId(job.jobId),
+      statusPath: current.visible ? current.statusPath : undefined,
+      startedAt: job.createdAt
+    });
+  }
+
+  private formatJobStatusTitle(kind: ActiveStoryLabJobState['kind'], tone: JobStatusPanelState['tone']): string {
+    if (tone === 'recovering') {
+      return kind === 'genesis' ? 'First chapter job recovered' : 'Continuation job recovered';
+    }
+
+    if (tone === 'starting') {
+      return kind === 'genesis' ? 'First chapter job starting' : 'Continuation job starting';
+    }
+
+    return kind === 'genesis' ? 'First chapter job running' : 'Continuation job running';
+  }
+
+  private formatJobStatusDescription(kind: ActiveStoryLabJobState['kind'], tone: JobStatusPanelState['tone']): string {
+    if (tone === 'recovering') {
+      return kind === 'genesis'
+        ? 'Resumed from this browser. Story Lab is reconnecting to the first chapter job.'
+        : 'Resumed from this browser. Story Lab found the saved story and reconnected to the continuation job.';
+    }
+
+    return kind === 'genesis'
+      ? 'Story Lab is writing the opening batch in a background job.'
+      : 'Story Lab is extending the saved story in a background job.';
+  }
+
+  private clearJobStatusPanel() {
+    this.jobStatusPanel.set(this.createHiddenJobStatusPanel());
+  }
+
+  private formatShortJobId(jobId: string | undefined): string | undefined {
+    if (!jobId) {
+      return undefined;
+    }
+
+    return jobId.length <= 16 ? jobId : `${jobId.slice(0, 8)}...${jobId.slice(-4)}`;
   }
 
   private enqueueBatch(label: string, batchSize: ChapterBatchSize): string {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -839,7 +839,7 @@ ${chapters}
 
   private updateProgressFromJob(job: StoryLabJob<unknown>) {
     const stage = this.formatJobStage(job.currentStep, job.status);
-    const progressPercent = Math.max(0, Math.min(100, Math.round(job.progressPercent)));
+    const progressPercent = this.normalizeJobProgressPercent(job.progressPercent);
     this.jobDrivenProgress = true;
     this.statusMessage.set(stage);
     this.generationProgress.update(current => ({
@@ -1101,15 +1101,9 @@ ${chapters}
   }
 
   private showStartingJobStatus(kind: ActiveStoryLabJobState['kind']) {
-    this.jobStatusPanel.set({
-      visible: true,
+    this.setJobStatusPanel({
       kind,
       tone: 'starting',
-      label: kind === 'genesis' ? 'Story generation' : 'Story continuation',
-      title: kind === 'genesis' ? 'First chapter job starting' : 'Continuation job starting',
-      description: kind === 'genesis'
-        ? 'Story Lab is creating a background job for the opening batch.'
-        : 'Story Lab is creating a background job for the next batch.',
       progressPercent: 8,
       stage: this.generationProgress().stage,
       startedAt: new Date().toISOString()
@@ -1117,15 +1111,9 @@ ${chapters}
   }
 
   private showRecoveringJobStatus(activeJob: ActiveStoryLabJobState) {
-    this.jobStatusPanel.set({
-      visible: true,
+    this.setJobStatusPanel({
       kind: activeJob.kind,
       tone: 'recovering',
-      label: 'Recovered job',
-      title: activeJob.kind === 'genesis' ? 'First chapter job recovered' : 'Continuation job recovered',
-      description: activeJob.kind === 'genesis'
-        ? 'Resumed from this browser. Story Lab is reconnecting to the first chapter job.'
-        : 'Resumed from this browser. Story Lab found the saved story and reconnected to the continuation job.',
       progressPercent: this.generationProgress().percent || 8,
       stage: this.generationProgress().stage,
       jobId: this.formatShortJobId(activeJob.jobId),
@@ -1139,23 +1127,38 @@ ${chapters}
     const current = this.jobStatusPanel();
     const tone = current.visible && current.tone === 'recovering' ? 'recovering' : 'running';
     const stage = this.formatJobStage(job.currentStep, job.status);
-    const progressPercent = Math.max(0, Math.min(100, Math.round(job.progressPercent)));
+    const progressPercent = this.normalizeJobProgressPercent(job.progressPercent);
 
-    this.jobStatusPanel.set({
-      visible: true,
+    this.setJobStatusPanel({
       kind,
       tone,
-      label: tone === 'recovering'
-        ? 'Recovered job'
-        : kind === 'genesis' ? 'Story generation' : 'Story continuation',
-      title: this.formatJobStatusTitle(kind, tone),
-      description: this.formatJobStatusDescription(kind, tone),
       progressPercent,
       stage,
       jobId: this.formatShortJobId(job.jobId),
       statusPath: current.visible ? current.statusPath : undefined,
       startedAt: job.createdAt
     });
+  }
+
+  private setJobStatusPanel(status: Pick<
+    JobStatusPanelState,
+    'kind' | 'tone' | 'progressPercent' | 'stage' | 'jobId' | 'statusPath' | 'startedAt'
+  >) {
+    this.jobStatusPanel.set({
+      visible: true,
+      ...status,
+      label: this.formatJobStatusLabel(status.kind, status.tone),
+      title: this.formatJobStatusTitle(status.kind, status.tone),
+      description: this.formatJobStatusDescription(status.kind, status.tone)
+    });
+  }
+
+  private formatJobStatusLabel(kind: ActiveStoryLabJobState['kind'], tone: JobStatusPanelState['tone']): string {
+    if (tone === 'recovering') {
+      return 'Recovered job';
+    }
+
+    return kind === 'genesis' ? 'Story generation' : 'Story continuation';
   }
 
   private formatJobStatusTitle(kind: ActiveStoryLabJobState['kind'], tone: JobStatusPanelState['tone']): string {
@@ -1177,8 +1180,14 @@ ${chapters}
         : 'Resumed from this browser. Story Lab found the saved story and reconnected to the continuation job.';
     }
 
-    return kind === 'genesis'
-      ? 'Story Lab is writing the opening batch in a background job.'
+    if (kind === 'genesis') {
+      return tone === 'starting'
+        ? 'Story Lab is creating a background job for the opening batch.'
+        : 'Story Lab is writing the opening batch in a background job.';
+    }
+
+    return tone === 'starting'
+      ? 'Story Lab is creating a background job for the next batch.'
       : 'Story Lab is extending the saved story in a background job.';
   }
 
@@ -1192,6 +1201,10 @@ ${chapters}
     }
 
     return jobId.length <= 16 ? jobId : `${jobId.slice(0, 8)}...${jobId.slice(-4)}`;
+  }
+
+  private normalizeJobProgressPercent(progressPercent: number | null | undefined): number {
+    return Math.max(0, Math.min(100, Math.round(progressPercent ?? 0)));
   }
 
   private enqueueBatch(label: string, batchSize: ChapterBatchSize): string {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -1163,32 +1163,50 @@ ${chapters}
 
   private formatJobStatusTitle(kind: ActiveStoryLabJobState['kind'], tone: JobStatusPanelState['tone']): string {
     if (tone === 'recovering') {
-      return kind === 'genesis' ? 'First chapter job recovered' : 'Continuation job recovered';
+      if (kind === 'genesis') {
+        return 'First chapter job recovered';
+      }
+
+      return 'Continuation job recovered';
     }
 
     if (tone === 'starting') {
-      return kind === 'genesis' ? 'First chapter job starting' : 'Continuation job starting';
+      if (kind === 'genesis') {
+        return 'First chapter job starting';
+      }
+
+      return 'Continuation job starting';
     }
 
-    return kind === 'genesis' ? 'First chapter job running' : 'Continuation job running';
+    if (kind === 'genesis') {
+      return 'First chapter job running';
+    }
+
+    return 'Continuation job running';
   }
 
   private formatJobStatusDescription(kind: ActiveStoryLabJobState['kind'], tone: JobStatusPanelState['tone']): string {
     if (tone === 'recovering') {
-      return kind === 'genesis'
-        ? 'Resumed from this browser. Story Lab is reconnecting to the first chapter job.'
-        : 'Resumed from this browser. Story Lab found the saved story and reconnected to the continuation job.';
+      if (kind === 'genesis') {
+        return 'Resumed from this browser. Story Lab is reconnecting to the first chapter job.';
+      }
+
+      return 'Resumed from this browser. Story Lab found the saved story and reconnected to the continuation job.';
     }
 
     if (kind === 'genesis') {
-      return tone === 'starting'
-        ? 'Story Lab is creating a background job for the opening batch.'
-        : 'Story Lab is writing the opening batch in a background job.';
+      if (tone === 'starting') {
+        return 'Story Lab is creating a background job for the opening batch.';
+      }
+
+      return 'Story Lab is writing the opening batch in a background job.';
     }
 
-    return tone === 'starting'
-      ? 'Story Lab is creating a background job for the next batch.'
-      : 'Story Lab is extending the saved story in a background job.';
+    if (tone === 'starting') {
+      return 'Story Lab is creating a background job for the next batch.';
+    }
+
+    return 'Story Lab is extending the saved story in a background job.';
   }
 
   private clearJobStatusPanel() {


### PR DESCRIPTION
## Summary
- add a compact Story Lab job status banner for starting, running, and recovered jobs
- show current stage, percent complete, and shortened opaque job id without exposing story or blueprint text
- add DOM specs for running genesis, recovered continuation, and abandoned continuation recovery banner behavior

## Verification
- RED: `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'"` failed with the expected missing-banner assertions
- GREEN: `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'"` passed with `33 SUCCESS`
- `git diff --check`
- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`
- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`
- `scripts/recovery/check-vercel-function-count.sh` passed at `10/12`
- `npm run smoke:story-lab-ui` passed in mock mode; Angular reported existing bundle budget warnings

## Scope
This does not make jobs cold-start durable. The underlying scaffold remains `non_durable_memory`; this PR makes active/recovered job state visible and understandable in the UI.