### PR TITLE
Add Story Lab batch queue UI

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -4,6 +4,36 @@ Created: 2026-05-26 00:12 EDT
 
 This is the chronological work log for the PR #70 recovery. It should capture commands, decisions, self-review notes, validation results, and anything that changes the plan.
 
+## 2026-06-07 09:59 EDT - Story Lab Batch Queue UI
+
+Actions:
+
+- Created `feature/story-lab-batch-queue-ui` from current `main` after PR #109 merged.
+- Added `STORY_LAB_BATCH_QUEUE_UI_EXEC_PLAN.md` for the focused UI checklist.
+- Exposed the existing Story Lab batch queue in the creation panel.
+- The new panel shows:
+  - each active/completed/failed batch label;
+  - user-readable status;
+  - generated chapter count;
+  - failed-batch error text when present.
+- Added a visible `Clear finished` button that calls the existing `clearFinishedBatchQueue()` method only when completed or failed batches are present.
+
+Validation:
+
+- RED: focused Angular app spec failed with 2 expected batch queue failures because `[data-testid="batch-queue-panel"]` and `[data-testid="clear-finished-batches"]` did not exist yet.
+- `git diff --check`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`: passed.
+- GREEN: `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'"`: passed with `36 SUCCESS`.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
+- `npm run smoke:story-lab-ui`: passed in mock mode.
+
+Self-review:
+
+- Good: The UI now shows the job batch history the app was already tracking internally.
+- Good: The clear action uses existing state cleanup and does not touch saved stories or backend job state.
+- Remaining risk: The panel is browser-session state only; durable cloud job history still needs account/job persistence.
+
 ## 2026-06-07 09:47 EDT - PR109 Review Follow-Up
 
 Problem:

--- a/STORY_LAB_BATCH_QUEUE_UI_EXEC_PLAN.md
+++ b/STORY_LAB_BATCH_QUEUE_UI_EXEC_PLAN.md
@@ -1,0 +1,64 @@
+# Story Lab Batch Queue UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Story Lab's existing batch queue visible so users can see current, completed, and failed generation/continuation batches.
+
+**Architecture:** Reuse the existing `activeBatchQueue`, `hasFinishedBatchQueueItems`, and `clearFinishedBatchQueue()` state in `app.ts`. Add a compact rendered panel in `app.html`, minimal helper formatting in `app.ts`, and focused styles in `app.css`.
+
+**Tech Stack:** Angular signals, Angular templates, Jasmine/Karma DOM specs.
+
+---
+
+### Task 1: RED Specs
+
+**Files:**
+- Modify: `story-generator/src/app/app.spec.ts`
+
+- [x] Add a rendered DOM helper for `[data-testid="batch-queue-panel"]`.
+- [x] Add a failing spec proving a running genesis job renders the batch queue with label, status, and chapter count.
+- [x] Add a failing spec proving completed batches can be cleared with a visible button.
+- [x] Run the focused app spec and confirm the new specs fail because the panel is not rendered.
+
+### Task 2: UI Implementation
+
+**Files:**
+- Modify: `story-generator/src/app/app.ts`
+- Modify: `story-generator/src/app/app.html`
+- Modify: `story-generator/src/app/app.css`
+
+- [x] Add `trackBatch` and status-label helpers if the template needs them.
+- [x] Render the batch queue panel when `activeBatchQueue().length` is nonzero.
+- [x] Show each batch label, status, chapter count, and error message when present.
+- [x] Show a compact clear button only when finished or failed batches exist.
+- [x] Style the panel as an operational list, not a nested card.
+
+### Task 3: Docs And Verification
+
+**Files:**
+- Modify: `PR70_RECOVERY_CHANGELOG.md`
+- Modify: `STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md`
+
+- [x] Record the UI slice and validation evidence.
+- [x] Run:
+
+```bash
+git diff --check
+npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"
+npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"
+npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'"
+scripts/recovery/check-vercel-function-count.sh
+npm run smoke:story-lab-ui
+```
+
+Expected: all commands pass; function count remains `10/12`.
+
+Actual validation:
+
+- RED: the focused app spec failed with 2 expected failures before implementation because the rendered batch queue panel and clear button were missing.
+- `git diff --check`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'"`: passed with `36 SUCCESS`.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
+- `npm run smoke:story-lab-ui`: passed in mock mode.

--- a/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
+++ b/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
@@ -81,6 +81,10 @@ The key product goal is not "more features." The key product goal is a story stu
   - [x] added a compact job status banner for starting, running, and recovered Story Lab jobs;
   - [x] showed current stage, percent complete, and shortened opaque job id without exposing story or blueprint text;
   - [x] hid the banner when continuation recovery cannot safely reconnect to a saved browser-local story.
+- [x] Continued Phase D batch queue visibility on `feature/story-lab-batch-queue-ui`:
+  - [x] rendered the existing batch queue in the Story Lab creation panel;
+  - [x] showed batch label, status, chapter count, and failed-batch error text;
+  - [x] exposed the existing clear-finished-batches action through a visible compact button.
 - [ ] Leave final handoff describing what remains and what requires external provisioning.
 
 ## Surprises & Discoveries
@@ -133,6 +137,7 @@ The key product goal is not "more features." The key product goal is a story stu
   - Heat Contract v0 gives users visible adult-only/spice-boundary controls and carries those boundaries into generation.
   - The generated-story reader shows the active Heat Contract summary beside the story metadata.
   - Story Lab now shows a visible job banner when generation/continuation starts, runs, or is recovered after reload.
+  - Story Lab now shows a visible batch queue so users can see and clear completed/failed generation batches.
 - What became better technically:
   - Story Lab stream parsing accepts the same expanded creature set as the Charmed UI.
   - Heat Contract data is typed in frontend contracts, mapped through the Story Lab engine, and preserved in the classic generation context.
@@ -145,6 +150,7 @@ The key product goal is not "more features." The key product goal is a story stu
   - Future Story Lab job streaming now has an opaque `job_<uuid>` contract and path builder that keeps blueprint/story/private fields out of status and events URLs.
   - Story Lab job routes now create opaque jobs, replay queued/running/terminal snapshots, and label the in-process store as `non_durable_memory`.
   - The Angular UI now has signal-backed job status state that mirrors job lifecycle and recovery without adding routes or backend contracts.
+  - The Angular UI now renders the existing batch queue state instead of keeping it hidden behind component internals.
 - What was intentionally deferred:
   - Accounts, cloud storage, durable Workflow execution, owner-scoped job persistence, cold-start-safe job resume, Blob export, email, and audio runtime.
 - What hostile review still objected to:
@@ -160,6 +166,7 @@ The key product goal is not "more features." The key product goal is a story stu
   - Phase D backend job-route focused checks passed: `git diff --check`, `npx tsx tests/story-lab-job-contracts.test.ts`, `npx tsx tests/story-lab-job-routes.test.ts`, `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`, `scripts/recovery/check-vercel-function-count.sh` at `10/12`, and `scripts/recovery/preflight.sh --quick --skip-status`.
   - Phase D genesis UI job migration focused checks passed: `git diff --check`, app/spec TypeScript compiles, targeted Angular `app.spec.ts` Karma run, `npx tsx tests/story-lab-job-contracts.test.ts`, `npx tsx tests/story-lab-job-routes.test.ts`, and `scripts/recovery/check-vercel-function-count.sh` at `10/12`.
   - Phase D job status UI focused checks passed: RED targeted Angular app spec failed on missing rendered banner, PR follow-up RED failed on missing progress rendering `NaN%`, then GREEN targeted Angular app spec passed with `34 SUCCESS`.
+  - Phase D batch queue UI focused checks passed: RED targeted Angular app spec failed on missing rendered batch queue, then GREEN targeted Angular app spec passed with `36 SUCCESS`; `git diff --check`, app/spec TypeScript compiles, function count at `10/12`, and mocked browser smoke also passed.
 
 ## Context and Orientation
 
@@ -629,6 +636,7 @@ Files:
 - [x] Modified `story-generator/src/app/app.ts` to use job routes for genesis visible progress.
 - [x] Modified `story-generator/src/app/app.ts` to use job routes for continuation visible progress.
 - [x] Modified `story-generator/src/app/app.ts`, `story-generator/src/app/app.html`, and `story-generator/src/app/app.css` for a visible job status/recovery banner.
+- [x] Modified `story-generator/src/app/app.ts`, `story-generator/src/app/app.html`, and `story-generator/src/app/app.css` for a visible batch queue panel.
 - [x] Modified `story-generator/src/app/app.spec.ts` for genesis job creation, event progress, completion, and failed-job handling.
 - [x] Modified `story-generator/src/app/app.spec.ts` for continuation job creation, event progress, completion, and failed-job handling.
 - [x] Reused `story-generator/src/app/app.html` existing progress panel for reload-safe job progress.
@@ -666,6 +674,7 @@ Acceptance:
 - [x] UI can survive reload for active genesis jobs by polling job id inside the current browser session.
 - [x] UI can survive reload for active continuation jobs when the local saved story context is available.
 - [x] UI shows a compact job status/recovery banner with current stage, percent complete, and shortened opaque job id.
+- [x] UI shows current/completed/failed batch queue entries and can clear finished entries.
 - [x] Mocked browser smoke sees queued -> running -> completed through the visible UI.
 
 ### Phase E: Account Sync

--- a/story-generator/src/app/app.css
+++ b/story-generator/src/app/app.css
@@ -277,6 +277,7 @@
 .story-details,
 .generation-progress,
 .job-status-panel,
+.batch-queue-panel,
 .continue-panel,
 .chapter-timeline,
 .continuity-soft,
@@ -632,6 +633,78 @@ button:disabled {
   line-height: 1.35;
 }
 
+.batch-queue-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.batch-queue-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.batch-queue-panel__header h3 {
+  margin: 2px 0 0;
+  color: var(--ink);
+  font-size: 1rem;
+  line-height: 1.25;
+  letter-spacing: 0;
+}
+
+.batch-queue-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+}
+
+.batch-queue-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 6px 10px;
+  border-top: 1px solid var(--line);
+  padding-top: 8px;
+}
+
+.batch-queue-item:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.batch-queue-item__main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.batch-queue-item__main strong {
+  color: var(--ink);
+  font-size: 0.9rem;
+}
+
+.batch-queue-item__main span,
+.batch-queue-item__count {
+  color: var(--muted);
+  font-size: 0.8rem;
+  line-height: 1.35;
+}
+
+.batch-queue-item--failed .batch-queue-item__main span {
+  color: #923039;
+  font-weight: 760;
+}
+
+.batch-queue-item .warning-text {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
 .reader-panel {
   min-height: 680px;
 }
@@ -907,11 +980,13 @@ button:disabled {
   .story-header,
   .chapter-view header,
   .progress-copy,
-  .job-status-panel__header {
+  .job-status-panel__header,
+  .batch-queue-panel__header {
     flex-direction: column;
   }
 
-  .job-status-panel__header {
+  .job-status-panel__header,
+  .batch-queue-panel__header {
     align-items: flex-start;
   }
 
@@ -925,6 +1000,10 @@ button:disabled {
 
   .story-actions button {
     flex: 1 1 auto;
+  }
+
+  .batch-queue-item {
+    grid-template-columns: 1fr;
   }
 
   .reader-panel {

--- a/story-generator/src/app/app.html
+++ b/story-generator/src/app/app.html
@@ -360,6 +360,38 @@
           <span *ngIf="jobStatusPanel().jobId">Job {{ jobStatusPanel().jobId }}</span>
         </div>
       </section>
+
+      <section class="batch-queue-panel" data-testid="batch-queue-panel" *ngIf="activeBatchQueue().length" aria-live="polite">
+        <div class="batch-queue-panel__header">
+          <div>
+            <p class="eyebrow">Job batches</p>
+            <h3>Story Lab queue</h3>
+          </div>
+          <button
+            type="button"
+            class="ghost compact"
+            data-testid="clear-finished-batches"
+            *ngIf="hasFinishedBatchQueueItems()"
+            (click)="clearFinishedBatchQueue()"
+          >
+            Clear finished
+          </button>
+        </div>
+        <ol class="batch-queue-list">
+          <li
+            class="batch-queue-item"
+            *ngFor="let batch of activeBatchQueue(); trackBy: trackBatch"
+            [class.batch-queue-item--failed]="batch.status === 'failed'"
+          >
+            <div class="batch-queue-item__main">
+              <strong>{{ batch.label }}</strong>
+              <span>{{ formatBatchStatus(batch.status) }}</span>
+            </div>
+            <span class="batch-queue-item__count">{{ formatBatchChapterProgress(batch) }}</span>
+            <p class="warning-text" *ngIf="batch.errorMessage">{{ batch.errorMessage }}</p>
+          </li>
+        </ol>
+      </section>
     </section>
 
     <section class="reader-panel" data-testid="story-panel" *ngIf="workbench().story as story; else emptyReader">

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -357,6 +357,15 @@ describe('App', () => {
     return panel?.textContent?.replace(/\s+/g, ' ').trim() ?? null;
   }
 
+  function renderedBatchQueuePanel(targetFixture: ComponentFixture<App> = fixture): HTMLElement | null {
+    targetFixture.detectChanges();
+    return targetFixture.nativeElement.querySelector('[data-testid="batch-queue-panel"]') as HTMLElement | null;
+  }
+
+  function renderedBatchQueueText(targetFixture: ComponentFixture<App> = fixture): string | null {
+    return renderedBatchQueuePanel(targetFixture)?.textContent?.replace(/\s+/g, ' ').trim() ?? null;
+  }
+
   it('creates the workbench with default blueprint values', () => {
     expect(component.blueprint().creature).toBe('vampire');
     expect(component.blueprint().tone).toBe('dark_romance');
@@ -505,6 +514,52 @@ describe('App', () => {
     expect(statusText).toContain('32%');
     expect(statusText).toContain('job_123e...4000');
     expect(statusText).toContain('Grok is writing your first chapter.');
+  });
+
+  it('renders the active batch queue while a genesis job is running', () => {
+    const events$ = new Subject<StoryLabJobEvent<StoryIterationPayload>>();
+
+    startGenesisJobFlow('A siren archivist bargains with a moonlit duke.', events$);
+
+    const queueText = renderedBatchQueueText();
+    expect(queueText).toContain('Story Lab queue');
+    expect(queueText).toContain('Genesis');
+    expect(queueText).toContain('In Progress');
+    expect(queueText).toContain('0 of 1 chapter');
+  });
+
+  it('clears finished batches from the visible batch queue', () => {
+    const payload: StoryIterationPayload = {
+      summary: createSummary(),
+      batch: {
+        chapters: [createChapter()],
+        totalWordCount: 900,
+        suggestedNextPrompts: []
+      },
+      state: createState(),
+      telemetry: {
+        engine: 'gpt',
+        totalLatencyMs: 1200,
+        averageChapterLatencyMs: 1200,
+        tokensConsumed: 900,
+        retryCount: 0
+      }
+    };
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createGenesisJobResponse(payload)
+    }));
+    configureValidBlueprint('A siren archivist bargains with a moonlit duke.');
+
+    component.startGenesis();
+
+    expect(renderedBatchQueueText()).toContain('Completed');
+    const clearButton = renderedBatchQueuePanel()?.querySelector('[data-testid="clear-finished-batches"]') as HTMLButtonElement | null;
+    clearButton?.click();
+    fixture.detectChanges();
+
+    expect(component.activeBatchQueue().length).toBe(0);
+    expect(renderedBatchQueueText()).toBeNull();
   });
 
   it('defaults missing job progress to zero instead of rendering NaN', () => {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -1548,6 +1548,28 @@ ${chapters}
     this.setBatchQueue(this.activeBatchQueue().filter(item => item.status !== 'completed' && item.status !== 'failed'));
   }
 
+  trackBatch(_index: number, batch: BatchProgressState): string {
+    return batch.id;
+  }
+
+  formatBatchStatus(status: BatchProgressState['status']): string {
+    switch (status) {
+      case 'queued':
+        return 'Queued';
+      case 'in_progress':
+        return 'In Progress';
+      case 'completed':
+        return 'Completed';
+      case 'failed':
+        return 'Failed';
+    }
+  }
+
+  formatBatchChapterProgress(batch: BatchProgressState): string {
+    const noun = batch.totalChapters === 1 ? 'chapter' : 'chapters';
+    return `${batch.chaptersGenerated} of ${batch.totalChapters} ${noun}`;
+  }
+
   toggleChapterGroup(groupId: number) {
     const next = new Set(this.collapsedChapterGroups());
     if (next.has(groupId)) {


### PR DESCRIPTION
## Summary
- Exposes the existing Story Lab batch queue in the creation panel so users can see running, completed, and failed batches.
- Shows batch label, user-readable status, generated chapter count, and failed-batch error text.
- Adds a compact Clear finished action that uses the existing batch cleanup method.
- Adds focused Angular DOM specs and records the slice in the recovery/platform docs.

## Verification
- RED: focused app spec failed with the expected missing batch queue panel / clear button failures before implementation.
- git diff --check
- npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"
- npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"
- npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'" passed with 36 SUCCESS
- scripts/recovery/check-vercel-function-count.sh passed at 10/12
- npm run smoke:story-lab-ui passed in mock mode

## Scope
- No new routes or backend job contracts.
- No durable account/cloud job history; this is still browser-session UI over existing in-memory component state.