### PR TITLE
Add Story Lab Director Room UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ The active Charmed MVP execution plan is `STORY_LAB_CHARMED_MVP_EXEC_PLAN.md`. U
 
 The active Story Lab platform evolution plan is `STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md`. Use it before changing Heat Contract behavior, dedicated creature style banks, Story Lab provider smoke, cloud accounts/sync, durable storage, job/workflow progress, audio, server export, or Director's Room-style creative tooling.
 
+The active Story Lab Director's Room UI plan is `STORY_LAB_DIRECTOR_ROOM_UI_EXEC_PLAN.md`. Use it before changing the compact craft-notes UI, accepted/dismissed note behavior, or note-driven continuation briefs.
+
 The active Story Lab privacy/streaming gate plan is `STORY_LAB_PRIVACY_STREAMING_GATES_EXEC_PLAN.md`. Use it before changing CORS policy, account-boundary headers, export sanitization, retention/deletion policy, or opaque job-id streaming contracts.
 
 The active Story Lab storage-port plan is `STORY_LAB_STORAGE_PORT_EXEC_PLAN.md`. Use it before changing Story Lab storage ports, in-memory account-store scaffolding, Postgres adapter scaffolding, or account-sync persistence boundaries.

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -4,6 +4,39 @@ Created: 2026-05-26 00:12 EDT
 
 This is the chronological work log for the PR #70 recovery. It should capture commands, decisions, self-review notes, validation results, and anything that changes the plan.
 
+## 2026-06-07 10:13 EDT - Story Lab Director's Room UI
+
+Actions:
+
+- Created `feature/story-lab-director-room-ui` from current `main` after PR #110 merged.
+- Added `STORY_LAB_DIRECTOR_ROOM_UI_EXEC_PLAN.md` and linked it from `AGENTS.md`.
+- Added a compact Director's Room panel below the selected chapter.
+- The panel renders three deterministic craft notes when a chapter exists:
+  - `Desire Ledger`;
+  - `Continuity Keeper`;
+  - `Chapter Ending`.
+- Added note actions for accepting, dismissing, and moving a note into the custom continuation brief.
+- Added `Continue with notes`, which sends accepted notes through the existing continuation job flow instead of adding a new route or fake AI-review service.
+
+Validation:
+
+- RED: focused Angular app spec failed with 3 expected Director's Room failures because the panel/actions did not exist yet.
+- `git diff --check`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`: passed.
+- GREEN: `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'"`: passed with `40 SUCCESS`.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
+- `npm run smoke:story-lab-ui`: initially failed production build because `app.css` exceeded the 15 kB hard budget by 937 bytes.
+- Reused existing batch queue list/grid CSS for the Director's Room panel and trimmed nonessential note styling.
+- `npm run smoke:story-lab-ui`: passed in mock mode after the CSS budget fix; Angular still reports existing warning-level budgets, with `app.css` at 14.95 kB.
+
+Self-review:
+
+- Good: The UI now exposes the platform plan's Director's Room concept without claiming durable workflow or AI critique.
+- Good: Accepted notes reuse the job-backed continuation path, so the new UI stays inside existing contracts.
+- Good: The production CSS hard budget caught the first styling pass before it reached the PR.
+- Remaining risk: This is deterministic local craft guidance; AI-backed critique and true rewrite jobs remain future platform work.
+
 ## 2026-06-07 09:59 EDT - Story Lab Batch Queue UI
 
 Actions:

--- a/STORY_LAB_DIRECTOR_ROOM_UI_EXEC_PLAN.md
+++ b/STORY_LAB_DIRECTOR_ROOM_UI_EXEC_PLAN.md
@@ -1,0 +1,196 @@
+# Story Lab Director's Room UI ExecPlan
+
+Created: 2026-06-07 10:13 EDT
+
+## Purpose / Big Picture
+
+Add the first visible "Director's Room" slice to Story Lab: after a story chapter exists, the reader panel should show a compact craft-notes panel with practical next-chapter guidance. Users can accept a note, dismiss a note, or move a note into the custom continuation brief. Accepted notes can be sent through the existing continuation job flow.
+
+This is intentionally a UI-first slice. It does not add a new AI reviewer, backend route, durable workflow, account storage, or server-side revision pipeline. The panel uses deterministic local notes derived from the selected chapter, current story state, Heat Contract, and blueprint.
+
+## Progress
+
+- [x] Started fresh branch `feature/story-lab-director-room-ui` from `main` after PR #110 merged.
+- [x] Read `AGENTS.md`, `.agent/PLANS.md`, active Story Lab platform plan, current Angular component/template/styles/specs, and relevant contracts.
+- [x] Selected the recommended design: a compact local Director's Room panel that feeds accepted notes into existing continuation jobs.
+- [x] Ran hostile review before implementation and constrained the scope.
+- [x] Add failing Angular DOM specs for visible Director's Room behavior.
+- [x] Implement local Director's Room note model, actions, template, and styles.
+- [x] Update recovery/platform docs with evidence.
+- [ ] Run verification, commit, push PR, address comments/checks, and merge if clean.
+
+## Surprises & Discoveries
+
+- The current app already has the right seams: selected chapter, story state, Heat Contract, custom continuation brief, and job-backed continuation.
+- The safest first version is not a "rewrite this chapter" backend flow. It should improve the next continuation request until durable jobs and AI review passes exist.
+- The platform plan already names Director's Room as "a compact improvement panel," so this slice should avoid dashboard-style process theater.
+- The first smoke run failed production build because `app.css` exceeded the 15 kB hard budget by 937 bytes. Reusing the existing batch queue list/grid styles brought component CSS back under the hard budget at 14.95 kB.
+
+## Decision Log
+
+- Decision: Use deterministic local notes in this branch.
+  Rationale: It gives users visible craft guidance now without pretending we added an AI critique service or durable workflow.
+- Decision: Keep notes scoped to the selected chapter.
+  Rationale: Users need the panel to respond to what they are reading, not generic app state.
+- Decision: Accepted notes become continuation instructions.
+  Rationale: The existing continuation job path is already tested and user-facing; this branch should reuse it instead of adding new routes.
+- Decision: Dismissed notes remain visible as dismissed rather than disappearing.
+  Rationale: This avoids confusing layout jumps and lets tests prove the user's choice.
+
+## Outcomes & Retrospective
+
+- What became better for users: Story Lab now shows a compact Director's Room panel after a chapter exists, with three practical craft notes that can shape the next continuation.
+- What became better technically: The panel is a deterministic Angular UI layer over existing selected chapter, continuity, Heat Contract, and continuation-job state. It adds no backend route or storage claim.
+- What was intentionally deferred: AI-backed critique, true chapter rewrite jobs, durable accepted-note persistence, and account/cloud sync.
+- What hostile review still objected to: The panel is not an AI editor yet; copy and behavior must continue to frame it as local next-chapter guidance.
+- What validation proved: RED/GREEN focused Angular app specs proved the panel is hidden before a chapter exists, renders three notes for a selected chapter, supports accepted/dismissed/brief behavior, and sends accepted notes through the existing continuation job flow. Mocked browser smoke passed after trimming CSS under the production budget.
+
+## Context and Orientation
+
+Repository root: `/Users/hbpheonix/fairytaleswithspice`.
+
+Current branch: `feature/story-lab-director-room-ui`.
+
+Primary files:
+
+- `story-generator/src/app/app.ts`: Angular Story Lab component state/actions. Add the note model, computed notes, accept/dismiss/rewrite actions, and continuation dispatch helper here.
+- `story-generator/src/app/app.html`: render the panel below the selected chapter and above existing continuation controls.
+- `story-generator/src/app/app.css`: style the panel as a compact tool surface, not nested cards.
+- `story-generator/src/app/app.spec.ts`: add focused DOM specs and continuation request assertions.
+- `PR70_RECOVERY_CHANGELOG.md`: record work and validation.
+- `STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md`: mark the Director's Room UI slice as started/completed.
+
+Existing unrelated untracked files must stay untouched:
+
+- `SPARK_TRIAL_TASKS.md`
+- `STORY_QUALITY_EVALS_PLAN.md`
+- `tests/grok-smoke.test.ts`
+
+## Hostile Review
+
+Critical risks before implementation:
+
+- The UI could imply an AI editor is reviewing prose when it is only local deterministic guidance.
+  Fix: copy and method names must call them "notes" and "next chapter" guidance, not AI review.
+- The branch could accidentally add a new backend route or workflow claim.
+  Fix: touch only Angular UI/specs and recovery docs.
+- Accepted notes could bypass the already-tested job path.
+  Fix: tests must assert `createStoryLabJob({ kind: 'continuation', ... })` receives the accepted note text.
+
+Important risks:
+
+- The panel could show before a story exists and clutter the initial creation flow.
+  Fix: render only when `selectedChapter()` exists.
+- Rejected notes could disappear and create layout jumps.
+  Fix: keep notes visible with a dismissed status.
+- Long note text could overflow the reader panel on mobile.
+  Fix: use compact text, wrapping, and existing mobile column behavior.
+
+Minor polish that should not block:
+
+- Future AI-backed critique, chapter rewrite jobs, and accept/reject persistence belong after durable jobs/storage.
+
+## Plan of Work
+
+### Task 1: RED Specs
+
+Files:
+
+- Modify `story-generator/src/app/app.spec.ts`.
+
+Steps:
+
+- [x] Add DOM helpers for `[data-testid="director-room-panel"]` and rendered text.
+- [x] Add a spec proving the panel is hidden before a chapter exists.
+- [x] Add a spec proving a seeded story renders three craft note names: `Desire Ledger`, `Continuity Keeper`, and `Chapter Ending`.
+- [x] Add a spec proving accepting Director's Room notes and clicking `Continue with notes` sends the accepted note text through the existing continuation job request.
+- [x] Run the focused Angular spec and confirm the new tests fail because the panel/actions do not exist yet.
+
+### Task 2: UI Implementation
+
+Files:
+
+- Modify `story-generator/src/app/app.ts`.
+- Modify `story-generator/src/app/app.html`.
+- Modify `story-generator/src/app/app.css`.
+
+Steps:
+
+- [x] Add `DirectorRoomNote`, note status, and note id types local to `app.ts`.
+- [x] Add a `directorRoomDecisions` signal keyed by selected chapter and note id.
+- [x] Add a `directorRoomNotes` computed value that returns three notes when a chapter exists:
+  - `Desire Ledger`: focus the next chapter on the protagonist's want or current goal.
+  - `Continuity Keeper`: carry forward an active thread, artifact, warning, or chapter summary.
+  - `Chapter Ending`: request a sharper ending bet based on cliffhanger state.
+- [x] Add public actions:
+  - `acceptDirectorRoomNote(note)`
+  - `dismissDirectorRoomNote(note)`
+  - `useDirectorRoomNoteAsBrief(note)`
+  - `continueWithDirectorRoomNotes()`
+  - `trackDirectorRoomNote(...)`
+- [x] Render the panel under the selected chapter, above existing continuation controls.
+- [x] Use existing `continueSaga()` to dispatch accepted notes; do not add service methods.
+- [x] Style note rows and controls so they wrap on mobile and do not create nested card UI.
+
+### Task 3: Docs And Verification
+
+Files:
+
+- Modify `PR70_RECOVERY_CHANGELOG.md`.
+- Modify `STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md`.
+- Modify this plan.
+
+Steps:
+
+- [x] Mark checklist items complete as they pass.
+- [x] Record validation evidence in the changelog and platform plan.
+- [x] Run:
+
+```bash
+git diff --check
+npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"
+npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"
+npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'"
+scripts/recovery/check-vercel-function-count.sh
+npm run smoke:story-lab-ui
+```
+
+Expected: all commands pass; function count remains `10/12`.
+
+Actual validation:
+
+- RED: focused Angular app spec failed with 3 expected failures before implementation because the Director's Room panel/actions were missing.
+- `git diff --check`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'"`: passed with `40 SUCCESS`.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
+- `npm run smoke:story-lab-ui`: initially failed because `app.css` exceeded the 15 kB hard budget, then passed in mock mode after CSS was trimmed under the budget.
+
+## Validation and Acceptance
+
+Accepted when:
+
+- The Director's Room panel does not render before a chapter exists.
+- The panel renders three deterministic notes for an existing selected chapter.
+- Users can accept, dismiss, and use a note as the custom continuation brief.
+- `Continue with notes` calls the existing continuation job flow and sends accepted note text in `continuationBrief`.
+- No backend route, Vercel function, storage adapter, auth behavior, or durable workflow is changed.
+
+## Idempotence and Recovery
+
+- If tests fail because the seeded story lacks state details, adjust the test fixture data rather than loosening user-visible assertions.
+- If the panel text becomes too specific and brittle, assert stable headings and continuation request content rather than full copy.
+- If `npm run smoke:story-lab-ui` fails because selectors changed, preserve existing `data-testid` hooks and update only the new panel selectors.
+- If review flags this as fake AI review, rename/copy-edit to "Director's notes" and keep the backend scope unchanged.
+
+## Artifacts and Notes
+
+- PR #110 merged immediately before this branch and added the visible batch queue.
+- This branch is the next UI-only step from the platform plan's Director's Room concept.
+
+## Interfaces and Dependencies
+
+- Existing continuation dependency: `continueSaga(brief?: string)` creates a `StoryLabJob` with `kind: 'continuation'`.
+- Existing story state dependency: `selectedChapter()`, `continuityPanel()`, `activeHeatContract()`, and `blueprint()` are enough for deterministic notes.
+- No new package, external API, route, or environment variable is needed.

--- a/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
+++ b/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
@@ -85,6 +85,11 @@ The key product goal is not "more features." The key product goal is a story stu
   - [x] rendered the existing batch queue in the Story Lab creation panel;
   - [x] showed batch label, status, chapter count, and failed-batch error text;
   - [x] exposed the existing clear-finished-batches action through a visible compact button.
+- [x] Started the first Director's Room UI slice on `feature/story-lab-director-room-ui`:
+  - [x] rendered a compact local craft-notes panel after a chapter exists;
+  - [x] added Desire Ledger, Continuity Keeper, and Chapter Ending notes;
+  - [x] let users accept/dismiss notes or move a note into the custom continuation brief;
+  - [x] sent accepted notes through the existing continuation job path.
 - [ ] Leave final handoff describing what remains and what requires external provisioning.
 
 ## Surprises & Discoveries
@@ -138,6 +143,7 @@ The key product goal is not "more features." The key product goal is a story stu
   - The generated-story reader shows the active Heat Contract summary beside the story metadata.
   - Story Lab now shows a visible job banner when generation/continuation starts, runs, or is recovered after reload.
   - Story Lab now shows a visible batch queue so users can see and clear completed/failed generation batches.
+  - Story Lab now shows the first Director's Room panel so users can turn craft notes into the next continuation request.
 - What became better technically:
   - Story Lab stream parsing accepts the same expanded creature set as the Charmed UI.
   - Heat Contract data is typed in frontend contracts, mapped through the Story Lab engine, and preserved in the classic generation context.
@@ -151,6 +157,7 @@ The key product goal is not "more features." The key product goal is a story stu
   - Story Lab job routes now create opaque jobs, replay queued/running/terminal snapshots, and label the in-process store as `non_durable_memory`.
   - The Angular UI now has signal-backed job status state that mirrors job lifecycle and recovery without adding routes or backend contracts.
   - The Angular UI now renders the existing batch queue state instead of keeping it hidden behind component internals.
+  - The Angular UI now has deterministic Director's Room note state that reuses existing continuation jobs instead of adding backend review routes.
 - What was intentionally deferred:
   - Accounts, cloud storage, durable Workflow execution, owner-scoped job persistence, cold-start-safe job resume, Blob export, email, and audio runtime.
 - What hostile review still objected to:
@@ -167,6 +174,7 @@ The key product goal is not "more features." The key product goal is a story stu
   - Phase D genesis UI job migration focused checks passed: `git diff --check`, app/spec TypeScript compiles, targeted Angular `app.spec.ts` Karma run, `npx tsx tests/story-lab-job-contracts.test.ts`, `npx tsx tests/story-lab-job-routes.test.ts`, and `scripts/recovery/check-vercel-function-count.sh` at `10/12`.
   - Phase D job status UI focused checks passed: RED targeted Angular app spec failed on missing rendered banner, PR follow-up RED failed on missing progress rendering `NaN%`, then GREEN targeted Angular app spec passed with `34 SUCCESS`.
   - Phase D batch queue UI focused checks passed: RED targeted Angular app spec failed on missing rendered batch queue, then GREEN targeted Angular app spec passed with `36 SUCCESS`; `git diff --check`, app/spec TypeScript compiles, function count at `10/12`, and mocked browser smoke also passed.
+  - Director's Room UI focused checks passed: RED targeted Angular app spec failed on missing rendered panel/actions, then GREEN targeted Angular app spec passed with `40 SUCCESS`; `git diff --check`, app/spec TypeScript compiles, and function count at `10/12` passed; the first mocked browser smoke failed on the `app.css` hard budget, then passed after reusing existing list/grid styles and trimming CSS under 15 kB.
 
 ## Context and Orientation
 

--- a/story-generator/src/app/app.css
+++ b/story-generator/src/app/app.css
@@ -796,6 +796,26 @@ button:disabled {
   gap: 10px;
 }
 
+.director-room-note p {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.84rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.director-room-note--dismissed {
+  opacity: 0.72;
+}
+
+.director-room-note__actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .prompt-chip {
   min-height: 40px;
   padding: 9px 10px;

--- a/story-generator/src/app/app.html
+++ b/story-generator/src/app/app.html
@@ -429,6 +429,48 @@
         <div class="chapter-content" [innerHTML]="getSafeHtml(chapter.htmlContent)"></div>
       </article>
 
+      <section class="director-room-panel batch-queue-panel" data-testid="director-room-panel" *ngIf="directorRoomNotes().length">
+        <div class="section-heading compact-heading">
+          <p class="eyebrow">Director's Room</p>
+          <h3>Make the next chapter sharper</h3>
+        </div>
+        <ol class="batch-queue-list">
+          <li
+            class="batch-queue-item director-room-note"
+            *ngFor="let note of directorRoomNotes(); trackBy: trackDirectorRoomNote"
+            [class.director-room-note--accepted]="note.status === 'accepted'"
+            [class.director-room-note--dismissed]="note.status === 'dismissed'"
+          >
+            <div class="batch-queue-item__main director-room-note__title">
+              <strong>{{ note.title }}</strong>
+              <span>{{ formatDirectorRoomNoteStatus(note.status) }}</span>
+            </div>
+            <div class="director-room-note__actions">
+              <button type="button" class="ghost compact" data-testid="accept-director-note" (click)="acceptDirectorRoomNote(note)" [disabled]="isGenerating()">
+                Use note
+              </button>
+              <button type="button" class="ghost compact" data-testid="rewrite-director-note" (click)="useDirectorRoomNoteAsBrief(note)" [disabled]="isGenerating()">
+                Use as brief
+              </button>
+              <button type="button" class="ghost compact" data-testid="dismiss-director-note" (click)="dismissDirectorRoomNote(note)" [disabled]="isGenerating()">
+                Dismiss
+              </button>
+            </div>
+            <p>{{ note.focus }}</p>
+            <p>{{ note.suggestion }}</p>
+          </li>
+        </ol>
+        <button
+          type="button"
+          class="secondary"
+          data-testid="continue-with-director-notes"
+          (click)="continueWithDirectorRoomNotes()"
+          [disabled]="isGenerating() || !acceptedDirectorRoomNotes().length"
+        >
+          Continue with notes
+        </button>
+      </section>
+
       <section class="continue-panel">
         <div class="section-heading compact-heading">
           <p class="eyebrow">Next chapter</p>

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -366,6 +366,15 @@ describe('App', () => {
     return renderedBatchQueuePanel(targetFixture)?.textContent?.replace(/\s+/g, ' ').trim() ?? null;
   }
 
+  function renderedDirectorRoomPanel(targetFixture: ComponentFixture<App> = fixture): HTMLElement | null {
+    targetFixture.detectChanges();
+    return targetFixture.nativeElement.querySelector('[data-testid="director-room-panel"]') as HTMLElement | null;
+  }
+
+  function renderedDirectorRoomText(targetFixture: ComponentFixture<App> = fixture): string | null {
+    return renderedDirectorRoomPanel(targetFixture)?.textContent?.replace(/\s+/g, ' ').trim() ?? null;
+  }
+
   it('creates the workbench with default blueprint values', () => {
     expect(component.blueprint().creature).toBe('vampire');
     expect(component.blueprint().tone).toBe('dark_romance');
@@ -560,6 +569,93 @@ describe('App', () => {
 
     expect(component.activeBatchQueue().length).toBe(0);
     expect(renderedBatchQueueText()).toBeNull();
+  });
+
+  it('hides the Director Room before a chapter exists', () => {
+    expect(renderedDirectorRoomText()).toBeNull();
+  });
+
+  it('renders Director Room craft notes for the selected chapter', () => {
+    seedWorkbenchForContinuation({
+      state: createState({
+        characters: [
+          {
+            id: 'heroine',
+            displayName: 'Mara',
+            archetype: 'protagonist',
+            summary: 'A siren archivist guarding a forbidden oath.',
+            currentGoal: 'Keep the moonlit bargain from consuming her archive.',
+            internalConflict: 'She wants the duke and fears the cost.',
+            externalConflict: 'The rival court wants the same oath.',
+            secrets: [],
+            relationships: [],
+            spiceCompatibilities: [3]
+          }
+        ],
+        threads: [
+          {
+            id: 'oath',
+            label: 'Moonlit oath',
+            status: 'escalating',
+            description: 'The bargain demands a public sacrifice.',
+            foreshadowedDevices: []
+          }
+        ]
+      })
+    });
+
+    const directorText = renderedDirectorRoomText();
+
+    expect(directorText).toContain('Director');
+    expect(directorText).toContain('Desire Ledger');
+    expect(directorText).toContain('Continuity Keeper');
+    expect(directorText).toContain('Chapter Ending');
+    expect(directorText).toContain('Mara');
+    expect(directorText).toContain('Moonlit oath');
+  });
+
+  it('moves a Director Room note into the custom continuation brief and keeps dismissed notes visible', () => {
+    seedWorkbenchForContinuation();
+
+    const panel = renderedDirectorRoomPanel();
+    const rewriteButton = panel?.querySelector('[data-testid="rewrite-director-note"]') as HTMLButtonElement | null;
+    const dismissButton = panel?.querySelector('[data-testid="dismiss-director-note"]') as HTMLButtonElement | null;
+
+    rewriteButton?.click();
+    fixture.detectChanges();
+    dismissButton?.click();
+    fixture.detectChanges();
+
+    expect(component.customContinuationBrief()).toContain('Desire Ledger');
+    expect(renderedDirectorRoomText()).toContain('Dismissed');
+  });
+
+  it('continues with accepted Director Room notes through the existing job flow', () => {
+    const genesisPayload = seedWorkbenchForContinuation();
+    const continuationPayload = createContinuationPayload(genesisPayload);
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(continuationPayload)
+    }));
+
+    const panel = renderedDirectorRoomPanel();
+    const acceptButtons = panel?.querySelectorAll('[data-testid="accept-director-note"]') as NodeListOf<HTMLButtonElement> | undefined;
+    acceptButtons?.[0]?.click();
+    acceptButtons?.[1]?.click();
+    fixture.detectChanges();
+
+    const continueButton = renderedDirectorRoomPanel()?.querySelector('[data-testid="continue-with-director-notes"]') as HTMLButtonElement | null;
+    continueButton?.click();
+
+    expect(storyService.continueStory).not.toHaveBeenCalled();
+    const jobRequest = storyService.createStoryLabJob.calls.mostRecent().args[0] as {
+      kind: 'continuation';
+      continuation: { continuationBrief?: string };
+    };
+    expect(jobRequest.kind).toBe('continuation');
+    expect(jobRequest.continuation.continuationBrief).toContain('Director Room notes');
+    expect(jobRequest.continuation.continuationBrief).toContain('Desire Ledger');
+    expect(jobRequest.continuation.continuationBrief).toContain('Continuity Keeper');
   });
 
   it('defaults missing job progress to zero instead of rendering NaN', () => {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -74,6 +74,20 @@ type ContinuationDirection = {
   brief: string;
 };
 
+type DirectorRoomNoteId = 'desire-ledger' | 'continuity-keeper' | 'chapter-ending';
+
+type DirectorRoomNoteStatus = 'pending' | 'accepted' | 'dismissed';
+
+type DirectorRoomNote = {
+  id: DirectorRoomNoteId;
+  title: string;
+  focus: string;
+  suggestion: string;
+  continuationBrief: string;
+  status: DirectorRoomNoteStatus;
+  chapterId: string;
+};
+
 type GenerationProgressState = {
   active: boolean;
   percent: number;
@@ -227,6 +241,7 @@ export class App implements OnDestroy {
   readonly collapsedChapterGroups = signal<Set<number>>(new Set());
   readonly activeSkin = signal<StorySkinId>('writing-desk');
   readonly customContinuationBrief = signal('');
+  readonly directorRoomDecisions = signal<Record<string, DirectorRoomNoteStatus>>({});
   readonly isGenerating = signal(false);
   readonly statusMessage = signal<string>('Tell us what kind of enchanted, spicy story you want.');
   readonly workspaceSaveStatus = signal<string>('No saved stories in this browser yet.');
@@ -309,6 +324,60 @@ export class App implements OnDestroy {
   );
   readonly suggestedNextPrompts = computed(() => this.workbench().lastSuggestedPrompts ?? []);
   readonly continuityExtraction = computed(() => this.workbench().lastContinuityExtraction ?? null);
+  readonly directorRoomNotes = computed<DirectorRoomNote[]>(() => {
+    const chapter = this.selectedChapter();
+    if (!chapter) {
+      return [];
+    }
+
+    const blueprint = this.blueprint();
+    const continuity = this.continuityPanel();
+    const primaryCharacter = continuity.characters[0];
+    const primaryThread = continuity.activeThreads[0];
+    const primaryArtifact = continuity.unresolvedArtifacts[0];
+    const protagonist = primaryCharacter?.displayName || blueprint.protagonistName?.trim() || 'the lead';
+    const currentGoal = primaryCharacter?.currentGoal || `make the ${blueprint.creature} desire more costly`;
+    const continuityLabel = primaryThread?.label || primaryArtifact?.name || 'the current story thread';
+    const continuityDetail = primaryThread?.description || primaryArtifact?.significance || chapter.summary;
+    const endingSuggestion = chapter.hasCliffhanger
+      ? 'Pay off the current cliffhanger, then open a harder question before the chapter closes.'
+      : 'End the next chapter on an impossible choice instead of a quiet fade-out.';
+    const baseNotes: Omit<DirectorRoomNote, 'status'>[] = [
+      {
+        id: 'desire-ledger',
+        title: 'Desire Ledger',
+        focus: `${protagonist} wants: ${currentGoal}`,
+        suggestion: 'Make the next scene force that desire to cost something visible.',
+        continuationBrief: `Desire Ledger: Make ${protagonist} actively pursue ${currentGoal}, and make that desire cost something visible.`,
+        chapterId: chapter.chapterId
+      },
+      {
+        id: 'continuity-keeper',
+        title: 'Continuity Keeper',
+        focus: `${continuityLabel}: ${continuityDetail}`,
+        suggestion: 'Carry this thread forward on page so the next chapter feels connected.',
+        continuationBrief: `Continuity Keeper: Carry forward ${continuityLabel}. ${continuityDetail}`,
+        chapterId: chapter.chapterId
+      },
+      {
+        id: 'chapter-ending',
+        title: 'Chapter Ending',
+        focus: chapter.hasCliffhanger ? 'Current chapter already ends on a cliffhanger.' : 'Current chapter closes without a hard unresolved turn.',
+        suggestion: endingSuggestion,
+        continuationBrief: `Chapter Ending: ${endingSuggestion}`,
+        chapterId: chapter.chapterId
+      }
+    ];
+    const decisions = this.directorRoomDecisions();
+
+    return baseNotes.map(note => ({
+      ...note,
+      status: decisions[this.getDirectorRoomDecisionKey(note)] ?? 'pending'
+    }));
+  });
+  readonly acceptedDirectorRoomNotes = computed(() =>
+    this.directorRoomNotes().filter(note => note.status === 'accepted')
+  );
   readonly modelBadge = computed(() => {
     const telemetry = this.workbench().lastTelemetry;
     if (!telemetry?.model) {
@@ -549,6 +618,30 @@ export class App implements OnDestroy {
 
     this.customContinuationBrief.set('');
     this.continueSaga(brief);
+  }
+
+  acceptDirectorRoomNote(note: DirectorRoomNote) {
+    this.setDirectorRoomNoteStatus(note, 'accepted');
+  }
+
+  dismissDirectorRoomNote(note: DirectorRoomNote) {
+    this.setDirectorRoomNoteStatus(note, 'dismissed');
+  }
+
+  useDirectorRoomNoteAsBrief(note: DirectorRoomNote) {
+    this.setDirectorRoomNoteStatus(note, 'accepted');
+    this.customContinuationBrief.set(note.continuationBrief);
+    this.statusMessage.set('Director Room note moved into the custom continuation brief.');
+  }
+
+  continueWithDirectorRoomNotes() {
+    const acceptedNotes = this.acceptedDirectorRoomNotes();
+    if (!acceptedNotes.length) {
+      this.notificationService.warning('No Director Room notes selected', 'Accept at least one note before continuing with notes.');
+      return;
+    }
+
+    this.continueSaga(this.buildDirectorRoomContinuationBrief(acceptedNotes));
   }
 
   getSafeHtml(html: string): string {
@@ -1568,6 +1661,42 @@ ${chapters}
   formatBatchChapterProgress(batch: BatchProgressState): string {
     const noun = batch.totalChapters === 1 ? 'chapter' : 'chapters';
     return `${batch.chaptersGenerated} of ${batch.totalChapters} ${noun}`;
+  }
+
+  trackDirectorRoomNote(_index: number, note: DirectorRoomNote): string {
+    return note.id;
+  }
+
+  formatDirectorRoomNoteStatus(status: DirectorRoomNoteStatus): string {
+    switch (status) {
+      case 'accepted':
+        return 'Accepted';
+      case 'dismissed':
+        return 'Dismissed';
+      case 'pending':
+        return 'Pending';
+    }
+  }
+
+  private setDirectorRoomNoteStatus(note: DirectorRoomNote, status: DirectorRoomNoteStatus) {
+    this.directorRoomDecisions.update(current => ({
+      ...current,
+      [this.getDirectorRoomDecisionKey(note)]: status
+    }));
+  }
+
+  private getDirectorRoomDecisionKey(note: Pick<DirectorRoomNote, 'chapterId' | 'id'>): string {
+    return `${note.chapterId}:${note.id}`;
+  }
+
+  private buildDirectorRoomContinuationBrief(notes: DirectorRoomNote[]): string {
+    const customBrief = this.customContinuationBrief().trim();
+    const directorBrief = [
+      'Director Room notes:',
+      ...notes.map(note => `- ${note.continuationBrief}`)
+    ].join('\n');
+
+    return customBrief ? `${customBrief}\n\n${directorBrief}` : directorBrief;
   }
 
   toggleChapterGroup(groupId: number) {


### PR DESCRIPTION
## Summary
- Adds the first local Director Room panel below the selected chapter.
- Shows three deterministic craft notes: Desire Ledger, Continuity Keeper, and Chapter Ending.
- Lets users accept, dismiss, or move a note into the custom continuation brief.
- Sends accepted notes through the existing Story Lab continuation job flow via `createStoryLabJob`; no new backend route, storage, or workflow claim.
- Adds a self-contained ExecPlan and records the slice in recovery/platform docs.

## Verification
- RED: focused app spec failed with expected missing Director Room panel/action failures before implementation.
- git diff --check
- npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"
- npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"
- npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'" passed with 40 SUCCESS
- scripts/recovery/check-vercel-function-count.sh passed at 10/12
- npm run smoke:story-lab-ui initially failed because app.css exceeded the 15 kB hard budget; after reusing existing list/grid styles and trimming CSS, the smoke passed in mock mode with app.css at 14.95 kB.

## Scope
- UI-only deterministic notes over existing selected chapter/story state.
- No new API routes, durable jobs, auth/storage behavior, or AI-review service.
- AI-backed critique and true rewrite jobs remain future platform work.