### PR TITLE
Add Story Lab villain pressure UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ The active Story Lab platform evolution plan is `STORY_LAB_PLATFORM_EVOLUTION_EX
 
 The active Story Lab Director's Room UI plan is `STORY_LAB_DIRECTOR_ROOM_UI_EXEC_PLAN.md`. Use it before changing the compact craft-notes UI, accepted/dismissed note behavior, or note-driven continuation briefs.
 
+The active Story Lab Villain Pressure UI plan is `STORY_LAB_VILLAIN_PRESSURE_UI_EXEC_PLAN.md`. Use it before changing continuation pressure controls or pressure-driven continuation brief composition.
+
 The active Story Lab privacy/streaming gate plan is `STORY_LAB_PRIVACY_STREAMING_GATES_EXEC_PLAN.md`. Use it before changing CORS policy, account-boundary headers, export sanitization, retention/deletion policy, or opaque job-id streaming contracts.
 
 The active Story Lab storage-port plan is `STORY_LAB_STORAGE_PORT_EXEC_PLAN.md`. Use it before changing Story Lab storage ports, in-memory account-store scaffolding, Postgres adapter scaffolding, or account-sync persistence boundaries.

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -4,6 +4,39 @@ Created: 2026-05-26 00:12 EDT
 
 This is the chronological work log for the PR #70 recovery. It should capture commands, decisions, self-review notes, validation results, and anything that changes the plan.
 
+## 2026-06-07 10:24 EDT - Story Lab Villain Pressure UI
+
+Actions:
+
+- Created `feature/story-lab-villain-pressure-ui` from current `main` after PR #111 merged.
+- Added `STORY_LAB_VILLAIN_PRESSURE_UI_EXEC_PLAN.md` and linked it from `AGENTS.md`.
+- Added a Villain Pressure dial inside the existing continuation panel.
+- Added five pressure choices:
+  - `Antagonist`;
+  - `Environment`;
+  - `Secret`;
+  - `Deadline`;
+  - `Inner Desire`.
+- Composed selected pressure into UI-generated continuation briefs for normal continuation, direction continuation, and Director's Room notes.
+- Kept direct `continueSaga(brief)` unchanged so lower-level tests/callers do not receive hidden UI pressure.
+- Reused existing heat-option/grid styles and added no new CSS.
+
+Validation:
+
+- RED: focused Angular app spec failed with 3 expected pressure-dial failures because the panel and pressure text did not exist yet.
+- `git diff --check`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`: passed.
+- GREEN: `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'"`: passed with `43 SUCCESS`.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
+- `npm run smoke:story-lab-ui`: passed in mock mode; Angular still reports warning-level initial bundle and CSS budget warnings, but `app.css` remains under the 15 kB hard limit.
+
+Self-review:
+
+- Good: The dial makes continuation more directive without creating backend or AI-review scope.
+- Good: The Director's Room path and normal Continue Story path both carry selected pressure through the existing job request.
+- Remaining risk: This is still a brief-shaping control, not a true villain-planning engine.
+
 ## 2026-06-07 10:13 EDT - Story Lab Director's Room UI
 
 Actions:

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -4,6 +4,27 @@ Created: 2026-05-26 00:12 EDT
 
 This is the chronological work log for the PR #70 recovery. It should capture commands, decisions, self-review notes, validation results, and anything that changes the plan.
 
+## 2026-06-07 10:31 EDT - PR112 Review Follow-Up
+
+Problem:
+
+- Gemini review flagged two medium-pressure UI maintainability issues:
+  - template method calls for pressure active state run on each Angular change detection cycle;
+  - `selectedVillainPressure` used a magic fallback array index.
+
+Actions:
+
+- Replaced the template method call with direct signal comparison: `selectedVillainPressureId() === pressure.id`.
+- Replaced the magic fallback index with a non-null assertion on the typed pressure lookup.
+- Removed the now-unused `isVillainPressureSelected()` method.
+
+Validation:
+
+- `git diff --check`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'"`: passed with `43 SUCCESS`.
+
 ## 2026-06-07 10:24 EDT - Story Lab Villain Pressure UI
 
 Actions:

--- a/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
+++ b/STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md
@@ -90,6 +90,10 @@ The key product goal is not "more features." The key product goal is a story stu
   - [x] added Desire Ledger, Continuity Keeper, and Chapter Ending notes;
   - [x] let users accept/dismiss notes or move a note into the custom continuation brief;
   - [x] sent accepted notes through the existing continuation job path.
+- [x] Started the Villain Pressure UI slice on `feature/story-lab-villain-pressure-ui`:
+  - [x] rendered pressure controls inside the existing continuation panel;
+  - [x] added antagonist, environment, secret, deadline, and inner-desire pressure choices;
+  - [x] composed selected pressure into UI-generated continuation briefs without changing direct continuation internals.
 - [ ] Leave final handoff describing what remains and what requires external provisioning.
 
 ## Surprises & Discoveries
@@ -144,6 +148,7 @@ The key product goal is not "more features." The key product goal is a story stu
   - Story Lab now shows a visible job banner when generation/continuation starts, runs, or is recovered after reload.
   - Story Lab now shows a visible batch queue so users can see and clear completed/failed generation batches.
   - Story Lab now shows the first Director's Room panel so users can turn craft notes into the next continuation request.
+  - Story Lab now lets users choose the pressure source for the next continuation.
 - What became better technically:
   - Story Lab stream parsing accepts the same expanded creature set as the Charmed UI.
   - Heat Contract data is typed in frontend contracts, mapped through the Story Lab engine, and preserved in the classic generation context.
@@ -158,6 +163,7 @@ The key product goal is not "more features." The key product goal is a story stu
   - The Angular UI now has signal-backed job status state that mirrors job lifecycle and recovery without adding routes or backend contracts.
   - The Angular UI now renders the existing batch queue state instead of keeping it hidden behind component internals.
   - The Angular UI now has deterministic Director's Room note state that reuses existing continuation jobs instead of adding backend review routes.
+  - The Angular UI now composes Villain Pressure choices in public continuation handlers without changing the lower-level job request seam.
 - What was intentionally deferred:
   - Accounts, cloud storage, durable Workflow execution, owner-scoped job persistence, cold-start-safe job resume, Blob export, email, and audio runtime.
 - What hostile review still objected to:
@@ -175,6 +181,7 @@ The key product goal is not "more features." The key product goal is a story stu
   - Phase D job status UI focused checks passed: RED targeted Angular app spec failed on missing rendered banner, PR follow-up RED failed on missing progress rendering `NaN%`, then GREEN targeted Angular app spec passed with `34 SUCCESS`.
   - Phase D batch queue UI focused checks passed: RED targeted Angular app spec failed on missing rendered batch queue, then GREEN targeted Angular app spec passed with `36 SUCCESS`; `git diff --check`, app/spec TypeScript compiles, function count at `10/12`, and mocked browser smoke also passed.
   - Director's Room UI focused checks passed: RED targeted Angular app spec failed on missing rendered panel/actions, then GREEN targeted Angular app spec passed with `40 SUCCESS`; `git diff --check`, app/spec TypeScript compiles, and function count at `10/12` passed; the first mocked browser smoke failed on the `app.css` hard budget, then passed after reusing existing list/grid styles and trimming CSS under 15 kB.
+  - Villain Pressure UI focused checks passed: RED targeted Angular app spec failed on missing rendered pressure dial and pressure text, then GREEN targeted Angular app spec passed with `43 SUCCESS`; `git diff --check`, app/spec TypeScript compiles, function count at `10/12`, and mocked browser smoke passed.
 
 ## Context and Orientation
 

--- a/STORY_LAB_VILLAIN_PRESSURE_UI_EXEC_PLAN.md
+++ b/STORY_LAB_VILLAIN_PRESSURE_UI_EXEC_PLAN.md
@@ -1,0 +1,141 @@
+# Story Lab Villain Pressure UI ExecPlan
+
+Created: 2026-06-07 10:24 EDT
+
+## Purpose / Big Picture
+
+Add the next small continuation UI control from the platform plan: a Villain Pressure Dial. Once a story exists, users should choose what kind of pressure drives the next chapter: antagonist, environment, secret, deadline, or inner desire. The selected pressure becomes part of the existing continuation job request.
+
+This is UI-only. It does not add backend routes, storage, auth, providers, or durable workflow behavior.
+
+## Progress
+
+- [x] Created `feature/story-lab-villain-pressure-ui` from `main` after PR #111 merged.
+- [x] Chose the smallest implementation: a selected pressure signal plus visible buttons in the existing continuation panel.
+- [x] Hostile review constrained the slice to continuation-brief composition only.
+- [x] Add failing Angular specs for pressure dial rendering and continuation request wiring.
+- [x] Implement pressure options, selection, brief composition, template, and minimal styles.
+- [ ] Update docs, run verification, commit, push PR, address comments/checks, and merge if clean.
+
+## Surprises & Discoveries
+
+- The existing continuation directions and Director's Room notes already create continuation briefs, so pressure should compose with those paths rather than replacing them.
+
+## Decision Log
+
+- Decision: Compose pressure text into continuation briefs at the UI level.
+  Rationale: This keeps the feature observable and testable without adding backend scope.
+- Decision: Default pressure is `secret`.
+  Rationale: It fits the existing dark-romance story tone without forcing overt violence or external combat.
+
+## Outcomes & Retrospective
+
+- What became better for users: Continuation now has a visible pressure dial, so users can choose whether the next chapter is pushed by the antagonist, environment, a secret, a deadline, or inner desire.
+- What became better technically: Pressure is composed through existing UI continuation handlers and existing continuation jobs; direct `continueSaga()` remains unchanged.
+- What was intentionally deferred: AI villain planning, durable pressure history, account sync, and backend pressure contracts.
+- What hostile review still objected to: The dial is a brief-shaping control, not a true villain engine.
+- What validation proved: RED/GREEN app specs proved the dial renders after a story exists and selected pressure is included in both normal continuation and Director's Room continuation requests.
+
+## Hostile Review
+
+Critical risks:
+
+- The dial could silently change direct low-level `continueSaga()` calls in tests or internals.
+  Fix: compose pressure only through public UI handlers (`continueWithDirection`, `continueWithCustomDirection`, and `continueWithDirectorRoomNotes`), not inside `continueSaga()` itself.
+- The dial could become a fake antagonist engine.
+  Fix: copy says pressure, and the output is only a brief string sent to existing continuation jobs.
+
+Important risks:
+
+- Selected pressure could disappear from the request when users use Director's Room notes.
+  Fix: tests must prove the selected pressure is included in continuation request text.
+- Extra CSS could break the tight app.css budget again.
+  Fix: reuse `.direction-grid` and `.prompt-chip`; add little or no CSS.
+
+## Plan of Work
+
+### Task 1: RED Specs
+
+Files:
+
+- Modify `story-generator/src/app/app.spec.ts`.
+
+Steps:
+
+- [x] Add a spec proving the pressure dial renders after a story exists.
+- [x] Add a spec proving selecting `Deadline` and clicking `Continue Story` sends deadline pressure through `createStoryLabJob`.
+- [x] Add a spec proving Director's Room accepted notes include the selected pressure when continued.
+- [x] Run focused app spec and confirm the new tests fail before implementation.
+
+### Task 2: UI Implementation
+
+Files:
+
+- Modify `story-generator/src/app/app.ts`.
+- Modify `story-generator/src/app/app.html`.
+- Modify `story-generator/src/app/app.css` only if existing classes cannot handle the dial.
+
+Steps:
+
+- [x] Add `VillainPressureOption` type and five options.
+- [x] Add selected pressure signal and helper methods.
+- [x] Compose selected pressure into UI-generated continuation briefs.
+- [x] Render the dial inside the existing continuation panel.
+- [x] Keep CSS minimal by reusing existing grid/chip styles.
+
+### Task 3: Docs And Verification
+
+Files:
+
+- Modify `AGENTS.md`.
+- Modify `PR70_RECOVERY_CHANGELOG.md`.
+- Modify `STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md`.
+- Modify this plan.
+
+Steps:
+
+- [x] Link this plan from `AGENTS.md`.
+- [x] Record the slice and validation evidence.
+- [x] Run:
+
+```bash
+git diff --check
+npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"
+npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"
+npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'"
+scripts/recovery/check-vercel-function-count.sh
+npm run smoke:story-lab-ui
+```
+
+Expected: all commands pass; function count remains `10/12`; `app.css` stays under the hard production budget.
+
+Actual validation:
+
+- RED: focused Angular app spec failed with 3 expected pressure-dial failures before implementation because the dial and pressure text were missing.
+- `git diff --check`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`: passed.
+- `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'"`: passed with `43 SUCCESS`.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
+- `npm run smoke:story-lab-ui`: passed in mock mode; production build still has warning-level initial bundle and CSS budget warnings, but `app.css` remains under the 15 kB hard limit.
+
+## Validation and Acceptance
+
+Accepted when:
+
+- The pressure dial appears only when continuation controls are visible.
+- The selected pressure visibly changes.
+- UI-generated continuation requests include the selected pressure text.
+- Existing direct `continueSaga(brief)` behavior remains unchanged.
+- No backend or route count changes happen.
+
+## Idempotence and Recovery
+
+- If tests show pressure composition duplicates text, centralize it in one helper.
+- If CSS budget fails, remove custom CSS and rely on existing chip/grid classes.
+- If review says the dial overpromises villain intelligence, rename text toward "pressure" and keep backend scope unchanged.
+
+## Interfaces and Dependencies
+
+- Existing continuation methods: `continueWithDirection`, `continueWithCustomDirection`, `continueWithDirectorRoomNotes`, and `continueSaga`.
+- Existing job seam: `StoryService.createStoryLabJob({ kind: 'continuation', continuation: { continuationBrief } })`.

--- a/story-generator/src/app/app.html
+++ b/story-generator/src/app/app.html
@@ -476,6 +476,25 @@
           <p class="eyebrow">Next chapter</p>
           <h3>Where should it go?</h3>
         </div>
+        <div data-testid="villain-pressure-dial">
+          <p class="eyebrow">Villain Pressure</p>
+          <p class="muted">{{ selectedVillainPressure().description }}</p>
+          <div class="heat-option-grid">
+            <button
+              type="button"
+              class="heat-option"
+              data-testid="villain-pressure-option"
+              [attr.data-pressure-id]="pressure.id"
+              [class.heat-option--active]="isVillainPressureSelected(pressure)"
+              *ngFor="let pressure of villainPressureOptions; trackBy: trackVillainPressure"
+              (click)="selectVillainPressure(pressure.id)"
+              [disabled]="isGenerating()"
+            >
+              <strong>{{ pressure.label }}</strong>
+              <span>{{ pressure.description }}</span>
+            </button>
+          </div>
+        </div>
         <div class="direction-grid">
           <button
             type="button"

--- a/story-generator/src/app/app.html
+++ b/story-generator/src/app/app.html
@@ -485,7 +485,7 @@
               class="heat-option"
               data-testid="villain-pressure-option"
               [attr.data-pressure-id]="pressure.id"
-              [class.heat-option--active]="isVillainPressureSelected(pressure)"
+              [class.heat-option--active]="selectedVillainPressureId() === pressure.id"
               *ngFor="let pressure of villainPressureOptions; trackBy: trackVillainPressure"
               (click)="selectVillainPressure(pressure.id)"
               [disabled]="isGenerating()"

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -375,6 +375,15 @@ describe('App', () => {
     return renderedDirectorRoomPanel(targetFixture)?.textContent?.replace(/\s+/g, ' ').trim() ?? null;
   }
 
+  function renderedVillainPressureDial(targetFixture: ComponentFixture<App> = fixture): HTMLElement | null {
+    targetFixture.detectChanges();
+    return targetFixture.nativeElement.querySelector('[data-testid="villain-pressure-dial"]') as HTMLElement | null;
+  }
+
+  function renderedVillainPressureText(targetFixture: ComponentFixture<App> = fixture): string | null {
+    return renderedVillainPressureDial(targetFixture)?.textContent?.replace(/\s+/g, ' ').trim() ?? null;
+  }
+
   it('creates the workbench with default blueprint values', () => {
     expect(component.blueprint().creature).toBe('vampire');
     expect(component.blueprint().tone).toBe('dark_romance');
@@ -656,6 +665,65 @@ describe('App', () => {
     expect(jobRequest.continuation.continuationBrief).toContain('Director Room notes');
     expect(jobRequest.continuation.continuationBrief).toContain('Desire Ledger');
     expect(jobRequest.continuation.continuationBrief).toContain('Continuity Keeper');
+  });
+
+  it('renders a villain pressure dial after a story exists', () => {
+    seedWorkbenchForContinuation();
+
+    const pressureText = renderedVillainPressureText();
+
+    expect(pressureText).toContain('Villain Pressure');
+    expect(pressureText).toContain('Secret');
+    expect(pressureText).toContain('Deadline');
+  });
+
+  it('continues with selected deadline pressure through the existing job flow', () => {
+    const genesisPayload = seedWorkbenchForContinuation();
+    const continuationPayload = createContinuationPayload(genesisPayload);
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(continuationPayload)
+    }));
+
+    const deadlineButton = renderedVillainPressureDial()?.querySelector('[data-pressure-id="deadline"]') as HTMLButtonElement | null;
+    deadlineButton?.click();
+    fixture.detectChanges();
+    const continueButton = fixture.nativeElement.querySelector('[data-testid="continue-saga"]') as HTMLButtonElement;
+    continueButton.click();
+
+    expect(storyService.continueStory).not.toHaveBeenCalled();
+    const jobRequest = storyService.createStoryLabJob.calls.mostRecent().args[0] as {
+      kind: 'continuation';
+      continuation: { continuationBrief?: string };
+    };
+    expect(jobRequest.kind).toBe('continuation');
+    expect(jobRequest.continuation.continuationBrief).toContain('tight deadline');
+  });
+
+  it('adds selected pressure to Director Room continuation notes', () => {
+    const genesisPayload = seedWorkbenchForContinuation();
+    const continuationPayload = createContinuationPayload(genesisPayload);
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(continuationPayload)
+    }));
+
+    const environmentButton = renderedVillainPressureDial()?.querySelector('[data-pressure-id="environment"]') as HTMLButtonElement | null;
+    environmentButton?.click();
+    fixture.detectChanges();
+    const acceptButton = renderedDirectorRoomPanel()?.querySelector('[data-testid="accept-director-note"]') as HTMLButtonElement | null;
+    acceptButton?.click();
+    fixture.detectChanges();
+    const continueButton = renderedDirectorRoomPanel()?.querySelector('[data-testid="continue-with-director-notes"]') as HTMLButtonElement | null;
+    continueButton?.click();
+
+    const jobRequest = storyService.createStoryLabJob.calls.mostRecent().args[0] as {
+      kind: 'continuation';
+      continuation: { continuationBrief?: string };
+    };
+    expect(jobRequest.kind).toBe('continuation');
+    expect(jobRequest.continuation.continuationBrief).toContain('Director Room notes');
+    expect(jobRequest.continuation.continuationBrief).toContain('environment itself');
   });
 
   it('defaults missing job progress to zero instead of rendering NaN', () => {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -74,6 +74,15 @@ type ContinuationDirection = {
   brief: string;
 };
 
+type VillainPressureId = 'antagonist' | 'environment' | 'secret' | 'deadline' | 'inner-desire';
+
+type VillainPressureOption = {
+  id: VillainPressureId;
+  label: string;
+  description: string;
+  brief: string;
+};
+
 type DirectorRoomNoteId = 'desire-ledger' | 'continuity-keeper' | 'chapter-ending';
 
 type DirectorRoomNoteStatus = 'pending' | 'accepted' | 'dismissed';
@@ -208,6 +217,39 @@ export class App implements OnDestroy {
     { label: 'Slow down and linger', brief: 'Slow down for atmosphere, longing, and character intimacy before the next plot turn.' }
   ];
 
+  readonly villainPressureOptions: VillainPressureOption[] = [
+    {
+      id: 'antagonist',
+      label: 'Antagonist',
+      description: 'Make the rival or villain act directly.',
+      brief: 'Villain Pressure: Let the antagonist directly raise the cost of the next choice.'
+    },
+    {
+      id: 'environment',
+      label: 'Environment',
+      description: 'Make the setting itself push back.',
+      brief: 'Villain Pressure: Let the environment itself become dangerous and force a decision.'
+    },
+    {
+      id: 'secret',
+      label: 'Secret',
+      description: 'Let hidden truth create pressure.',
+      brief: 'Villain Pressure: Let a secret create pressure before anyone fully explains it.'
+    },
+    {
+      id: 'deadline',
+      label: 'Deadline',
+      description: 'Put the scene under a clock.',
+      brief: 'Villain Pressure: Put the characters under a tight deadline that makes delay costly.'
+    },
+    {
+      id: 'inner-desire',
+      label: 'Inner Desire',
+      description: 'Make want itself the problem.',
+      brief: 'Villain Pressure: Let inner desire pressure the character into a dangerous choice.'
+    }
+  ];
+
   readonly blueprint = signal<BlueprintForm>({
     creature: 'vampire',
     themes: [],
@@ -241,6 +283,7 @@ export class App implements OnDestroy {
   readonly collapsedChapterGroups = signal<Set<number>>(new Set());
   readonly activeSkin = signal<StorySkinId>('writing-desk');
   readonly customContinuationBrief = signal('');
+  readonly selectedVillainPressureId = signal<VillainPressureId>('secret');
   readonly directorRoomDecisions = signal<Record<string, DirectorRoomNoteStatus>>({});
   readonly isGenerating = signal(false);
   readonly statusMessage = signal<string>('Tell us what kind of enchanted, spicy story you want.');
@@ -267,6 +310,9 @@ export class App implements OnDestroy {
     this.spiceOptions.find(option => option.level === Number(this.blueprint().spicyLevel)) ?? this.spiceOptions[2]
   );
   readonly activeHeatContract = computed(() => this.normalizeHeatContract(this.blueprint().heatContract));
+  readonly selectedVillainPressure = computed(() =>
+    this.villainPressureOptions.find(option => option.id === this.selectedVillainPressureId()) ?? this.villainPressureOptions[2]
+  );
 
   readonly timeline = computed<ChapterTimelineEntry[]>(() => {
     const session = this.workbench();
@@ -606,18 +652,26 @@ export class App implements OnDestroy {
   }
 
   continueWithDirection(direction: ContinuationDirection) {
-    this.continueSaga(direction.brief);
+    this.continueSaga(this.withVillainPressureBrief(direction.brief));
   }
 
   continueWithCustomDirection() {
     const brief = this.customContinuationBrief().trim();
     if (!brief) {
-      this.continueSaga();
+      this.continueSaga(this.withVillainPressureBrief());
       return;
     }
 
     this.customContinuationBrief.set('');
-    this.continueSaga(brief);
+    this.continueSaga(this.withVillainPressureBrief(brief));
+  }
+
+  selectVillainPressure(pressureId: VillainPressureId) {
+    this.selectedVillainPressureId.set(pressureId);
+  }
+
+  isVillainPressureSelected(option: VillainPressureOption): boolean {
+    return this.selectedVillainPressureId() === option.id;
   }
 
   acceptDirectorRoomNote(note: DirectorRoomNote) {
@@ -641,7 +695,7 @@ export class App implements OnDestroy {
       return;
     }
 
-    this.continueSaga(this.buildDirectorRoomContinuationBrief(acceptedNotes));
+    this.continueSaga(this.withVillainPressureBrief(this.buildDirectorRoomContinuationBrief(acceptedNotes)));
   }
 
   getSafeHtml(html: string): string {
@@ -1667,6 +1721,10 @@ ${chapters}
     return note.id;
   }
 
+  trackVillainPressure(_index: number, option: VillainPressureOption): string {
+    return option.id;
+  }
+
   formatDirectorRoomNoteStatus(status: DirectorRoomNoteStatus): string {
     switch (status) {
       case 'accepted':
@@ -1697,6 +1755,13 @@ ${chapters}
     ].join('\n');
 
     return customBrief ? `${customBrief}\n\n${directorBrief}` : directorBrief;
+  }
+
+  private withVillainPressureBrief(brief?: string): string {
+    const trimmedBrief = brief?.trim();
+    const pressureBrief = this.selectedVillainPressure().brief;
+
+    return trimmedBrief ? `${trimmedBrief}\n\n${pressureBrief}` : pressureBrief;
   }
 
   toggleChapterGroup(groupId: number) {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -311,7 +311,7 @@ export class App implements OnDestroy {
   );
   readonly activeHeatContract = computed(() => this.normalizeHeatContract(this.blueprint().heatContract));
   readonly selectedVillainPressure = computed(() =>
-    this.villainPressureOptions.find(option => option.id === this.selectedVillainPressureId()) ?? this.villainPressureOptions[2]
+    this.villainPressureOptions.find(option => option.id === this.selectedVillainPressureId())!
   );
 
   readonly timeline = computed<ChapterTimelineEntry[]>(() => {
@@ -668,10 +668,6 @@ export class App implements OnDestroy {
 
   selectVillainPressure(pressureId: VillainPressureId) {
     this.selectedVillainPressureId.set(pressureId);
-  }
-
-  isVillainPressureSelected(option: VillainPressureOption): boolean {
-    return this.selectedVillainPressureId() === option.id;
   }
 
   acceptDirectorRoomNote(note: DirectorRoomNote) {


### PR DESCRIPTION
## Summary
- Adds a Villain Pressure dial inside the existing Story Lab continuation panel.
- Adds five pressure choices: Antagonist, Environment, Secret, Deadline, and Inner Desire.
- Composes selected pressure into UI-generated continuation briefs for normal continuation, direction continuation, and Director Room continuation notes.
- Keeps direct `continueSaga(brief)` behavior unchanged and adds no backend routes, storage, providers, or workflow scope.
- Adds a self-contained ExecPlan and records the slice in recovery/platform docs.

## Verification
- RED: focused app spec failed with expected missing pressure dial / pressure text failures before implementation.
- git diff --check
- npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"
- npx -p node@20 -c "node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"
- npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/app.spec.ts'" passed with 43 SUCCESS
- scripts/recovery/check-vercel-function-count.sh passed at 10/12
- npm run smoke:story-lab-ui passed in mock mode; production build still has warning-level initial bundle/CSS budgets, but app.css remains under the 15 kB hard limit.

## Scope
- UI-only continuation pressure control.
- No route count change.
- No durable villain-planning engine or AI critique service.