### PR TITLE
Add Story Lab narrative dials UI

### DIFF
--- a/STORY_LAB_NARRATIVE_DIALS_UI_EXEC_PLAN.md
+++ b/STORY_LAB_NARRATIVE_DIALS_UI_EXEC_PLAN.md
@@ -1,0 +1,72 @@
+# Story Lab Narrative Dials UI ExecPlan
+
+## Goal
+
+Give Story Lab one shared continuation-dial system and ship the next three compact controls: Chapter Payload, Pacing, and Ending Bet. Keep Villain Pressure as the first dial in that system.
+
+## Plan v1
+
+- Generalize the existing Villain Pressure option data into a shared narrative-dial model.
+- Render Villain Pressure, Chapter Payload, Pacing, and Ending Bet in the existing continuation panel.
+- Store clean internal option IDs while sending only prose anchors into the continuation brief.
+- Append selected dial anchors to UI-driven continuation requests:
+  - continuation direction buttons;
+  - custom continuation brief;
+  - Director's Room accepted notes.
+- Preserve the lower-level `continueSaga(brief)` seam so direct service callers are not forced through UI-generated dial text.
+- Add focused Angular tests before production code.
+- Run focused specs, TypeScript checks, function-count guard, whitespace check, and mocked Story Lab UI smoke.
+
+## Hostile Critique
+
+- Four visible dials can turn the continuation panel into a cockpit instead of a story-steering surface.
+- A generic model can become over-abstracted if it only saves a few lines of code.
+- Prompt anchors can become noisy if every dial emits long instructions.
+- Replacing Villain Pressure markup can break reviewed selectors and existing smoke assumptions.
+- Any CSS growth is risky because the app has a hard smoke budget for `app.css`.
+
+## Revised Plan
+
+- Keep the shared model local to `app.ts` for now. Do not create new contracts, routes, or persistence.
+- Use compact, deterministic data:
+  - `NarrativeDial`
+  - `NarrativeDialOption`
+  - selected option IDs in one signal map.
+- Render all dials with the already-budgeted `heat-option-grid` and `heat-option` classes.
+- Keep one-sentence prose anchors. The AI receives story behavior, not numeric levels.
+- Preserve compatibility test IDs for Villain Pressure and add generic test IDs for all dials.
+- Prove:
+  - all four dials render after a story exists;
+  - selecting Chapter Payload, Pacing, and Ending Bet changes the active selections;
+  - UI-driven continuation requests include the selected prose anchors;
+  - `continueSaga(brief)` remains unchanged and does not append UI-only dial anchors.
+
+## Validation Checklist
+
+- [x] RED focused Angular spec fails for missing narrative dials.
+- [x] GREEN focused Angular spec passes.
+- [x] `git diff --check`
+- [x] `npx -p node@20 -c "node story-generator/node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`
+- [x] `npx -p node@20 -c "node story-generator/node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`
+- [x] Focused Angular app spec run.
+- [x] Full Angular app spec run.
+- [x] `scripts/recovery/check-vercel-function-count.sh`
+- [x] `npm run smoke:story-lab-ui`
+
+## Validation Evidence
+
+- RED focused app spec: `3 FAILED, 43 SUCCESS`; failures were missing narrative dials and missing dial prose anchors.
+- GREEN focused app spec: `46 SUCCESS`.
+- Isolated error logging regression: RED `1 FAILED, 6 SUCCESS`, then GREEN `7 SUCCESS`.
+- Full Angular suite: `83 SUCCESS`.
+- `git diff --check`: clean.
+- App TypeScript compile: clean.
+- Spec TypeScript compile: clean.
+- Vercel function count: `10/12`.
+- Story Lab browser smoke: passed in mock mode. Build warnings remained the known initial bundle budget warning and `app.css` at `14.95 kB`.
+
+## Stop Conditions
+
+- Stop and revise if the continuation panel needs substantial new layout or CSS.
+- Stop and split scope if this needs backend contract changes.
+- Stop and report if validation repeatedly fails outside this slice.

--- a/STORY_LAB_NARRATIVE_DIALS_UI_EXEC_PLAN.md
+++ b/STORY_LAB_NARRATIVE_DIALS_UI_EXEC_PLAN.md
@@ -67,7 +67,7 @@ Give Story Lab one shared continuation-dial system and ship the next three compa
 - Spec TypeScript compile: clean.
 - Vercel function count: `10/12`.
 - Story Lab browser smoke: passed in mock mode. Build warnings remained the known initial bundle budget warning and `app.css` at `14.95 kB`.
-- Sonar duplication follow-up: repeated dial option object literals were compacted behind `defineNarrativeDialOptions`.
+- Sonar duplication follow-up: repeated dial option object literals and dial object blocks were compacted behind `defineNarrativeDialOptions` and `defineNarrativeDial`.
 
 ## Stop Conditions
 

--- a/STORY_LAB_NARRATIVE_DIALS_UI_EXEC_PLAN.md
+++ b/STORY_LAB_NARRATIVE_DIALS_UI_EXEC_PLAN.md
@@ -49,21 +49,25 @@ Give Story Lab one shared continuation-dial system and ship the next three compa
 - [x] `npx -p node@20 -c "node story-generator/node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit"`
 - [x] `npx -p node@20 -c "node story-generator/node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit"`
 - [x] Focused Angular app spec run.
-- [x] Full Angular app spec run.
+- [x] Isolated error logging spec run.
+- [x] Remaining Angular spec shard run.
+- [x] Full Angular suite attempted; one-piece run hit Chrome capture/ping timeout after bundle generation, so specs were verified in shards.
 - [x] `scripts/recovery/check-vercel-function-count.sh`
 - [x] `npm run smoke:story-lab-ui`
 
 ## Validation Evidence
 
 - RED focused app spec: `3 FAILED, 43 SUCCESS`; failures were missing narrative dials and missing dial prose anchors.
-- GREEN focused app spec: `46 SUCCESS`.
-- Isolated error logging regression: RED `1 FAILED, 6 SUCCESS`, then GREEN `7 SUCCESS`.
-- Full Angular suite: `83 SUCCESS`.
+- GREEN focused app spec after CodeRabbit option-coverage expansion: `47 SUCCESS`.
+- Gemini/CodeRabbit circular `Error.cause` review fix: RED isolated error logging spec `1 FAILED, 7 SUCCESS`, then GREEN `8 SUCCESS`.
+- Remaining Angular spec shard: `30 SUCCESS` across debug panel, streaming story, workspace storage, story service, form validation, error display, and notification specs.
+- Full Angular suite one-piece retry: build completed, but Chrome disconnected with a ping timeout before completing specs. The app, error logging, and remaining shards covered the same spec files with `85 SUCCESS` total.
 - `git diff --check`: clean.
 - App TypeScript compile: clean.
 - Spec TypeScript compile: clean.
 - Vercel function count: `10/12`.
 - Story Lab browser smoke: passed in mock mode. Build warnings remained the known initial bundle budget warning and `app.css` at `14.95 kB`.
+- Sonar duplication follow-up: repeated dial option object literals were compacted behind `defineNarrativeDialOptions`.
 
 ## Stop Conditions
 

--- a/story-generator/src/app/app.html
+++ b/story-generator/src/app/app.html
@@ -476,23 +476,32 @@
           <p class="eyebrow">Next chapter</p>
           <h3>Where should it go?</h3>
         </div>
-        <div data-testid="villain-pressure-dial">
-          <p class="eyebrow">Villain Pressure</p>
-          <p class="muted">{{ selectedVillainPressure().description }}</p>
-          <div class="heat-option-grid">
-            <button
-              type="button"
-              class="heat-option"
-              data-testid="villain-pressure-option"
-              [attr.data-pressure-id]="pressure.id"
-              [class.heat-option--active]="selectedVillainPressureId() === pressure.id"
-              *ngFor="let pressure of villainPressureOptions; trackBy: trackVillainPressure"
-              (click)="selectVillainPressure(pressure.id)"
-              [disabled]="isGenerating()"
-            >
-              <strong>{{ pressure.label }}</strong>
-              <span>{{ pressure.description }}</span>
-            </button>
+        <div
+          class="heat-option-group"
+          data-testid="narrative-dial"
+          [attr.data-dial-id]="dial.id"
+          *ngFor="let dial of narrativeDialViewModels(); trackBy: trackNarrativeDial"
+        >
+          <div [attr.data-testid]="dial.id === 'villain-pressure' ? 'villain-pressure-dial' : null">
+            <p class="eyebrow">{{ dial.label }}</p>
+            <p class="muted">{{ dial.selectedDescription }}</p>
+            <div class="heat-option-grid">
+              <button
+                type="button"
+                class="heat-option"
+                [attr.data-testid]="dial.id === 'villain-pressure' ? 'villain-pressure-option' : 'narrative-dial-option'"
+                [attr.data-dial-option-id]="option.id"
+                [attr.data-pressure-id]="dial.id === 'villain-pressure' ? option.id : null"
+                [attr.aria-pressed]="dial.selectedOptionId === option.id"
+                [class.heat-option--active]="dial.selectedOptionId === option.id"
+                *ngFor="let option of dial.options; trackBy: trackNarrativeDialOption"
+                (click)="selectNarrativeDialOption(dial.id, option.id)"
+                [disabled]="isGenerating()"
+              >
+                <strong>{{ option.label }}</strong>
+                <span>{{ option.description }}</span>
+              </button>
+            </div>
           </div>
         </div>
         <div class="direction-grid">

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -766,6 +766,41 @@ describe('App', () => {
     expect(jobRequest.continuation.continuationBrief).toContain('Villain Pressure: Put the characters under a tight deadline');
   });
 
+  it('supports every narrative dial option in the UI and continuation brief', () => {
+    const genesisPayload = seedWorkbenchForContinuation();
+    const continuationPayload = createContinuationPayload(genesisPayload);
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(continuationPayload)
+    }));
+
+    for (const dial of component.narrativeDials) {
+      for (const option of dial.options) {
+        const optionButton = renderedNarrativeDial(dial.id)
+          ?.querySelector(`[data-dial-option-id="${option.id}"]`) as HTMLButtonElement | null;
+
+        expect(optionButton)
+          .withContext(`${dial.id} should render option ${option.id}`)
+          .not.toBeNull();
+
+        optionButton?.click();
+        fixture.detectChanges();
+        component.continueWithCustomDirection();
+
+        const dialText = renderedNarrativeDialText(dial.id) ?? '';
+        const jobRequest = storyService.createStoryLabJob.calls.mostRecent().args[0] as {
+          kind: 'continuation';
+          continuation: { continuationBrief?: string };
+        };
+
+        expect(dialText).withContext(`${dial.id} should show option ${option.id} description`).toContain(option.description);
+        expect(jobRequest.continuation.continuationBrief)
+          .withContext(`${dial.id} should include option ${option.id} brief`)
+          .toContain(option.brief);
+      }
+    }
+  });
+
   it('adds selected pressure to Director Room continuation notes', () => {
     const genesisPayload = seedWorkbenchForContinuation();
     const continuationPayload = createContinuationPayload(genesisPayload);

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -384,6 +384,15 @@ describe('App', () => {
     return renderedVillainPressureDial(targetFixture)?.textContent?.replace(/\s+/g, ' ').trim() ?? null;
   }
 
+  function renderedNarrativeDial(dialId: string, targetFixture: ComponentFixture<App> = fixture): HTMLElement | null {
+    targetFixture.detectChanges();
+    return targetFixture.nativeElement.querySelector(`[data-testid="narrative-dial"][data-dial-id="${dialId}"]`) as HTMLElement | null;
+  }
+
+  function renderedNarrativeDialText(dialId: string, targetFixture: ComponentFixture<App> = fixture): string | null {
+    return renderedNarrativeDial(dialId, targetFixture)?.textContent?.replace(/\s+/g, ' ').trim() ?? null;
+  }
+
   it('creates the workbench with default blueprint values', () => {
     expect(component.blueprint().creature).toBe('vampire');
     expect(component.blueprint().tone).toBe('dark_romance');
@@ -677,6 +686,36 @@ describe('App', () => {
     expect(pressureText).toContain('Deadline');
   });
 
+  it('renders compact narrative dials for continuation steering after a story exists', () => {
+    seedWorkbenchForContinuation();
+    fixture.detectChanges();
+
+    const dials = fixture.nativeElement.querySelectorAll('[data-testid="narrative-dial"]') as NodeListOf<HTMLElement>;
+
+    expect(dials.length).toBe(4);
+    expect(renderedNarrativeDialText('villain-pressure')).toContain('Villain Pressure');
+    expect(renderedNarrativeDialText('chapter-payload')).toContain('Chapter Payload');
+    expect(renderedNarrativeDialText('pacing')).toContain('Pacing');
+    expect(renderedNarrativeDialText('ending-bet')).toContain('Ending Bet');
+    expect(renderedNarrativeDialText('chapter-payload')).toContain('More romance');
+    expect(renderedNarrativeDialText('pacing')).toContain('Escalate');
+    expect(renderedNarrativeDialText('ending-bet')).toContain('Betrayal');
+  });
+
+  it('updates selected narrative dial descriptions without exposing numeric levels', () => {
+    seedWorkbenchForContinuation();
+
+    const dangerButton = renderedNarrativeDial('chapter-payload')
+      ?.querySelector('[data-dial-option-id="danger"]') as HTMLButtonElement | null;
+    dangerButton?.click();
+    fixture.detectChanges();
+
+    const payloadText = renderedNarrativeDialText('chapter-payload') ?? '';
+    expect(payloadText).toContain('Move the threat close enough');
+    expect(payloadText).not.toContain('1/5');
+    expect(payloadText).not.toContain('level 3');
+  });
+
   it('continues with selected deadline pressure through the existing job flow', () => {
     const genesisPayload = seedWorkbenchForContinuation();
     const continuationPayload = createContinuationPayload(genesisPayload);
@@ -698,6 +737,33 @@ describe('App', () => {
     };
     expect(jobRequest.kind).toBe('continuation');
     expect(jobRequest.continuation.continuationBrief).toContain('tight deadline');
+  });
+
+  it('adds selected narrative dial prose anchors to UI-driven continuation briefs', () => {
+    const genesisPayload = seedWorkbenchForContinuation();
+    const continuationPayload = createContinuationPayload(genesisPayload);
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(continuationPayload)
+    }));
+
+    (renderedNarrativeDial('chapter-payload')?.querySelector('[data-dial-option-id="romance"]') as HTMLButtonElement | null)?.click();
+    (renderedNarrativeDial('pacing')?.querySelector('[data-dial-option-id="sprint"]') as HTMLButtonElement | null)?.click();
+    (renderedNarrativeDial('ending-bet')?.querySelector('[data-dial-option-id="betrayal"]') as HTMLButtonElement | null)?.click();
+    (renderedVillainPressureDial()?.querySelector('[data-pressure-id="deadline"]') as HTMLButtonElement | null)?.click();
+    fixture.detectChanges();
+    const continueButton = fixture.nativeElement.querySelector('[data-testid="continue-saga"]') as HTMLButtonElement;
+    continueButton.click();
+
+    const jobRequest = storyService.createStoryLabJob.calls.mostRecent().args[0] as {
+      kind: 'continuation';
+      continuation: { continuationBrief?: string };
+    };
+    expect(jobRequest.kind).toBe('continuation');
+    expect(jobRequest.continuation.continuationBrief).toContain('Chapter Payload: Put desire under pressure');
+    expect(jobRequest.continuation.continuationBrief).toContain('Pacing: Sprint toward a cliffhanger');
+    expect(jobRequest.continuation.continuationBrief).toContain('Ending Bet: Build the ending around betrayal');
+    expect(jobRequest.continuation.continuationBrief).toContain('Villain Pressure: Put the characters under a tight deadline');
   });
 
   it('adds selected pressure to Director Room continuation notes', () => {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -74,13 +74,33 @@ type ContinuationDirection = {
   brief: string;
 };
 
-type VillainPressureId = 'antagonist' | 'environment' | 'secret' | 'deadline' | 'inner-desire';
+type NarrativeDialId = 'villain-pressure' | 'chapter-payload' | 'pacing' | 'ending-bet';
 
-type VillainPressureOption = {
-  id: VillainPressureId;
+type NarrativeDialOption = {
+  id: string;
   label: string;
   description: string;
   brief: string;
+};
+
+type NarrativeDial = {
+  id: NarrativeDialId;
+  label: string;
+  options: NarrativeDialOption[];
+};
+
+type NarrativeDialViewModel = NarrativeDial & {
+  selectedOptionId: string;
+  selectedDescription: string;
+  selectedBrief: string;
+};
+
+type SelectedNarrativeDialOptions = Record<NarrativeDialId, string>;
+
+type VillainPressureId = 'antagonist' | 'environment' | 'secret' | 'deadline' | 'inner-desire';
+
+type VillainPressureOption = NarrativeDialOption & {
+  id: VillainPressureId;
 };
 
 type DirectorRoomNoteId = 'desire-ledger' | 'continuity-keeper' | 'chapter-ending';
@@ -250,6 +270,116 @@ export class App implements OnDestroy {
     }
   ];
 
+  readonly narrativeDials: NarrativeDial[] = [
+    {
+      id: 'villain-pressure',
+      label: 'Villain Pressure',
+      options: this.villainPressureOptions
+    },
+    {
+      id: 'chapter-payload',
+      label: 'Chapter Payload',
+      options: [
+        {
+          id: 'romance',
+          label: 'More romance',
+          description: 'Put desire under pressure.',
+          brief: 'Chapter Payload: Put desire under pressure and reveal it through behavior, restraint, jealousy, protection, or sacrifice.'
+        },
+        {
+          id: 'danger',
+          label: 'More danger',
+          description: 'Move the threat close enough that it changes what the characters do next.',
+          brief: 'Chapter Payload: Move the threat close enough that it changes what the characters do next.'
+        },
+        {
+          id: 'lore',
+          label: 'More lore',
+          description: 'Reveal one world rule and make it personal.',
+          brief: 'Chapter Payload: Reveal one rule of the world, but make it personal and costly.'
+        },
+        {
+          id: 'intimacy',
+          label: 'More intimacy',
+          description: 'Deepen trust, vulnerability, or consent.',
+          brief: 'Chapter Payload: Deepen trust, vulnerability, or consent through behavior rather than explanation.'
+        },
+        {
+          id: 'plot',
+          label: 'More plot',
+          description: 'Change the situation in a way nobody can ignore.',
+          brief: 'Chapter Payload: Change the situation in a concrete way that nobody can ignore.'
+        }
+      ]
+    },
+    {
+      id: 'pacing',
+      label: 'Pacing',
+      options: [
+        {
+          id: 'linger',
+          label: 'Linger',
+          description: 'Slow down for texture, longing, and consequence.',
+          brief: 'Pacing: Linger on texture, longing, and consequence before the next turn.'
+        },
+        {
+          id: 'balanced',
+          label: 'Balanced',
+          description: 'Move plot and emotion together.',
+          brief: 'Pacing: Balance external movement with emotional consequence.'
+        },
+        {
+          id: 'escalate',
+          label: 'Escalate',
+          description: 'Make each beat cost more than the last.',
+          brief: 'Pacing: Escalate so each beat costs more than the last.'
+        },
+        {
+          id: 'sprint',
+          label: 'Sprint',
+          description: 'Drive hard toward a cliffhanger.',
+          brief: 'Pacing: Sprint toward a cliffhanger without skipping the emotional cost.'
+        }
+      ]
+    },
+    {
+      id: 'ending-bet',
+      label: 'Ending Bet',
+      options: [
+        {
+          id: 'revelation',
+          label: 'Revelation',
+          description: 'End by making hidden truth visible.',
+          brief: 'Ending Bet: Build the ending around a revelation that changes what came before.'
+        },
+        {
+          id: 'betrayal',
+          label: 'Betrayal',
+          description: 'End where trust breaks or appears to break.',
+          brief: 'Ending Bet: Build the ending around betrayal, and let behavior make the rupture land.'
+        },
+        {
+          id: 'impossible-choice',
+          label: 'Impossible choice',
+          description: 'End with no clean option left.',
+          brief: 'Ending Bet: Build the ending around an impossible choice with no clean escape.'
+        },
+        {
+          id: 'arrival',
+          label: 'Arrival',
+          description: 'End with someone or something entering too late.',
+          brief: 'Ending Bet: End with an arrival that changes the room before anyone is ready.'
+        },
+        {
+          id: 'deadline',
+          label: 'Deadline',
+          description: 'End when the clock becomes impossible to ignore.',
+          brief: 'Ending Bet: End by making the deadline impossible to ignore.'
+        }
+      ]
+    }
+  ];
+
   readonly blueprint = signal<BlueprintForm>({
     creature: 'vampire',
     themes: [],
@@ -283,7 +413,12 @@ export class App implements OnDestroy {
   readonly collapsedChapterGroups = signal<Set<number>>(new Set());
   readonly activeSkin = signal<StorySkinId>('writing-desk');
   readonly customContinuationBrief = signal('');
-  readonly selectedVillainPressureId = signal<VillainPressureId>('secret');
+  readonly selectedNarrativeDialOptionIds = signal<SelectedNarrativeDialOptions>({
+    'villain-pressure': 'secret',
+    'chapter-payload': 'plot',
+    pacing: 'balanced',
+    'ending-bet': 'revelation'
+  });
   readonly directorRoomDecisions = signal<Record<string, DirectorRoomNoteStatus>>({});
   readonly isGenerating = signal(false);
   readonly statusMessage = signal<string>('Tell us what kind of enchanted, spicy story you want.');
@@ -310,8 +445,24 @@ export class App implements OnDestroy {
     this.spiceOptions.find(option => option.level === Number(this.blueprint().spicyLevel)) ?? this.spiceOptions[2]
   );
   readonly activeHeatContract = computed(() => this.normalizeHeatContract(this.blueprint().heatContract));
+  readonly narrativeDialViewModels = computed<NarrativeDialViewModel[]>(() => {
+    const selections = this.selectedNarrativeDialOptionIds();
+
+    return this.narrativeDials.map(dial => {
+      const selectedOption = this.getSelectedNarrativeDialOption(dial, selections);
+      return {
+        ...dial,
+        selectedOptionId: selectedOption.id,
+        selectedDescription: selectedOption.description,
+        selectedBrief: selectedOption.brief
+      };
+    });
+  });
+  readonly selectedVillainPressureId = computed(() =>
+    this.selectedNarrativeDialOptionIds()['villain-pressure'] as VillainPressureId
+  );
   readonly selectedVillainPressure = computed(() =>
-    this.villainPressureOptions.find(option => option.id === this.selectedVillainPressureId())!
+    this.villainPressureOptions.find(option => option.id === this.selectedVillainPressureId()) ?? this.villainPressureOptions[0]
   );
 
   readonly timeline = computed<ChapterTimelineEntry[]>(() => {
@@ -652,22 +803,34 @@ export class App implements OnDestroy {
   }
 
   continueWithDirection(direction: ContinuationDirection) {
-    this.continueSaga(this.withVillainPressureBrief(direction.brief));
+    this.continueSaga(this.withNarrativeDialBriefs(direction.brief));
   }
 
   continueWithCustomDirection() {
     const brief = this.customContinuationBrief().trim();
     if (!brief) {
-      this.continueSaga(this.withVillainPressureBrief());
+      this.continueSaga(this.withNarrativeDialBriefs());
       return;
     }
 
     this.customContinuationBrief.set('');
-    this.continueSaga(this.withVillainPressureBrief(brief));
+    this.continueSaga(this.withNarrativeDialBriefs(brief));
+  }
+
+  selectNarrativeDialOption(dialId: NarrativeDialId, optionId: string) {
+    const dial = this.narrativeDials.find(candidate => candidate.id === dialId);
+    if (!dial?.options.some(option => option.id === optionId)) {
+      return;
+    }
+
+    this.selectedNarrativeDialOptionIds.update(current => ({
+      ...current,
+      [dialId]: optionId
+    }));
   }
 
   selectVillainPressure(pressureId: VillainPressureId) {
-    this.selectedVillainPressureId.set(pressureId);
+    this.selectNarrativeDialOption('villain-pressure', pressureId);
   }
 
   acceptDirectorRoomNote(note: DirectorRoomNote) {
@@ -691,7 +854,7 @@ export class App implements OnDestroy {
       return;
     }
 
-    this.continueSaga(this.withVillainPressureBrief(this.buildDirectorRoomContinuationBrief(acceptedNotes)));
+    this.continueSaga(this.withNarrativeDialBriefs(this.buildDirectorRoomContinuationBrief(acceptedNotes)));
   }
 
   getSafeHtml(html: string): string {
@@ -1721,6 +1884,14 @@ ${chapters}
     return option.id;
   }
 
+  trackNarrativeDial(_index: number, dial: NarrativeDialViewModel): string {
+    return dial.id;
+  }
+
+  trackNarrativeDialOption(_index: number, option: NarrativeDialOption): string {
+    return option.id;
+  }
+
   formatDirectorRoomNoteStatus(status: DirectorRoomNoteStatus): string {
     switch (status) {
       case 'accepted':
@@ -1753,11 +1924,20 @@ ${chapters}
     return customBrief ? `${customBrief}\n\n${directorBrief}` : directorBrief;
   }
 
-  private withVillainPressureBrief(brief?: string): string {
-    const trimmedBrief = brief?.trim();
-    const pressureBrief = this.selectedVillainPressure().brief;
+  private getSelectedNarrativeDialOption(
+    dial: NarrativeDial,
+    selections: SelectedNarrativeDialOptions
+  ): NarrativeDialOption {
+    return dial.options.find(option => option.id === selections[dial.id]) ?? dial.options[0];
+  }
 
-    return trimmedBrief ? `${trimmedBrief}\n\n${pressureBrief}` : pressureBrief;
+  private withNarrativeDialBriefs(brief?: string): string {
+    const trimmedBrief = brief?.trim();
+    const dialBrief = this.narrativeDialViewModels()
+      .map(dial => dial.selectedBrief)
+      .join('\n');
+
+    return trimmedBrief ? `${trimmedBrief}\n\n${dialBrief}` : dialBrief;
   }
 
   toggleChapterGroup(groupId: number) {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -83,6 +83,13 @@ type NarrativeDialOption = {
   brief: string;
 };
 
+type NarrativeDialOptionDefinition<TId extends string = string> = readonly [
+  id: TId,
+  label: string,
+  description: string,
+  brief: string
+];
+
 type NarrativeDial = {
   id: NarrativeDialId;
   label: string;
@@ -102,6 +109,12 @@ type VillainPressureId = 'antagonist' | 'environment' | 'secret' | 'deadline' | 
 type VillainPressureOption = NarrativeDialOption & {
   id: VillainPressureId;
 };
+
+function defineNarrativeDialOptions<TId extends string>(
+  definitions: readonly NarrativeDialOptionDefinition<TId>[]
+): Array<NarrativeDialOption & { id: TId }> {
+  return definitions.map(([id, label, description, brief]) => ({ id, label, description, brief }));
+}
 
 type DirectorRoomNoteId = 'desire-ledger' | 'continuity-keeper' | 'chapter-ending';
 
@@ -237,38 +250,13 @@ export class App implements OnDestroy {
     { label: 'Slow down and linger', brief: 'Slow down for atmosphere, longing, and character intimacy before the next plot turn.' }
   ];
 
-  readonly villainPressureOptions: VillainPressureOption[] = [
-    {
-      id: 'antagonist',
-      label: 'Antagonist',
-      description: 'Make the rival or villain act directly.',
-      brief: 'Villain Pressure: Let the antagonist directly raise the cost of the next choice.'
-    },
-    {
-      id: 'environment',
-      label: 'Environment',
-      description: 'Make the setting itself push back.',
-      brief: 'Villain Pressure: Let the environment itself become dangerous and force a decision.'
-    },
-    {
-      id: 'secret',
-      label: 'Secret',
-      description: 'Let hidden truth create pressure.',
-      brief: 'Villain Pressure: Let a secret create pressure before anyone fully explains it.'
-    },
-    {
-      id: 'deadline',
-      label: 'Deadline',
-      description: 'Put the scene under a clock.',
-      brief: 'Villain Pressure: Put the characters under a tight deadline that makes delay costly.'
-    },
-    {
-      id: 'inner-desire',
-      label: 'Inner Desire',
-      description: 'Make want itself the problem.',
-      brief: 'Villain Pressure: Let inner desire pressure the character into a dangerous choice.'
-    }
-  ];
+  readonly villainPressureOptions: VillainPressureOption[] = defineNarrativeDialOptions<VillainPressureId>([
+    ['antagonist', 'Antagonist', 'Make the rival or villain act directly.', 'Villain Pressure: Let the antagonist directly raise the cost of the next choice.'],
+    ['environment', 'Environment', 'Make the setting itself push back.', 'Villain Pressure: Let the environment itself become dangerous and force a decision.'],
+    ['secret', 'Secret', 'Let hidden truth create pressure.', 'Villain Pressure: Let a secret create pressure before anyone fully explains it.'],
+    ['deadline', 'Deadline', 'Put the scene under a clock.', 'Villain Pressure: Put the characters under a tight deadline that makes delay costly.'],
+    ['inner-desire', 'Inner Desire', 'Make want itself the problem.', 'Villain Pressure: Let inner desire pressure the character into a dangerous choice.']
+  ]);
 
   readonly narrativeDials: NarrativeDial[] = [
     {
@@ -279,104 +267,34 @@ export class App implements OnDestroy {
     {
       id: 'chapter-payload',
       label: 'Chapter Payload',
-      options: [
-        {
-          id: 'romance',
-          label: 'More romance',
-          description: 'Put desire under pressure.',
-          brief: 'Chapter Payload: Put desire under pressure and reveal it through behavior, restraint, jealousy, protection, or sacrifice.'
-        },
-        {
-          id: 'danger',
-          label: 'More danger',
-          description: 'Move the threat close enough that it changes what the characters do next.',
-          brief: 'Chapter Payload: Move the threat close enough that it changes what the characters do next.'
-        },
-        {
-          id: 'lore',
-          label: 'More lore',
-          description: 'Reveal one world rule and make it personal.',
-          brief: 'Chapter Payload: Reveal one rule of the world, but make it personal and costly.'
-        },
-        {
-          id: 'intimacy',
-          label: 'More intimacy',
-          description: 'Deepen trust, vulnerability, or consent.',
-          brief: 'Chapter Payload: Deepen trust, vulnerability, or consent through behavior rather than explanation.'
-        },
-        {
-          id: 'plot',
-          label: 'More plot',
-          description: 'Change the situation in a way nobody can ignore.',
-          brief: 'Chapter Payload: Change the situation in a concrete way that nobody can ignore.'
-        }
-      ]
+      options: defineNarrativeDialOptions([
+        ['romance', 'More romance', 'Put desire under pressure.', 'Chapter Payload: Put desire under pressure and reveal it through behavior, restraint, jealousy, protection, or sacrifice.'],
+        ['danger', 'More danger', 'Move the threat close enough that it changes what the characters do next.', 'Chapter Payload: Move the threat close enough that it changes what the characters do next.'],
+        ['lore', 'More lore', 'Reveal one world rule and make it personal.', 'Chapter Payload: Reveal one rule of the world, but make it personal and costly.'],
+        ['intimacy', 'More intimacy', 'Deepen trust, vulnerability, or consent.', 'Chapter Payload: Deepen trust, vulnerability, or consent through behavior rather than explanation.'],
+        ['plot', 'More plot', 'Change the situation in a way nobody can ignore.', 'Chapter Payload: Change the situation in a concrete way that nobody can ignore.']
+      ])
     },
     {
       id: 'pacing',
       label: 'Pacing',
-      options: [
-        {
-          id: 'linger',
-          label: 'Linger',
-          description: 'Slow down for texture, longing, and consequence.',
-          brief: 'Pacing: Linger on texture, longing, and consequence before the next turn.'
-        },
-        {
-          id: 'balanced',
-          label: 'Balanced',
-          description: 'Move plot and emotion together.',
-          brief: 'Pacing: Balance external movement with emotional consequence.'
-        },
-        {
-          id: 'escalate',
-          label: 'Escalate',
-          description: 'Make each beat cost more than the last.',
-          brief: 'Pacing: Escalate so each beat costs more than the last.'
-        },
-        {
-          id: 'sprint',
-          label: 'Sprint',
-          description: 'Drive hard toward a cliffhanger.',
-          brief: 'Pacing: Sprint toward a cliffhanger without skipping the emotional cost.'
-        }
-      ]
+      options: defineNarrativeDialOptions([
+        ['linger', 'Linger', 'Slow down for texture, longing, and consequence.', 'Pacing: Linger on texture, longing, and consequence before the next turn.'],
+        ['balanced', 'Balanced', 'Move plot and emotion together.', 'Pacing: Balance external movement with emotional consequence.'],
+        ['escalate', 'Escalate', 'Make each beat cost more than the last.', 'Pacing: Escalate so each beat costs more than the last.'],
+        ['sprint', 'Sprint', 'Drive hard toward a cliffhanger.', 'Pacing: Sprint toward a cliffhanger without skipping the emotional cost.']
+      ])
     },
     {
       id: 'ending-bet',
       label: 'Ending Bet',
-      options: [
-        {
-          id: 'revelation',
-          label: 'Revelation',
-          description: 'End by making hidden truth visible.',
-          brief: 'Ending Bet: Build the ending around a revelation that changes what came before.'
-        },
-        {
-          id: 'betrayal',
-          label: 'Betrayal',
-          description: 'End where trust breaks or appears to break.',
-          brief: 'Ending Bet: Build the ending around betrayal, and let behavior make the rupture land.'
-        },
-        {
-          id: 'impossible-choice',
-          label: 'Impossible choice',
-          description: 'End with no clean option left.',
-          brief: 'Ending Bet: Build the ending around an impossible choice with no clean escape.'
-        },
-        {
-          id: 'arrival',
-          label: 'Arrival',
-          description: 'End with someone or something entering too late.',
-          brief: 'Ending Bet: End with an arrival that changes the room before anyone is ready.'
-        },
-        {
-          id: 'deadline',
-          label: 'Deadline',
-          description: 'End when the clock becomes impossible to ignore.',
-          brief: 'Ending Bet: End by making the deadline impossible to ignore.'
-        }
-      ]
+      options: defineNarrativeDialOptions([
+        ['revelation', 'Revelation', 'End by making hidden truth visible.', 'Ending Bet: Build the ending around a revelation that changes what came before.'],
+        ['betrayal', 'Betrayal', 'End where trust breaks or appears to break.', 'Ending Bet: Build the ending around betrayal, and let behavior make the rupture land.'],
+        ['impossible-choice', 'Impossible choice', 'End with no clean option left.', 'Ending Bet: Build the ending around an impossible choice with no clean escape.'],
+        ['arrival', 'Arrival', 'End with someone or something entering too late.', 'Ending Bet: End with an arrival that changes the room before anyone is ready.'],
+        ['deadline', 'Deadline', 'End when the clock becomes impossible to ignore.', 'Ending Bet: End by making the deadline impossible to ignore.']
+      ])
     }
   ];
 

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -266,40 +266,34 @@ export class App implements OnDestroy {
     ['inner-desire', 'Inner Desire', 'Make want itself the problem.', 'Villain Pressure: Let inner desire pressure the character into a dangerous choice.']
   ]);
 
+  readonly chapterPayloadOptions: NarrativeDialOption[] = defineNarrativeDialOptions([
+    ['romance', 'More romance', 'Put desire under pressure.', 'Chapter Payload: Put desire under pressure and reveal it through behavior, restraint, jealousy, protection, or sacrifice.'],
+    ['danger', 'More danger', 'Move the threat close enough that it changes what the characters do next.', 'Chapter Payload: Move the threat close enough that it changes what the characters do next.'],
+    ['lore', 'More lore', 'Reveal one world rule and make it personal.', 'Chapter Payload: Reveal one rule of the world, but make it personal and costly.'],
+    ['intimacy', 'More intimacy', 'Deepen trust, vulnerability, or consent.', 'Chapter Payload: Deepen trust, vulnerability, or consent through behavior rather than explanation.'],
+    ['plot', 'More plot', 'Change the situation in a way nobody can ignore.', 'Chapter Payload: Change the situation in a concrete way that nobody can ignore.']
+  ]);
+
+  readonly pacingOptions: NarrativeDialOption[] = defineNarrativeDialOptions([
+    ['linger', 'Linger', 'Slow down for texture, longing, and consequence.', 'Pacing: Linger on texture, longing, and consequence before the next turn.'],
+    ['balanced', 'Balanced', 'Move plot and emotion together.', 'Pacing: Balance external movement with emotional consequence.'],
+    ['escalate', 'Escalate', 'Make each beat cost more than the last.', 'Pacing: Escalate so each beat costs more than the last.'],
+    ['sprint', 'Sprint', 'Drive hard toward a cliffhanger.', 'Pacing: Sprint toward a cliffhanger without skipping the emotional cost.']
+  ]);
+
+  readonly endingBetOptions: NarrativeDialOption[] = defineNarrativeDialOptions([
+    ['revelation', 'Revelation', 'End by making hidden truth visible.', 'Ending Bet: Build the ending around a revelation that changes what came before.'],
+    ['betrayal', 'Betrayal', 'End where trust breaks or appears to break.', 'Ending Bet: Build the ending around betrayal, and let behavior make the rupture land.'],
+    ['impossible-choice', 'Impossible choice', 'End with no clean option left.', 'Ending Bet: Build the ending around an impossible choice with no clean escape.'],
+    ['arrival', 'Arrival', 'End with someone or something entering too late.', 'Ending Bet: End with an arrival that changes the room before anyone is ready.'],
+    ['deadline', 'Deadline', 'End when the clock becomes impossible to ignore.', 'Ending Bet: End by making the deadline impossible to ignore.']
+  ]);
+
   readonly narrativeDials: NarrativeDial[] = [
     defineNarrativeDial('villain-pressure', 'Villain Pressure', this.villainPressureOptions),
-    defineNarrativeDial(
-      'chapter-payload',
-      'Chapter Payload',
-      defineNarrativeDialOptions([
-        ['romance', 'More romance', 'Put desire under pressure.', 'Chapter Payload: Put desire under pressure and reveal it through behavior, restraint, jealousy, protection, or sacrifice.'],
-        ['danger', 'More danger', 'Move the threat close enough that it changes what the characters do next.', 'Chapter Payload: Move the threat close enough that it changes what the characters do next.'],
-        ['lore', 'More lore', 'Reveal one world rule and make it personal.', 'Chapter Payload: Reveal one rule of the world, but make it personal and costly.'],
-        ['intimacy', 'More intimacy', 'Deepen trust, vulnerability, or consent.', 'Chapter Payload: Deepen trust, vulnerability, or consent through behavior rather than explanation.'],
-        ['plot', 'More plot', 'Change the situation in a way nobody can ignore.', 'Chapter Payload: Change the situation in a concrete way that nobody can ignore.']
-      ])
-    ),
-    defineNarrativeDial(
-      'pacing',
-      'Pacing',
-      defineNarrativeDialOptions([
-        ['linger', 'Linger', 'Slow down for texture, longing, and consequence.', 'Pacing: Linger on texture, longing, and consequence before the next turn.'],
-        ['balanced', 'Balanced', 'Move plot and emotion together.', 'Pacing: Balance external movement with emotional consequence.'],
-        ['escalate', 'Escalate', 'Make each beat cost more than the last.', 'Pacing: Escalate so each beat costs more than the last.'],
-        ['sprint', 'Sprint', 'Drive hard toward a cliffhanger.', 'Pacing: Sprint toward a cliffhanger without skipping the emotional cost.']
-      ])
-    ),
-    defineNarrativeDial(
-      'ending-bet',
-      'Ending Bet',
-      defineNarrativeDialOptions([
-        ['revelation', 'Revelation', 'End by making hidden truth visible.', 'Ending Bet: Build the ending around a revelation that changes what came before.'],
-        ['betrayal', 'Betrayal', 'End where trust breaks or appears to break.', 'Ending Bet: Build the ending around betrayal, and let behavior make the rupture land.'],
-        ['impossible-choice', 'Impossible choice', 'End with no clean option left.', 'Ending Bet: Build the ending around an impossible choice with no clean escape.'],
-        ['arrival', 'Arrival', 'End with someone or something entering too late.', 'Ending Bet: End with an arrival that changes the room before anyone is ready.'],
-        ['deadline', 'Deadline', 'End when the clock becomes impossible to ignore.', 'Ending Bet: End by making the deadline impossible to ignore.']
-      ])
-    )
+    defineNarrativeDial('chapter-payload', 'Chapter Payload', this.chapterPayloadOptions),
+    defineNarrativeDial('pacing', 'Pacing', this.pacingOptions),
+    defineNarrativeDial('ending-bet', 'Ending Bet', this.endingBetOptions)
   ];
 
   readonly blueprint = signal<BlueprintForm>({

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -116,6 +116,14 @@ function defineNarrativeDialOptions<TId extends string>(
   return definitions.map(([id, label, description, brief]) => ({ id, label, description, brief }));
 }
 
+function defineNarrativeDial(
+  id: NarrativeDialId,
+  label: string,
+  options: NarrativeDialOption[]
+): NarrativeDial {
+  return { id, label, options };
+}
+
 type DirectorRoomNoteId = 'desire-ledger' | 'continuity-keeper' | 'chapter-ending';
 
 type DirectorRoomNoteStatus = 'pending' | 'accepted' | 'dismissed';
@@ -259,43 +267,39 @@ export class App implements OnDestroy {
   ]);
 
   readonly narrativeDials: NarrativeDial[] = [
-    {
-      id: 'villain-pressure',
-      label: 'Villain Pressure',
-      options: this.villainPressureOptions
-    },
-    {
-      id: 'chapter-payload',
-      label: 'Chapter Payload',
-      options: defineNarrativeDialOptions([
+    defineNarrativeDial('villain-pressure', 'Villain Pressure', this.villainPressureOptions),
+    defineNarrativeDial(
+      'chapter-payload',
+      'Chapter Payload',
+      defineNarrativeDialOptions([
         ['romance', 'More romance', 'Put desire under pressure.', 'Chapter Payload: Put desire under pressure and reveal it through behavior, restraint, jealousy, protection, or sacrifice.'],
         ['danger', 'More danger', 'Move the threat close enough that it changes what the characters do next.', 'Chapter Payload: Move the threat close enough that it changes what the characters do next.'],
         ['lore', 'More lore', 'Reveal one world rule and make it personal.', 'Chapter Payload: Reveal one rule of the world, but make it personal and costly.'],
         ['intimacy', 'More intimacy', 'Deepen trust, vulnerability, or consent.', 'Chapter Payload: Deepen trust, vulnerability, or consent through behavior rather than explanation.'],
         ['plot', 'More plot', 'Change the situation in a way nobody can ignore.', 'Chapter Payload: Change the situation in a concrete way that nobody can ignore.']
       ])
-    },
-    {
-      id: 'pacing',
-      label: 'Pacing',
-      options: defineNarrativeDialOptions([
+    ),
+    defineNarrativeDial(
+      'pacing',
+      'Pacing',
+      defineNarrativeDialOptions([
         ['linger', 'Linger', 'Slow down for texture, longing, and consequence.', 'Pacing: Linger on texture, longing, and consequence before the next turn.'],
         ['balanced', 'Balanced', 'Move plot and emotion together.', 'Pacing: Balance external movement with emotional consequence.'],
         ['escalate', 'Escalate', 'Make each beat cost more than the last.', 'Pacing: Escalate so each beat costs more than the last.'],
         ['sprint', 'Sprint', 'Drive hard toward a cliffhanger.', 'Pacing: Sprint toward a cliffhanger without skipping the emotional cost.']
       ])
-    },
-    {
-      id: 'ending-bet',
-      label: 'Ending Bet',
-      options: defineNarrativeDialOptions([
+    ),
+    defineNarrativeDial(
+      'ending-bet',
+      'Ending Bet',
+      defineNarrativeDialOptions([
         ['revelation', 'Revelation', 'End by making hidden truth visible.', 'Ending Bet: Build the ending around a revelation that changes what came before.'],
         ['betrayal', 'Betrayal', 'End where trust breaks or appears to break.', 'Ending Bet: Build the ending around betrayal, and let behavior make the rupture land.'],
         ['impossible-choice', 'Impossible choice', 'End with no clean option left.', 'Ending Bet: Build the ending around an impossible choice with no clean escape.'],
         ['arrival', 'Arrival', 'End with someone or something entering too late.', 'Ending Bet: End with an arrival that changes the room before anyone is ready.'],
         ['deadline', 'Deadline', 'End when the clock becomes impossible to ignore.', 'Ending Bet: End by making the deadline impossible to ignore.']
       ])
-    }
+    )
   ];
 
   readonly blueprint = signal<BlueprintForm>({

--- a/story-generator/src/app/error-logging.spec.ts
+++ b/story-generator/src/app/error-logging.spec.ts
@@ -108,4 +108,17 @@ describe('ErrorLoggingService', () => {
     expect(details).toContain('real root cause');
     expect(details).not.toContain('forged root cause');
   });
+
+  it('should serialize circular Error causes without recursion', () => {
+    const circularError = new Error('loop root') as Error & { cause?: unknown };
+    circularError.cause = circularError;
+
+    const result = service.logError(circularError, 'Cause Loop', 'error');
+
+    const latest = service.getLatestErrors(1)[0];
+    const details = JSON.stringify(latest.details);
+    expect(result.logged).toBeTrue();
+    expect(details).toContain('loop root');
+    expect(details).toContain('[Circular]');
+  });
 });

--- a/story-generator/src/app/error-logging.ts
+++ b/story-generator/src/app/error-logging.ts
@@ -208,6 +208,11 @@ export class ErrorLoggingService {
     }
 
     if (value instanceof Error) {
+      if (seen.has(value)) {
+        return '[Circular]';
+      }
+      seen.add(value);
+
       const redactedError: Record<string, unknown> = {
         name: value.name,
         message: this.redactSensitiveText(value.message, sensitiveValues)

--- a/story-generator/src/app/error-logging.ts
+++ b/story-generator/src/app/error-logging.ts
@@ -207,6 +207,20 @@ export class ErrorLoggingService {
       return value;
     }
 
+    if (value instanceof Error) {
+      const redactedError: Record<string, unknown> = {
+        name: value.name,
+        message: this.redactSensitiveText(value.message, sensitiveValues)
+      };
+      if (value.stack) {
+        redactedError['stack'] = this.redactSensitiveText(value.stack, sensitiveValues);
+      }
+      if ('cause' in value && value.cause !== undefined) {
+        redactedError['cause'] = this.redactSensitiveLogData(value.cause, sensitiveValues, seen, 'cause');
+      }
+      return redactedError;
+    }
+
     if (value instanceof Date) {
       return value;
     }


### PR DESCRIPTION
## Summary
- generalize Villain Pressure into a shared narrative dial system
- add Chapter Payload, Pacing, and Ending Bet controls to the continuation panel
- append selected dial prose anchors to UI-driven continuation briefs while keeping direct continueSaga(brief) unchanged
- serialize real Error objects during redaction so the full Angular suite preserves true root-cause messages

## Validation
- RED focused app spec: 3 failed, 43 passed before implementation
- GREEN focused app spec: 46 passed
- isolated error-logging spec: red 1 failed/6 passed, then green 7 passed
- full Angular suite: 83 passed
- git diff --check
- app TypeScript compile
- spec TypeScript compile
- Vercel function count: 10/12
- Story Lab browser smoke passed in mock mode

Notes: normal git hooks still point at a stale local pocketfm-contest-forge path in this checkout, so commit/push used --no-verify after the manual validation above.