### PR TITLE
Add Story Lab operating docs baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,28 @@
 
 Last updated: 2026-06-13 00:00 EDT
 
-This file is read automatically by AI coding agents. It is the repo-level operating guide for the current recovery effort.
+This file is read automatically by AI coding agents. It is the repo-level operating guide for current Story Lab platform work, recovery work, and autonomous sessions.
+
+## Required Start Order
+
+Before planning, editing, or claiming readiness:
+
+1. Run `git status --short --branch` and treat the live worktree as authoritative.
+2. Read `STORY_LAB_UNPUBLISHED_BRANCH_SPLIT_PLAN.md` when recovering the local Story Lab stack.
+3. For long-running autonomous work, read `OVERNIGHT_MODE.md` before selecting the next task.
+4. Use `STORY_LAB_IDEA_BOARD.md` for research-mined ideas, story-quality experiments, and Weird Lab candidates.
+5. Read the execution plan that matches the files or behavior being changed.
+6. Run `scripts/recovery/check-vercel-function-count.sh` before adding, retiring, consolidating, or documenting deployable Vercel route files.
+
+## Current Operating Direction
+
+The current recovery task is to split the unpublished `feature/story-lab-auth-profile-contracts` stack into reviewable PRs, address checks/review comments, and merge each slice before starting more feature work.
+
+The autonomous operating guide is `OVERNIGHT_MODE.md`. Use it before long-running task selection, research mining, or Weird Lab work.
+
+The idea/backlog board is `STORY_LAB_IDEA_BOARD.md`. Keep it honest: `Done` means merged to `main`; use `Local-only` for unpublished branch material.
+
+The active Story Lab auth/profile/cloud-library plan is `STORY_LAB_AUTH_PROFILE_CLOUD_LIBRARY_EXEC_PLAN.md`. Use it before adding provider-backed auth, private user profiles, cloud project library APIs, account route rewrites, or signed-in save/load/list/delete behavior.
 
 ## Current Recovery Direction
 
@@ -27,6 +48,8 @@ The active Story Lab Villain Pressure UI plan is `STORY_LAB_VILLAIN_PRESSURE_UI_
 The active Story Lab privacy/streaming gate plan is `STORY_LAB_PRIVACY_STREAMING_GATES_EXEC_PLAN.md`. Use it before changing CORS policy, account-boundary headers, export sanitization, retention/deletion policy, or opaque job-id streaming contracts.
 
 The active Story Lab storage-port plan is `STORY_LAB_STORAGE_PORT_EXEC_PLAN.md`. Use it before changing Story Lab storage ports, in-memory account-store scaffolding, Postgres adapter scaffolding, or account-sync persistence boundaries.
+
+The active Story Lab auth/profile/cloud-library checklist is `STORY_LAB_AUTH_PROFILE_CLOUD_LIBRARY_EXEC_PLAN.md`. Use it before changing provider-backed auth, private user profiles, cloud project library APIs, account route rewrites, or signed-in save/load/list/delete behavior.
 
 The active Story Lab route-budget plan is `STORY_LAB_ROUTE_BUDGET_EXEC_PLAN.md`. Use it before retiring, adding, consolidating, or documenting Vercel-facing route files for Story Lab capacity work.
 

--- a/OVERNIGHT_MODE.md
+++ b/OVERNIGHT_MODE.md
@@ -1,0 +1,180 @@
+# Overnight Mode
+
+Last updated: 2026-06-13
+
+## Purpose
+
+Overnight Mode is the operating guide for long autonomous coding sessions on Fairytales with Spice. It lets an agent keep working after one coherent task is done without drifting into random unsafe changes.
+
+## Core Rule
+
+Do not stop just because one task is done. Finish a coherent slice, validate it, push it, open a PR, address checks and review comments, and merge it before selecting another feature slice.
+
+Continuing after a slice means continuing through publication. If a committed slice is not pushed, PR'd, reviewed, and merged, the next autonomous task is publishing or recovery, not another feature.
+
+Stopping is appropriate when:
+
+- a destructive or credential-sensitive action would be required;
+- the same blocker has repeated and there is no meaningful local progress left;
+- tests reveal a serious regression that needs user direction before riskier repair;
+- the user explicitly says to stop or pause;
+- external services, secrets, billing, or account-provider setup are required and cannot be safely inferred.
+
+## Start Of Run Checklist
+
+Run or inspect these before making changes:
+
+1. `git status --short --branch`
+2. `gh pr list --state open --json number,title,headRefName,baseRefName,url,reviewDecision`
+3. `scripts/recovery/check-vercel-function-count.sh`
+4. `scripts/recovery/preflight.sh --quick --skip-status`
+5. `npm run test:all` when the change risk justifies the time
+6. Read or skim:
+   - `AGENTS.md`
+   - `STORY_LAB_UNPUBLISHED_BRANCH_SPLIT_PLAN.md`
+   - `STORY_LAB_IDEA_BOARD.md`
+   - the execution plan matching the files being changed
+
+If checks are already failing before edits, record the baseline failure in the active changelog or execution plan and prioritize repair before feature work.
+
+## Task Selection Order
+
+Use this order when the user has not given a newer explicit task:
+
+1. User's newest explicit request.
+2. Open PR review comments or failing CI.
+3. Failing local checks from the start-of-run checklist.
+4. The next unchecked publishing step in `STORY_LAB_UNPUBLISHED_BRANCH_SPLIT_PLAN.md`.
+5. The next unchecked gate in the active execution plan.
+6. Source-backed research ideas from `STORY_LAB_IDEA_BOARD.md`.
+7. One bounded Weird Lab experiment from `STORY_LAB_IDEA_BOARD.md`.
+8. Documentation cleanup that improves future autonomous runs.
+
+## Lane Weights
+
+When nothing is urgent and several tasks are valid, use this rough mix:
+
+- 40 percent repair, tests, review comments, and cleanup that removes real risk.
+- 25 percent planned product or platform progress.
+- 20 percent story-quality improvement or competitor/research mining.
+- 15 percent Weird Lab experiment.
+
+If a required check fails, ignore the weights and repair the failure first.
+
+## GitHub Issues
+
+The user does not need to create issues for every task. Issues are useful when work needs durable tracking outside the current branch.
+
+Create or recommend a GitHub issue for:
+
+- user-visible features that will take more than one PR;
+- bugs likely to recur;
+- research tasks with source links and follow-up experiments;
+- provider decisions such as auth, storage, email, Blob, or Workflow;
+- work that is blocked on credentials, billing, project setup, or user preference.
+
+Do not require an issue for:
+
+- small docs updates;
+- one-file test fixes;
+- local cleanup with obvious acceptance criteria;
+- immediate PR review comments;
+- short experiments that will be reverted or parked if they do not work.
+
+If no issue exists, log the task in the active execution plan, recovery changelog, or idea board.
+
+## Research Mining Rules
+
+Research is allowed when it is source-backed and transformed into this app's language.
+
+For each research pass:
+
+1. Search current web sources. Do not rely on memory for product features, pricing, platform rules, or provider capabilities.
+2. Capture links and access dates in `STORY_LAB_IDEA_BOARD.md` or a dedicated research note.
+3. Write what the competing or adjacent product does in plain words.
+4. Translate the idea into a Fairytales with Spice experiment.
+5. Do not copy protected text, UI, branding, or exact product structure.
+6. Prefer small prototypeable insights over broad market summaries.
+
+Good research targets:
+
+- AI novel-writing assistants.
+- Serialized fiction reading apps.
+- Interactive fiction tools.
+- Writing critique and revision tools.
+- Roleplay/chat story apps.
+- Creator workflow tools that handle drafts, versions, notes, and memory.
+
+## Weird Lab Rules
+
+Weird Lab work is for small creative experiments that might make story output more distinctive.
+
+Rules:
+
+- Timebox the experiment to 30, 60, or 90 minutes.
+- Put it behind a clear seam, local flag, or isolated branch.
+- Add a tiny acceptance test or a before/after sample.
+- Never merge a weird experiment unless it proves value and passes normal gates.
+- If the experiment fails, record why and park it instead of hiding it.
+
+Examples:
+
+- A "tension thread" translator that turns internal state into prose anchors.
+- A "continuity courtroom" that lists contradictions before a continuation runs.
+- A "chapter ending stress test" that generates three possible final lines and scores which one pulls hardest.
+- A "cliche detector" that intentionally names the most obvious trope so the writer can dodge it.
+- A "scene pressure mixer" that combines emotional, deadline, secret, and setting pressures into one continuation brief.
+
+## Commit Cadence
+
+Commit after coherent, reviewable slices. Do not commit every tiny edit just to show activity.
+
+Before committing:
+
+- run `git diff --check`;
+- run the focused tests for files touched;
+- run the function-count check when route files or `vercel.json` change;
+- update docs if the work changes plan state;
+- inspect `git diff --stat` so unrelated untracked or user files are not accidentally included.
+
+Useful commit scopes:
+
+- one doc package;
+- one test-backed bug fix;
+- one UI slice;
+- one provider/storage/auth seam;
+- one research note plus idea-board update.
+
+## Safety Gates
+
+Do not cross these without explicit user approval or a written provider decision:
+
+- Adding production auth provider dependencies.
+- Creating, deleting, or migrating real databases.
+- Adding paid provider usage.
+- Storing user story text in a new external service.
+- Adding deployable Vercel route files when function count would reach or exceed the limit.
+- Changing secrets, billing, domains, DNS, or production deployment settings.
+- Reintroducing DigitalOcean as the active deployment target.
+- Reopening audio runtime work.
+
+Never claim:
+
+- "cloud save" unless signed-in save/load/list/delete works against durable storage;
+- "durable jobs" unless progress survives process loss;
+- "live AI verified" unless provider telemetry proves it was not mock mode;
+- "review comments addressed" unless current PR review comments were inspected.
+
+## End Of Run Handoff
+
+Before the session ends, update the active execution plan or recovery changelog with:
+
+- branch and commit;
+- what changed in normal people words;
+- files touched;
+- checks run and exact result;
+- known failures or skipped checks;
+- whether anything was committed or left uncommitted;
+- the next best task.
+
+If work continues after the handoff, keep that record fresh after each coherent slice.

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -2418,3 +2418,21 @@ Decision:
 Validation:
 
 - Pending after scope correction.
+
+## 2026-06-13 08:09 EDT - PR 114 Merged And PR 2 Scope Set
+
+Actions:
+
+- Merged PR #114 into `main` after checks passed and review comments were answered.
+- Preserved the polluted local `main` tip as `backup/local-main-docs-stack-2026-06-13`.
+- Started `recovery/story-lab-operating-docs` from `origin/main`.
+- Set PR #2 scope to operating docs, idea board, storage-plan reconciliation, and auth/profile/cloud-library checklist.
+- Deferred the old full app audit and overnight handoff because they describe unpublished work as current reality and are too stale/large for a clean docs PR.
+
+Decision:
+
+- Operating docs can land before code only when they avoid current-evidence claims about unpublished slices.
+
+Validation:
+
+- Pending for PR #2.

--- a/STORY_LAB_AUTH_PROFILE_CLOUD_LIBRARY_EXEC_PLAN.md
+++ b/STORY_LAB_AUTH_PROFILE_CLOUD_LIBRARY_EXEC_PLAN.md
@@ -1,0 +1,222 @@
+# Story Lab Auth, Profile, And Cloud Library Checklist
+
+Created: 2026-06-13
+
+## Purpose
+
+Turn the existing Story Lab storage/auth scaffolding into a signed-in cloud library without breaking anonymous local use or making false durability claims.
+
+The desired user-visible outcome is:
+
+- anonymous users can still create, continue, and locally save stories in the browser;
+- signed-in users can have a private profile with writing preferences;
+- signed-in users can save, list, load, and delete Story Lab projects from cloud storage;
+- the app has a clear local-only versus cloud-synced distinction;
+- no user can read, modify, or delete another user's projects;
+- future durable job work has owner/user context available, but this plan does not claim crash-safe background jobs.
+
+## Current Reality On Main
+
+This checklist starts after PR #114.
+
+- `AuthPort` exists and is deny-by-default.
+- `authorizeProjectAccess` exists.
+- `StoryProjectStore` exists with non-durable memory and injected Postgres scaffolds.
+- Browser-local `StoryWorkspaceStorageService` remains the current user-visible save path.
+- Story Lab jobs are still `non_durable_memory` and not account-owned.
+- Vercel function count must stay within the repo guard.
+- The large local branch is being split through `STORY_LAB_UNPUBLISHED_BRANCH_SPLIT_PLAN.md`.
+
+Not live yet:
+
+- production auth provider wiring;
+- signed-in browser flow;
+- private user profiles in durable storage;
+- cloud project save/list/load/delete against durable storage;
+- database provisioning or executed migrations;
+- durable jobs.
+
+## Operating Rules
+
+- Keep anonymous local saves working.
+- Keep auth, profile, storage, route, and UI slices reviewable.
+- Do not install provider SDKs or database drivers unless the slice explicitly justifies the dependency.
+- Do not add multiple account/profile/project route files; prefer one consolidated account route if route work is in scope.
+- Do not claim "cloud save" until signed-in save/load/list/delete works against durable storage and has live proof.
+- Do not claim "durable jobs" until job progress survives process loss.
+- Treat user profile fields as preferences, not authorization metadata.
+- Use `AuthUser.userId` and owner columns for authorization.
+
+## Phase Checklist
+
+### Phase 0: Publication Recovery
+
+- [x] Push a remote backup branch for the unpublished local stack.
+- [x] Open PR #114 for publication discipline and split planning.
+- [x] Address PR #114 review comments.
+- [x] Merge PR #114.
+- [ ] Land the operating-docs baseline.
+- [ ] Land auth/profile contracts.
+- [ ] Land cloud schema/storage readiness.
+- [ ] Land consolidated account route.
+- [ ] Land Angular cloud library UI.
+- [ ] Land durable job owner scaffolding only if kept honest as non-durable in the active UI.
+
+### Phase 1: Auth And Profile Contracts
+
+Goal: add the account/profile domain seam without live provider or database claims.
+
+Candidate local commits:
+
+- `75b485f Add Story Lab auth profile contract slice`
+- `6459454 Add Story Lab profile store slice`
+- `b99ad12 Add Clerk auth adapter scaffold`
+- `99317f1 Add env-gated Story Lab Clerk auth config`
+- `448d0c3 Harden Story Lab profile preferences`
+
+Expected files:
+
+- `api/_lib/story-lab/auth/configuredAuthPort.ts`
+- `api/_lib/story-lab/auth/clerkAuthPort.ts`
+- `api/_lib/story-lab/profile/*`
+- `api/_lib/story-lab/contracts.ts`
+- `story-generator/src/app/contracts.ts`
+- focused tests under `tests/`
+
+Validation:
+
+- `npm run test:story-lab-auth`
+- `npm run test:story-lab-storage-port`
+- `npm run test:story-lab-configured-auth`
+- `npm run test:story-lab-clerk-auth`
+- `npm run test:story-lab-profile-contracts`
+- `npm run test:story-lab-profile-store`
+- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`
+- `scripts/recovery/preflight.sh --quick --skip-status`
+
+Acceptance:
+
+- missing provider config denies by default;
+- blank or unknown provider selection fails closed;
+- Clerk-shaped token extraction requires an injected verifier before returning an app user;
+- profile preferences are normalized from runtime data before persistence;
+- no route or UI claims cloud sync.
+
+### Phase 2: Cloud Schema And Storage Readiness
+
+Goal: add schema/readiness/config/executor scaffolding while staying guarded when no real `DATABASE_URL` exists.
+
+Candidate local commits:
+
+- `7144dff Add Story Lab cloud schema scaffold`
+- `aa8d848 Add Story Lab cloud storage config seam`
+- `c3d77f0 Add Story Lab Neon storage executor`
+- `2bd5691 Add Story Lab cloud schema migration helper`
+- `bf5cf38 Add Story Lab cloud database readiness smoke`
+
+Validation:
+
+- `npm run test:story-lab-cloud-schema`
+- `npm run test:story-lab-cloud-schema-migration`
+- `npm run test:story-lab-cloud-db-readiness`
+- `npm run test:story-lab-cloud-storage-config`
+- `npm run test:story-lab-neon-executor`
+- `npm run test:all`
+- `scripts/recovery/check-vercel-function-count.sh`
+
+Acceptance:
+
+- schema drift tests cover profile, project, and future job tables;
+- guarded scripts refuse missing `DATABASE_URL`;
+- driver creation is lazy and testable with injected executors;
+- no live database migration is claimed unless actually run.
+
+### Phase 3: Consolidated Account Route
+
+Goal: add one deployable account route for profile and project cloud library operations.
+
+Candidate local commits:
+
+- `0d5b659 Add Story Lab account route slice`
+- backend account-route part of `a7fbacd Report non-durable account storage mode`
+
+Validation:
+
+- `npm run test:story-lab-account-routes`
+- `npm run test:story-lab-storage-port`
+- `npm run test:story-lab-profile-store`
+- `scripts/recovery/check-vercel-function-count.sh`
+- `scripts/recovery/preflight.sh --quick --skip-status`
+
+Acceptance:
+
+- profile and project operations share one deployable route target;
+- function count stays within the limit;
+- cross-owner access fails;
+- non-durable injected stores report `non_durable_memory`, not `cloud_postgres`.
+
+### Phase 4: Angular Cloud Library Service And UI
+
+Goal: expose local-vs-cloud library state honestly in the Angular app while preserving anonymous browser-local saves.
+
+Candidate local commits:
+
+- `ca79e26 Add Story Lab account service methods`
+- `def026c Add Story Lab cloud library UI state`
+- `29fc248 Show Story Lab cloud account status`
+- `033112c Show Story Lab account setup action`
+- `504dc84 Gate cloud save on connected account`
+- `77b3b13 Gate cloud project actions on connected account`
+- `7b87100 Correct cloud controls browser spec`
+- frontend part of `a7fbacd Report non-durable account storage mode`
+- `9465073 Show non-durable cloud storage as unavailable`
+
+Validation:
+
+- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`
+- targeted Angular specs if Chrome is stable
+- `npm run build`
+- `scripts/recovery/preflight.sh --quick --skip-status`
+
+Acceptance:
+
+- local browser saves remain visible and usable;
+- cloud calls are gated until account state is connected;
+- failed or unavailable account state does not imply durable cloud sync;
+- non-durable account storage is displayed as cloud-unavailable.
+
+### Phase 5: Durable Job Owner Scaffolding
+
+Goal: prepare owner-scoped durable job storage seams while keeping active jobs labelled non-durable until Workflow/database route wiring is real.
+
+Candidate local commits:
+
+- `206e6ea Add Story Lab durable job schema contract`
+- `6e348b7 Add Story Lab durable job store scaffold`
+- `db86c28 Add Story Lab job store config seam`
+- `d8782ab Guard Story Lab job route store config`
+- `462425e Pass owner context to durable Story Lab jobs`
+- `d7bc5b2 Scope Story Lab job reads by owner`
+- `244aef5 Guard durable job updates by owner`
+
+Acceptance:
+
+- durable stores require authenticated owner context;
+- default job mode remains `non_durable_memory`;
+- UI and docs do not claim crash-safe progress.
+
+## Research Notes
+
+- Supabase Auth can model permanent and anonymous users and supports RLS, but user-editable metadata must not be used for authorization. Source: https://supabase.com/docs/guides/auth/users, accessed 2026-06-08.
+- Vercel Postgres guidance points new projects toward Marketplace Postgres integrations rather than legacy Vercel Postgres. Source: https://vercel.com/docs/postgres, accessed 2026-06-08.
+- Vercel Workflow is the later durable-execution direction, not part of the first cloud-library slice. Sources: https://vercel.com/workflows and https://vercel.com/blog/a-new-programming-model-for-durable-execution, accessed 2026-06-08.
+- Clerk backend docs describe bearer tokens and `__session` cookies. Any adapter must verify these through an explicit verifier and fail closed without one. Sources: https://clerk.com/docs/request-authentication/backend and https://clerk.com/docs/backend-requests/manual-jwt, accessed 2026-06-08.
+
+## PR Language Guard
+
+Use precise language in PRs:
+
+- Say "contract," "port," "scaffold," "guarded script," or "non-durable store" when that is what shipped.
+- Say "live cloud sync" only after signed-in save/load/list/delete works against durable storage.
+- Say "provider-backed auth" only after the provider SDK/verifier is wired and verified.
+- Say "durable jobs" only after progress survives process loss.

--- a/STORY_LAB_IDEA_BOARD.md
+++ b/STORY_LAB_IDEA_BOARD.md
@@ -1,0 +1,153 @@
+# Story Lab Idea Board
+
+Last updated: 2026-06-13
+
+## Purpose
+
+This board is the parking lot and selection queue for product ideas, research leads, story-quality improvements, and bounded Weird Lab experiments. It exists so autonomous work can be creative without becoming random.
+
+## Status Labels
+
+- `Now`: should be picked up soon unless a newer user request supersedes it.
+- `Soon`: valuable but not first in line.
+- `Research`: needs current source review before implementation.
+- `Weird Lab`: small experiment, not guaranteed product work.
+- `Parked`: useful but blocked or not timely.
+- `Done`: implemented, reviewed, and merged.
+- `Local-only`: implemented or drafted on an unpublished local branch and not yet available on `main`.
+- `Rejected`: considered and intentionally not taken.
+
+## Current Priorities
+
+### Done: Publication Discipline
+
+PR #114 merged on 2026-06-13 and added hard guardrails for publishing validated slices before starting more feature work.
+
+Acceptance evidence:
+
+- PR #114 checks passed.
+- PR #114 review comments were answered.
+- The PR was merged into `main`.
+
+### Now: Split The Unpublished Story Lab Stack
+
+The local `feature/story-lab-auth-profile-contracts` branch contains a large stack of useful work that must be recovered as reviewable PRs rather than landed all at once.
+
+Acceptance:
+
+- Each slice starts from current `origin/main`.
+- Each slice has focused validation evidence.
+- Each slice is pushed, reviewed, fixed, and merged before the next feature slice.
+- The backup branch remains only a safety anchor.
+
+Tracking:
+
+- `STORY_LAB_UNPUBLISHED_BRANCH_SPLIT_PLAN.md`
+
+### Now: Auth, Profiles, And Cloud Library Plan Baseline
+
+The app has route-free storage and auth seams, but signed-in cloud library behavior is not live. The next plan baseline must keep provider, database, profile, route, and UI work split into reviewable PRs.
+
+Acceptance:
+
+- Provider decision points are explicit.
+- User profile contract is sketched.
+- Cloud project save/list/load/delete flow is scoped.
+- Route/function budget impact is called out.
+- Owner-isolation tests are listed.
+- The plan does not claim cloud sync is live.
+
+Tracking:
+
+- `STORY_LAB_AUTH_PROFILE_CLOUD_LIBRARY_EXEC_PLAN.md`
+
+### Now: Storage Plan Reconciliation
+
+The storage port plan should continue to distinguish the merged route-free Phase C scaffold from unfinished account/cloud sync work.
+
+Acceptance:
+
+- `STORY_LAB_STORAGE_PORT_EXEC_PLAN.md` records PR #102 as merged.
+- Current route count wording reflects the post-route-budget baseline.
+- Remaining work points to auth/profile/cloud-library planning instead of treating storage-port scaffolding as unfinished.
+
+### Soon: Auth And Profile Contracts
+
+Add the account/profile domain seam without live provider or database claims.
+
+Candidate source commits from the local stack:
+
+- `75b485f Add Story Lab auth profile contract slice`
+- `6459454 Add Story Lab profile store slice`
+- `b99ad12 Add Clerk auth adapter scaffold`
+- `99317f1 Add env-gated Story Lab Clerk auth config`
+- `448d0c3 Harden Story Lab profile preferences`
+
+Acceptance:
+
+- Missing auth provider config fails closed.
+- The Clerk-shaped adapter does not turn raw tokens into users without an injected verifier.
+- Profile preferences are normalized as runtime data.
+- Tests prove profile contracts, configured auth, Clerk adapter behavior, and profile store behavior.
+- PR language says "contracts/store seams/scaffold," not "cloud library shipped."
+
+### Soon: Cloud Storage And Database Scaffold
+
+Add schema, migration, readiness, and storage-config seams while staying guarded when no real `DATABASE_URL` exists.
+
+Acceptance:
+
+- Schema and readiness tests are deterministic.
+- Real database scripts refuse to run without explicit `DATABASE_URL`.
+- No live cloud persistence is claimed without executed migration and live smoke evidence.
+
+### Soon: Consolidated Account Route
+
+Add one deployable account route for profile and project cloud library operations without spending multiple Vercel function slots.
+
+Acceptance:
+
+- Function count stays within the Vercel limit.
+- Route tests prove fail-closed auth, credentialed CORS, profile read/write, project save/list/load/delete, cross-owner denial, and missing-storage failures.
+- The route remains one consolidated function target.
+
+### Soon: Angular Cloud Library UI
+
+Expose local-vs-cloud library state honestly in the Angular app while preserving anonymous browser-local saves.
+
+Acceptance:
+
+- Local browser saves remain visible and usable.
+- Cloud controls do not call account routes while account/cloud sync is unavailable.
+- Non-durable account storage is not displayed as cloud-available.
+- Angular specs cover unavailable, refresh, save, load, delete, and error states.
+
+## Research Notes
+
+Source-backed notes from 2026-06-08, kept as planning context only:
+
+- Supabase Auth models permanent and anonymous users, issues access tokens tied to users, and supports RLS-driven access. Its docs warn that user-editable metadata must not be used for security-sensitive authorization. Source: https://supabase.com/docs/guides/auth/users, accessed 2026-06-08.
+- Vercel's Postgres guidance says new projects should use Marketplace Postgres integrations rather than legacy Vercel Postgres. Source: https://vercel.com/docs/postgres, accessed 2026-06-08.
+- Vercel's Workflow material positions Workflow SDK as the path for long-running durable work with step isolation, retries, persistence, and observability. Sources: https://vercel.com/workflows and https://vercel.com/blog/a-new-programming-model-for-durable-execution, accessed 2026-06-08.
+- Clerk backend docs describe bearer session tokens for cross-origin requests and the `__session` cookie for same-origin requests. Any Clerk adapter must verify tokens through an explicit verifier and fail closed without one. Sources: https://clerk.com/docs/request-authentication/backend and https://clerk.com/docs/backend-requests/manual-jwt, accessed 2026-06-08.
+
+## Parked Local Artifacts
+
+These files were observed as local untracked workspace artifacts and must not be committed automatically:
+
+- `SPARK_TRIAL_TASKS.md`
+- `STORY_LAB_REVIEW_MISTAKES_2026-06-09.md`
+- `STORY_QUALITY_EVALS_PLAN.md`
+- `tests/grok-smoke.test.ts`
+
+Adopt any material from them only through a separate cleanup decision with focused review.
+
+## Weird Lab Candidates
+
+These remain candidates until implemented and merged:
+
+- Continuity courtroom: visible contradiction or unresolved-debt preview before continuation.
+- Chapter ending stress test: generate and compare candidate ending pressures.
+- Cliche alarm: name the obvious stale path so a continuation can dodge it.
+- Scene pressure mixer: combine emotional, deadline, secret, and setting pressures into one continuation brief.
+- Memory-card trigger shelf: let users pin durable story facts before continuation.

--- a/STORY_LAB_STORAGE_PORT_EXEC_PLAN.md
+++ b/STORY_LAB_STORAGE_PORT_EXEC_PLAN.md
@@ -1,10 +1,13 @@
 # Story Lab Storage Port ExecPlan
 
 Created: 2026-06-05 03:48 EDT
+Reconciled: 2026-06-13
 
 ## Purpose / Big Picture
 
 Implement Phase C from `STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md`: a Story Lab storage port and local/test adapters without provisioning a database, adding deployable routes, or claiming cloud persistence.
+
+Current state as of 2026-06-13: this route-free storage-port scaffold is merged into `main` through PR #102 (`4d21e4f`). The remaining platform work is not this Phase C scaffold; it is the later auth/provider/profile/cloud-library work that turns the scaffold into a signed-in user feature.
 
 The user-visible outcome is not account sync yet. The observable technical outcome is that the app has a typed owner-scoped persistence boundary ready for future account sync:
 
@@ -15,7 +18,7 @@ The user-visible outcome is not account sync yet. The observable technical outco
 - the in-memory store is explicitly non-durable;
 - the Postgres adapter is a dependency-injected scaffold that lazy-reads configuration and fails closed until a real executor/migration is provided.
 
-This plan is intentionally route-free. The Vercel function-count guard is already `12/12`; Phase C must not add `api/story-lab/storage*` or job/export routes.
+This plan is intentionally route-free. At the time Phase C was written, the Vercel function-count guard was `12/12`; route-budget work later reduced the count. Phase C still must not add `api/story-lab/storage*` routes or claim cloud sync.
 
 ## Progress
 
@@ -33,7 +36,9 @@ This plan is intentionally route-free. The Vercel function-count guard is alread
 - [x] Update platform plan, changelog, and lessons with focused storage evidence.
 - [x] Address Gemini review comments for missing metadata and corrupt stored JSON handling.
 - [x] Run focused validation and recovery preflight.
-- [ ] Push, open PR, address review/checks, and merge the PR.
+- [x] Push, open PR, address review/checks, and merge the PR.
+- [x] Reconcile this plan against PR #102 merge evidence, route-budget changes, and the later split-recovery plan.
+- [ ] Use `STORY_LAB_AUTH_PROFILE_CLOUD_LIBRARY_EXEC_PLAN.md` for future account/profile/cloud-library work instead of treating this Phase C storage plan as active implementation permission.
 
 ## Surprises & Discoveries
 
@@ -55,11 +60,11 @@ This plan is intentionally route-free. The Vercel function-count guard is alread
 - Decision: The Postgres adapter lazy-reads `DATABASE_URL` only when an operation is called.
   Rationale: Module import must be safe in tests, preflight, and Vercel builds where no cloud database exists.
 - Decision: No route files are added.
-  Rationale: Function count is `12/12`; route consolidation is required before Phase D job routes or cloud-sync endpoints.
+  Rationale: Phase C is a backend seam only. Cloud-sync endpoints need a separate auth/provider/storage plan and function-budget review.
 
 ## Outcomes & Retrospective
 
-Current implementation state as of 2026-06-07 05:20 EDT:
+Current implementation state as of 2026-06-13:
 
 - Files changed for this slice:
   - `AGENTS.md`: points agents at this active storage-port plan.
@@ -77,13 +82,17 @@ Current implementation state as of 2026-06-07 05:20 EDT:
   - `npm run test:story-lab-state` -> `Story-lab state delta tests passed`;
   - `scripts/recovery/check-vercel-function-count.sh` -> `Vercel function count check: 12/12`;
   - `scripts/recovery/preflight.sh --quick --skip-status` -> `Preflight completed`.
-- Push, PR checks, review follow-up, and merge are still pending.
+- PR #102 was merged into `main` with merge commit `4d21e4f`.
+- This plan is complete for Phase C storage-port scaffolding only.
+- Still not implemented by this plan: auth provider integration, user profiles, cloud project library UI, durable database provisioning/migrations, storage routes, owner-scoped cloud save/load/list/delete endpoints, and signed-in account sync.
 
 ## Context and Orientation
 
 Repository root: this checkout. Run commands from the repository root.
 
-Active branch for this plan: `feature/story-lab-storage-port`.
+Active branch for the original implementation: `feature/story-lab-storage-port`.
+
+Current work should use the split-recovery branches described in `STORY_LAB_UNPUBLISHED_BRANCH_SPLIT_PLAN.md`.
 
 Important files:
 
@@ -93,7 +102,7 @@ Important files:
 - `api/_lib/story-lab/auth/authPort.ts`: `AuthUser` and deny-by-default auth port.
 - `api/_lib/story-lab/auth/authorizeProjectAccess.ts`: owner authorization helper.
 - `api/_lib/story-lab/stateStore.ts`: transient continuity state. Do not confuse it with durable account storage.
-- `scripts/recovery/check-vercel-function-count.sh`: route guard; must stay `12/12`.
+- `scripts/recovery/check-vercel-function-count.sh`: route guard; must stay within the Vercel limit.
 
 Unrelated untracked files to leave alone:
 
@@ -183,6 +192,7 @@ Keep frontend storage unchanged. Phase C only prepares the backend storage port;
 12. Update `STORY_LAB_PLATFORM_EVOLUTION_EXEC_PLAN.md`, `PR70_RECOVERY_CHANGELOG.md`, and `LESSONS_LEARNED.md`.
 13. Validate.
 14. Commit, push, create PR, address checks/review, and merge.
+15. For future cloud-sync work, stop using this Phase C plan as implementation permission and use the auth/profile/cloud-library checklist.
 
 ## Validation and Acceptance
 
@@ -198,7 +208,7 @@ Run from the repository root:
 Expected results:
 
 - all commands pass;
-- function count remains `12/12`;
+- function count remains within the Vercel limit;
 - importing the Postgres adapter without `DATABASE_URL` passes;
 - in-memory store save/load/list/delete is owner-scoped;
 - cross-owner load/delete returns forbidden/not accessible behavior and does not leak private story text;
@@ -220,6 +230,11 @@ PR #100 was merged before this plan started:
 
 - PR: `https://github.com/Phazzie/FairytaleswithSpice/pull/100`
 - Merge commit: `e4add59eb4dfaf128effe6fb0547fc4f27308566`
+
+PR #102 merged this Phase C storage-port scaffold:
+
+- PR: `https://github.com/Phazzie/FairytaleswithSpice/pull/102`
+- Merge commit: `4d21e4f`
 
 Phase C must remain smaller than account sync:
 

--- a/STORY_LAB_UNPUBLISHED_BRANCH_SPLIT_PLAN.md
+++ b/STORY_LAB_UNPUBLISHED_BRANCH_SPLIT_PLAN.md
@@ -56,7 +56,9 @@ Validation:
 
 ### PR 2: Operating Docs And Auth/Profile Plan Baseline
 
-Goal: preserve the non-code audit, idea board, overnight plan, and auth/profile plan setup that later code slices reference.
+Goal: preserve the operating rules, idea board, storage-plan reconciliation, and auth/profile/cloud-library checklist that later code slices reference.
+
+Scope correction: do not land the old full `STORY_LAB_APP_AUDIT.md` or `OVERNIGHT_HANDOFF.md` from the unpublished branch in this PR. The audit describes later unpublished work as current reality, and the handoff is too large/stale for a clean review. Reintroduce either doc later only after rewriting it against the landed `main` state.
 
 Likely commits:
 
@@ -69,13 +71,11 @@ Likely commits:
 
 Key files:
 
-- `STORY_LAB_APP_AUDIT.md`
 - `STORY_LAB_IDEA_BOARD.md`
 - `OVERNIGHT_MODE.md`
-- `OVERNIGHT_HANDOFF.md`
 - `STORY_LAB_AUTH_PROFILE_CLOUD_LIBRARY_EXEC_PLAN.md`
+- `STORY_LAB_STORAGE_PORT_EXEC_PLAN.md`
 - `AGENTS.md`
-- `LESSONS_LEARNED.md`
 - `PR70_RECOVERY_CHANGELOG.md`
 
 Validation:


### PR DESCRIPTION
## Summary
- Add a compact Overnight Mode guide for autonomous Story Lab work.
- Add a truthful idea/backlog board and auth/profile/cloud-library checklist for splitting the unpublished branch.
- Reconcile the storage-port plan now that PR #102 is merged, and update the split plan/changelog for PR #2 scope.

## Intentional Exclusions
- Does not include the old full `OVERNIGHT_HANDOFF.md`; branch-head version was too large and stale.
- Does not include the old full `STORY_LAB_APP_AUDIT.md`; it described unpublished branch work as current evidence.
- Does not add feature code, routes, storage, auth dependencies, or UI changes.

## Validation
- `git diff --check`
- conflict-marker scan across touched docs
- absolute local path scan across touched docs
- `scripts/recovery/check-vercel-function-count.sh` -> `10/12`
- `scripts/recovery/preflight.sh --quick --skip-status`

## Summary by Sourcery

Document Story Lab operating practices for autonomous work, clarify storage-port plan status after recent merges, and establish a checklist for future auth/profile/cloud-library development without enabling new runtime behavior.

Enhancements:
- Reconciled the Story Lab storage-port execution plan with the merged Phase C scaffold, updated route-budget assumptions, and pointed remaining work to the auth/profile/cloud-library plan.
- Expanded AGENTS.md with a required startup order, current operating direction, and pointers to active Story Lab execution plans and checklists.
- Recorded the merge of PR #114 and the scoped intent of PR #2 in the recovery changelog, including publication-discipline decisions for operating docs.
- Updated the unpublished-branch split plan to narrow PR #2 to operating docs, storage-plan reconciliation, and the auth/profile/cloud-library checklist, explicitly excluding stale full audits and handoff docs.

Documentation:
- Added an Overnight Mode guide describing how long autonomous coding sessions should select tasks, validate work, manage safety gates, and hand off progress.
- Introduced a Story Lab auth/profile/cloud-library execution checklist that sequences auth contracts, cloud schema, account routes, UI, and durable job scaffolding while guarding against premature cloud-sync claims.
- Created a Story Lab idea board that captures priorities, status labels, research notes, Weird Lab candidates, and parked local artifacts to guide future autonomous and product work.