### PR TITLE
Add Story Lab cloud storage scaffold

### DIFF
--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -135,3 +135,5 @@ This file consolidates lessons that should shape the PR #70 recovery and future 
 - Large autonomous implementation blocks still need merge discipline. Once a slice validates, push it, open a PR, address review/checks, and merge before starting the next slice. A long local-only commit stack makes good work harder to trust, review, and land.
 - If a branch accumulates multiple validated slices locally, stop feature work immediately and turn it into a publishing task. Inventory commits, split into reviewable PRs, and use a remote backup branch only as a safety anchor, not as a substitute for mergeable PRs.
 - A validated but unpublished slice is a stop condition for feature work: publishing, PR review, checks, and merge become the next task.
+- Runtime validation should consume shared contract constants, not duplicate string literal unions. Otherwise preference normalizers, tests, and UI contracts can drift while TypeScript still appears clean.
+- Auth and private-storage observability must be redacted by default. Log safe operation names and error classes, not raw provider errors that may include tokens, emails, story text, SQL params, URLs, or profile payloads.

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -2530,5 +2530,32 @@ Validation:
 
 Self-review:
 
-- Scope risk found: one source commit touched the later account-route handler. That hunk was deliberately removed so PR #4 stays storage-only.
+- Scope risk found: one source commit touched the later account-route handler. That hunk was deliberately removed so this change set stays storage-only.
 - Honesty check: docs and PR language must say schema/config/readiness scaffold, not cloud save, live database, or durable sync.
+
+## 2026-06-13 08:48 EDT - PR 118 Review Follow-Up
+
+Actions:
+
+- Addressed PR #118 review feedback:
+  - made explicit `env: {}` cloud-storage config ignore ambient `process.env.DATABASE_URL`;
+  - loaded the tracked SQL schema relative to the module directory instead of the process CWD;
+  - extended the schema statement splitter for block comments and dollar-quoted SQL bodies;
+  - cast readiness `to_regclass(...)` values to text and accepted schema-prefixed table names;
+  - reworded the changelog self-review note to avoid confusing internal slice numbering with GitHub PR numbers.
+- Checked the installed `@neondatabase/serverless` package and confirmed `neon()` returns a function with a documented `.query(text, params)` method in this version; added a non-network regression test for that API shape rather than switching to an incompatible direct-call form.
+
+Validation:
+
+- `npm run test:story-lab-cloud-storage-config`: passed.
+- `npm run test:story-lab-neon-executor`: passed.
+- `npm run test:story-lab-cloud-schema-migration`: passed.
+- `npm run test:story-lab-cloud-db-readiness`: passed.
+- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`: passed.
+- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit`: passed.
+- `git diff --check`: passed.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
+- `npm run test:all`: passed in mock mode because `XAI_API_KEY` is not configured.
+- First `scripts/recovery/preflight.sh --quick --skip-status` run failed because `import.meta.url` is not allowed under the API CommonJS typecheck.
+- After switching the schema loader to `__dirname`, `npm run test:story-lab-cloud-schema-migration` passed.
+- After switching the schema loader to `__dirname`, `scripts/recovery/preflight.sh --quick --skip-status` passed.

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -2488,3 +2488,47 @@ Validation:
 - `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
 - `npm run test:all`: passed in mock mode because `XAI_API_KEY` is not configured.
 - `scripts/recovery/preflight.sh --quick --skip-status`: passed.
+
+## 2026-06-13 08:40 EDT - Cloud Storage Scaffold Slice Ready For PR
+
+Actions:
+
+- Confirmed PR #116 merged into `main` as `d8b53fd`.
+- Started `recovery/story-lab-cloud-storage-scaffold` from `origin/main` after PR #116 merged.
+- Cherry-picked the cloud storage/database scaffold slice in dependency order:
+  - `7144dff`
+  - `aa8d848`
+  - `c3d77f0`
+  - `2bd5691`
+  - `bf5cf38`
+- Dropped stale `OVERNIGHT_HANDOFF.md` and `STORY_LAB_APP_AUDIT.md` conflicts from the code slice.
+- Dropped the `api/_lib/story-lab/account/accountRouteHandlers.ts` hunk from this slice because the consolidated account route belongs to the next PR.
+- Added migration-ready cloud schema SQL, guarded cloud storage config, a Neon query executor wrapper, guarded schema apply/readiness helpers, and focused tests.
+- Updated the auth/profile/cloud-library checklist, split plan, idea board, and lessons to record PR #116 as merged and this storage slice as storage-only.
+
+Decision:
+
+- This slice adds storage/database scaffolding only.
+- It does not execute a migration, provision a database, add an account route, add signed-in UI, or claim live cloud persistence.
+
+Validation:
+
+- RED baseline: all five cloud-storage scripts were missing before the slice.
+- `npm run test:story-lab-cloud-schema`: passed.
+- `npm run test:story-lab-cloud-storage-config`: passed.
+- `npm run test:story-lab-neon-executor`: passed.
+- `npm run test:story-lab-cloud-schema-migration`: passed.
+- `npm run test:story-lab-cloud-db-readiness`: passed.
+- `npm run test:story-lab-profile-store`: passed.
+- `npm run test:story-lab-storage-port`: passed.
+- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`: passed.
+- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit`: passed.
+- `git diff --check`: passed.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
+- `npm run test:all`: passed in mock mode because `XAI_API_KEY` is not configured.
+- `scripts/recovery/preflight.sh --quick --skip-status`: passed.
+
+Self-review:
+
+- Scope risk found: one source commit touched the later account-route handler. That hunk was deliberately removed so PR #4 stays storage-only.
+- Honesty check: docs and PR language must say schema/config/readiness scaffold, not cloud save, live database, or durable sync.

--- a/STORY_LAB_AUTH_PROFILE_CLOUD_LIBRARY_EXEC_PLAN.md
+++ b/STORY_LAB_AUTH_PROFILE_CLOUD_LIBRARY_EXEC_PLAN.md
@@ -17,11 +17,15 @@ The desired user-visible outcome is:
 
 ## Current Reality On Main
 
-This checklist starts after PR #114.
+This checklist is current after PR #116.
 
 - `AuthPort` exists and is deny-by-default.
 - `authorizeProjectAccess` exists.
 - `StoryProjectStore` exists with non-durable memory and injected Postgres scaffolds.
+- Story Lab profile, cloud-library, and preference contract types exist.
+- Configured auth selection fails closed unless a supported provider is configured.
+- A Clerk-shaped auth adapter scaffold exists, but it still requires an injected verifier and is not a live sign-in flow.
+- Profile stores exist for non-durable memory and injected Postgres execution.
 - Browser-local `StoryWorkspaceStorageService` remains the current user-visible save path.
 - Story Lab jobs are still `non_durable_memory` and not account-owned.
 - Vercel function count must stay within the repo guard.
@@ -56,7 +60,7 @@ Not live yet:
 - [x] Address PR #114 review comments.
 - [x] Merge PR #114.
 - [x] Land the operating-docs baseline through PR #115.
-- [ ] Land auth/profile contracts.
+- [x] Land auth/profile contracts through PR #116.
 - [ ] Land cloud schema/storage readiness.
 - [ ] Land consolidated account route.
 - [ ] Land Angular cloud library UI.
@@ -66,13 +70,16 @@ Not live yet:
 
 Goal: add the account/profile domain seam without live provider or database claims.
 
-Status on `recovery/story-lab-auth-profile-contracts`:
+Status:
 
+- Merged through PR #116 on 2026-06-13.
 - Implemented profile/cloud-library contract types.
 - Added fail-closed configured auth selection.
 - Added Clerk-shaped auth adapter scaffold that requires an injected verifier.
 - Added non-durable and injected-Postgres profile store scaffolds.
 - Hardened profile preference normalization from runtime data.
+- Centralized runtime preference allowed values in shared contract constants to prevent type/runtime drift.
+- Added redacted auth/profile storage warnings that avoid logging tokens, emails, story text, SQL params, or raw provider payloads.
 - Still not live auth, signed-in UI, durable profiles, or cloud project sync.
 
 Candidate local commits:
@@ -131,6 +138,15 @@ Validation on 2026-06-13:
 
 Goal: add schema/readiness/config/executor scaffolding while staying guarded when no real `DATABASE_URL` exists.
 
+Status on `recovery/story-lab-cloud-storage-scaffold`:
+
+- Implemented and locally validated after PR #116 merged; PR/review/merge pending.
+- Adds migration-ready SQL for private profiles and owner-scoped story projects.
+- Adds cloud storage config that creates profile/project stores only when `DATABASE_URL` and an executor are available.
+- Adds a Neon executor wrapper with injectable query creation for tests.
+- Adds guarded schema-apply and readiness-smoke scripts that refuse missing `DATABASE_URL`.
+- Does not execute a migration, provision a database, add an account route, or claim live cloud persistence.
+
 Candidate local commits:
 
 - `7144dff Add Story Lab cloud schema scaffold`
@@ -155,6 +171,23 @@ Acceptance:
 - guarded scripts refuse missing `DATABASE_URL`;
 - driver creation is lazy and testable with injected executors;
 - no live database migration is claimed unless actually run.
+
+Validation on 2026-06-13:
+
+- RED baseline: all five cloud-storage scripts were missing before the slice.
+- `npm run test:story-lab-cloud-schema`: passed.
+- `npm run test:story-lab-cloud-storage-config`: passed.
+- `npm run test:story-lab-neon-executor`: passed.
+- `npm run test:story-lab-cloud-schema-migration`: passed.
+- `npm run test:story-lab-cloud-db-readiness`: passed.
+- `npm run test:story-lab-profile-store`: passed.
+- `npm run test:story-lab-storage-port`: passed.
+- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`: passed.
+- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit`: passed.
+- `git diff --check`: passed.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `10/12`.
+- `npm run test:all`: passed in mock mode because `XAI_API_KEY` is not configured.
+- `scripts/recovery/preflight.sh --quick --skip-status`: passed.
 
 ### Phase 3: Consolidated Account Route
 

--- a/STORY_LAB_IDEA_BOARD.md
+++ b/STORY_LAB_IDEA_BOARD.md
@@ -61,6 +61,19 @@ Tracking:
 
 - `STORY_LAB_AUTH_PROFILE_CLOUD_LIBRARY_EXEC_PLAN.md`
 
+### Done: Auth And Profile Contracts
+
+PR #116 merged on 2026-06-13 and added the account/profile domain seam without live provider or database claims.
+
+Acceptance evidence:
+
+- Missing auth provider config fails closed.
+- The Clerk-shaped adapter does not turn raw tokens into users without an injected verifier.
+- Profile preferences are normalized as runtime data.
+- Runtime preference allowed values are shared contract constants rather than duplicated string sets.
+- Auth/profile storage warnings are redacted and do not log tokens, emails, story text, SQL params, or raw provider payloads.
+- Focused auth/profile tests, TypeScript checks, function-count check, `npm run test:all`, and preflight passed before merge.
+
 ### Now: Storage Plan Reconciliation
 
 The storage port plan should continue to distinguish the merged route-free Phase C scaffold from unfinished account/cloud sync work.
@@ -71,34 +84,14 @@ Acceptance:
 - Current route count wording reflects the post-route-budget baseline.
 - Remaining work points to auth/profile/cloud-library planning instead of treating storage-port scaffolding as unfinished.
 
-### Local-only: Auth And Profile Contracts
+### Now: Cloud Storage And Database Scaffold
 
-Add the account/profile domain seam without live provider or database claims.
+Add schema, migration, readiness, and storage-config seams while staying guarded when no real `DATABASE_URL` exists.
 
 Status:
 
-- Implemented on `recovery/story-lab-auth-profile-contracts`.
-- Pending PR checks, review comments, and merge before it counts as `Done`.
-
-Candidate source commits from the local stack:
-
-- `75b485f Add Story Lab auth profile contract slice`
-- `6459454 Add Story Lab profile store slice`
-- `b99ad12 Add Clerk auth adapter scaffold`
-- `99317f1 Add env-gated Story Lab Clerk auth config`
-- `448d0c3 Harden Story Lab profile preferences`
-
-Acceptance:
-
-- Missing auth provider config fails closed.
-- The Clerk-shaped adapter does not turn raw tokens into users without an injected verifier.
-- Profile preferences are normalized as runtime data.
-- Tests prove profile contracts, configured auth, Clerk adapter behavior, and profile store behavior.
-- PR language says "contracts/store seams/scaffold," not "cloud library shipped."
-
-### Soon: Cloud Storage And Database Scaffold
-
-Add schema, migration, readiness, and storage-config seams while staying guarded when no real `DATABASE_URL` exists.
+- Implemented and locally validated on `recovery/story-lab-cloud-storage-scaffold`; PR/review/merge pending before it counts as `Done`.
+- Storage-only scope: no account route, signed-in UI, live migration, or cloud-sync claim.
 
 Acceptance:
 

--- a/STORY_LAB_UNPUBLISHED_BRANCH_SPLIT_PLAN.md
+++ b/STORY_LAB_UNPUBLISHED_BRANCH_SPLIT_PLAN.md
@@ -86,7 +86,7 @@ Validation:
 
 Goal: add the account/profile domain seam without live provider or database claims.
 
-Status: implemented on `recovery/story-lab-auth-profile-contracts`; PR/review/merge pending.
+Status: merged through PR #116 on 2026-06-13.
 
 Likely commits:
 
@@ -118,6 +118,8 @@ Validation:
 ### PR 4: Cloud Storage And Database Scaffold
 
 Goal: add schema/readiness/config/executor scaffolding while staying guarded when no real `DATABASE_URL` exists.
+
+Status: implemented and locally validated on `recovery/story-lab-cloud-storage-scaffold` after PR #116 merged; PR/review/merge pending. Keep this slice storage-only; do not include the later consolidated account route or stale handoff/audit files.
 
 Likely commits:
 

--- a/api/_lib/story-lab/storage/neonStoryLabExecutor.ts
+++ b/api/_lib/story-lab/storage/neonStoryLabExecutor.ts
@@ -1,0 +1,36 @@
+// Created: 2026-06-08 11:00 EDT
+
+import { neon } from '@neondatabase/serverless';
+import type { StoryLabCloudQueryExecutor } from './storyLabCloudStorageConfig';
+
+export type NeonStoryLabQuery = (sql: string, params: readonly unknown[]) => Promise<unknown[]>;
+
+export interface NeonStoryLabExecutorOptions {
+  createQuery?: (databaseUrl: string) => NeonStoryLabQuery;
+}
+
+export function createNeonStoryLabQueryExecutor(
+  databaseUrl: string,
+  options: NeonStoryLabExecutorOptions = {}
+): StoryLabCloudQueryExecutor {
+  const normalizedDatabaseUrl = databaseUrl.trim();
+  if (!normalizedDatabaseUrl) {
+    throw new Error('DATABASE_URL is required to create the Story Lab Neon executor.');
+  }
+
+  const runQuery = options.createQuery?.(normalizedDatabaseUrl) ?? createDefaultNeonQuery(normalizedDatabaseUrl);
+
+  return {
+    async query<T = unknown>(sql: string, params: readonly unknown[]): Promise<{ rows: T[] }> {
+      const rows = await runQuery(sql, params);
+      return {
+        rows: rows as T[]
+      };
+    }
+  };
+}
+
+function createDefaultNeonQuery(databaseUrl: string): NeonStoryLabQuery {
+  const sql = neon(databaseUrl);
+  return async (queryText, params) => sql.query(queryText, [...params]);
+}

--- a/api/_lib/story-lab/storage/storyLabCloudDatabaseReadiness.ts
+++ b/api/_lib/story-lab/storage/storyLabCloudDatabaseReadiness.ts
@@ -1,0 +1,79 @@
+// Created: 2026-06-08 11:10 EDT
+
+import type { StoryLabCloudQueryExecutor } from './storyLabCloudStorageConfig';
+
+export interface StoryLabCloudDatabaseReadinessOptions {
+  now?: () => string;
+}
+
+export interface StoryLabCloudDatabaseReadinessResult {
+  ready: boolean;
+  missing: string[];
+  checkedAt: string;
+  error?: string;
+}
+
+interface TableReadinessRow {
+  story_lab_profiles: string | null;
+  story_projects: string | null;
+}
+
+interface IndexReadinessRow {
+  indexname: string;
+}
+
+const REQUIRED_TABLES = ['story_lab_profiles', 'story_projects'] as const;
+const REQUIRED_INDEXES = ['story_projects_owner_updated_idx', 'story_projects_owner_story_idx'] as const;
+
+const TABLE_READINESS_SQL = `
+select
+  to_regclass('public.story_lab_profiles') as story_lab_profiles,
+  to_regclass('public.story_projects') as story_projects
+`;
+
+const INDEX_READINESS_SQL = `
+select indexname
+from pg_indexes
+where schemaname = 'public'
+  and tablename = 'story_projects'
+  and indexname in ('story_projects_owner_updated_idx', 'story_projects_owner_story_idx')
+`;
+
+export async function checkStoryLabCloudDatabaseReadiness(
+  executor: StoryLabCloudQueryExecutor,
+  options: StoryLabCloudDatabaseReadinessOptions = {}
+): Promise<StoryLabCloudDatabaseReadinessResult> {
+  const checkedAt = options.now?.() ?? new Date().toISOString();
+
+  try {
+    const tableResult = await executor.query<TableReadinessRow>(TABLE_READINESS_SQL, []);
+    const indexResult = await executor.query<IndexReadinessRow>(INDEX_READINESS_SQL, []);
+    const tableRow = tableResult.rows[0];
+    const foundIndexes = new Set(indexResult.rows.map(row => row.indexname));
+    const missing = [
+      ...missingTables(tableRow),
+      ...REQUIRED_INDEXES.filter(indexName => !foundIndexes.has(indexName))
+    ];
+
+    return {
+      ready: missing.length === 0,
+      missing,
+      checkedAt
+    };
+  } catch {
+    return {
+      ready: false,
+      missing: [...REQUIRED_TABLES, ...REQUIRED_INDEXES],
+      checkedAt,
+      error: 'Story Lab cloud database readiness check failed.'
+    };
+  }
+}
+
+function missingTables(row: TableReadinessRow | undefined): string[] {
+  if (!row) {
+    return [...REQUIRED_TABLES];
+  }
+
+  return REQUIRED_TABLES.filter(tableName => row[tableName] !== tableName);
+}

--- a/api/_lib/story-lab/storage/storyLabCloudDatabaseReadiness.ts
+++ b/api/_lib/story-lab/storage/storyLabCloudDatabaseReadiness.ts
@@ -27,8 +27,8 @@ const REQUIRED_INDEXES = ['story_projects_owner_updated_idx', 'story_projects_ow
 
 const TABLE_READINESS_SQL = `
 select
-  to_regclass('public.story_lab_profiles') as story_lab_profiles,
-  to_regclass('public.story_projects') as story_projects
+  to_regclass('public.story_lab_profiles')::text as story_lab_profiles,
+  to_regclass('public.story_projects')::text as story_projects
 `;
 
 const INDEX_READINESS_SQL = `
@@ -75,5 +75,9 @@ function missingTables(row: TableReadinessRow | undefined): string[] {
     return [...REQUIRED_TABLES];
   }
 
-  return REQUIRED_TABLES.filter(tableName => row[tableName] !== tableName);
+  return REQUIRED_TABLES.filter(tableName => !matchesTableName(row[tableName], tableName));
+}
+
+function matchesTableName(value: string | null, tableName: string): boolean {
+  return value?.split('.').pop() === tableName;
 }

--- a/api/_lib/story-lab/storage/storyLabCloudSchema.sql
+++ b/api/_lib/story-lab/storage/storyLabCloudSchema.sql
@@ -1,0 +1,43 @@
+-- Story Lab cloud library schema scaffold.
+-- Created: 2026-06-08 10:45 EDT
+--
+-- This file is a migration-ready contract for Vercel Marketplace Postgres/Neon-style
+-- storage. It is not executed automatically by the app.
+
+create table if not exists story_lab_profiles (
+  user_id text primary key,
+  display_name text,
+  preferences_json jsonb not null,
+  created_at timestamptz not null,
+  updated_at timestamptz not null
+);
+
+create table if not exists story_projects (
+  id text primary key,
+  owner_user_id text not null,
+  story_id text not null,
+  title text not null,
+  synopsis text not null,
+  tone text not null,
+  spicy_level integer not null,
+  creature text not null,
+  active_skin text not null,
+  latest_revision integer not null,
+  project_json jsonb not null,
+  created_at timestamptz not null,
+  updated_at timestamptz not null
+);
+
+create index if not exists story_projects_owner_updated_idx
+  on story_projects (owner_user_id, updated_at desc)
+  where owner_user_id is not null;
+
+create index if not exists story_projects_owner_story_idx
+  on story_projects (owner_user_id, story_id)
+  where owner_user_id is not null;
+
+comment on table story_lab_profiles is
+  'Private Story Lab user profiles keyed by provider user id. Editable profile fields must not be used for authorization.';
+
+comment on table story_projects is
+  'Owner-scoped Story Lab saved projects. App routes must always filter by owner_user_id.';

--- a/api/_lib/story-lab/storage/storyLabCloudSchemaMigration.ts
+++ b/api/_lib/story-lab/storage/storyLabCloudSchemaMigration.ts
@@ -38,7 +38,7 @@ export async function applyStoryLabCloudSchema(
 }
 
 export function loadStoryLabCloudSchemaSql(): string {
-  return readFileSync(resolve('api/_lib/story-lab/storage/storyLabCloudSchema.sql'), 'utf8');
+  return readFileSync(resolve(__dirname, 'storyLabCloudSchema.sql'), 'utf8');
 }
 
 export function splitStoryLabCloudSchemaStatements(schemaSql: string): string[] {
@@ -46,10 +46,23 @@ export function splitStoryLabCloudSchemaStatements(schemaSql: string): string[] 
   let current = '';
   let inSingleQuote = false;
   let inLineComment = false;
+  let inBlockComment = false;
+  let dollarQuoteTag: string | null = null;
 
   for (let index = 0; index < schemaSql.length; index += 1) {
     const char = schemaSql[index] ?? '';
     const next = schemaSql[index + 1] ?? '';
+
+    if (dollarQuoteTag) {
+      if (schemaSql.startsWith(dollarQuoteTag, index)) {
+        current += dollarQuoteTag;
+        index += dollarQuoteTag.length - 1;
+        dollarQuoteTag = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
 
     if (inLineComment) {
       current += char;
@@ -59,9 +72,33 @@ export function splitStoryLabCloudSchemaStatements(schemaSql: string): string[] 
       continue;
     }
 
+    if (inBlockComment) {
+      current += char;
+      if (char === '*' && next === '/') {
+        current += next;
+        index += 1;
+        inBlockComment = false;
+      }
+      continue;
+    }
+
     if (!inSingleQuote && char === '-' && next === '-') {
       inLineComment = true;
       current += char;
+      continue;
+    }
+
+    if (!inSingleQuote && char === '/' && next === '*') {
+      inBlockComment = true;
+      current += char;
+      continue;
+    }
+
+    const openingDollarQuoteTag = !inSingleQuote ? readDollarQuoteTag(schemaSql, index) : null;
+    if (openingDollarQuoteTag) {
+      dollarQuoteTag = openingDollarQuoteTag;
+      current += openingDollarQuoteTag;
+      index += openingDollarQuoteTag.length - 1;
       continue;
     }
 
@@ -99,10 +136,19 @@ function pushStatement(statements: string[], statement: string): void {
 }
 
 function hasSqlBody(statement: string): boolean {
-  return statement
+  return stripBlockComments(statement)
     .split('\n')
     .some(line => {
-      const trimmedLine = line.trim();
-      return trimmedLine && !trimmedLine.startsWith('--');
+      const [sqlBeforeLineComment] = line.split('--');
+      return Boolean(sqlBeforeLineComment?.trim());
     });
+}
+
+function readDollarQuoteTag(schemaSql: string, index: number): string | null {
+  const match = schemaSql.slice(index).match(/^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$/);
+  return match?.[0] ?? null;
+}
+
+function stripBlockComments(statement: string): string {
+  return statement.replace(/\/\*[\s\S]*?\*\//g, '');
 }

--- a/api/_lib/story-lab/storage/storyLabCloudSchemaMigration.ts
+++ b/api/_lib/story-lab/storage/storyLabCloudSchemaMigration.ts
@@ -1,0 +1,108 @@
+// Created: 2026-06-08 11:05 EDT
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { StoryLabCloudQueryExecutor } from './storyLabCloudStorageConfig';
+
+export interface ApplyStoryLabCloudSchemaOptions {
+  schemaSql?: string;
+  now?: () => string;
+}
+
+export interface ApplyStoryLabCloudSchemaResult {
+  applied: true;
+  statementCount: number;
+  appliedAt: string;
+}
+
+export async function applyStoryLabCloudSchema(
+  executor: StoryLabCloudQueryExecutor,
+  options: ApplyStoryLabCloudSchemaOptions = {}
+): Promise<ApplyStoryLabCloudSchemaResult> {
+  const schemaSql = options.schemaSql ?? loadStoryLabCloudSchemaSql();
+  const statements = splitStoryLabCloudSchemaStatements(schemaSql);
+
+  if (statements.length === 0) {
+    throw new Error('Story Lab cloud schema is empty.');
+  }
+
+  for (const statement of statements) {
+    await executor.query(statement, []);
+  }
+
+  return {
+    applied: true,
+    statementCount: statements.length,
+    appliedAt: options.now?.() ?? new Date().toISOString()
+  };
+}
+
+export function loadStoryLabCloudSchemaSql(): string {
+  return readFileSync(resolve('api/_lib/story-lab/storage/storyLabCloudSchema.sql'), 'utf8');
+}
+
+export function splitStoryLabCloudSchemaStatements(schemaSql: string): string[] {
+  const statements: string[] = [];
+  let current = '';
+  let inSingleQuote = false;
+  let inLineComment = false;
+
+  for (let index = 0; index < schemaSql.length; index += 1) {
+    const char = schemaSql[index] ?? '';
+    const next = schemaSql[index + 1] ?? '';
+
+    if (inLineComment) {
+      current += char;
+      if (char === '\n') {
+        inLineComment = false;
+      }
+      continue;
+    }
+
+    if (!inSingleQuote && char === '-' && next === '-') {
+      inLineComment = true;
+      current += char;
+      continue;
+    }
+
+    if (char === "'") {
+      current += char;
+      if (inSingleQuote && next === "'") {
+        current += next;
+        index += 1;
+        continue;
+      }
+
+      inSingleQuote = !inSingleQuote;
+      continue;
+    }
+
+    if (char === ';' && !inSingleQuote) {
+      pushStatement(statements, current);
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  pushStatement(statements, current);
+
+  return statements.filter(statement => hasSqlBody(statement));
+}
+
+function pushStatement(statements: string[], statement: string): void {
+  const trimmedStatement = statement.trim();
+  if (trimmedStatement) {
+    statements.push(trimmedStatement);
+  }
+}
+
+function hasSqlBody(statement: string): boolean {
+  return statement
+    .split('\n')
+    .some(line => {
+      const trimmedLine = line.trim();
+      return trimmedLine && !trimmedLine.startsWith('--');
+    });
+}

--- a/api/_lib/story-lab/storage/storyLabCloudStorageConfig.ts
+++ b/api/_lib/story-lab/storage/storyLabCloudStorageConfig.ts
@@ -1,0 +1,77 @@
+// Created: 2026-06-08 10:50 EDT
+
+import type { StoryLabProfileStore } from '../profile/storyLabProfileStore';
+import {
+  createPostgresStoryLabProfileStore,
+  type PostgresProfileQueryExecutor
+} from '../profile/postgresStoryLabProfileStore';
+import {
+  createPostgresStoryProjectStore,
+  type PostgresQueryExecutor
+} from './postgresStoryProjectStore';
+import { createNeonStoryLabQueryExecutor } from './neonStoryLabExecutor';
+import type { StoryProjectStore } from './storyProjectStore';
+
+export interface StoryLabCloudQueryExecutor extends PostgresProfileQueryExecutor, PostgresQueryExecutor {}
+
+export interface StoryLabCloudStorageConfigOptions {
+  databaseUrl?: string;
+  env?: Record<string, string | undefined>;
+  executor?: StoryLabCloudQueryExecutor;
+  createExecutor?: (databaseUrl: string) => StoryLabCloudQueryExecutor;
+  now?: () => string;
+}
+
+export interface StoryLabCloudStorageConfig {
+  databaseUrlConfigured: boolean;
+  executorConfigured: boolean;
+  profileStore: StoryLabProfileStore;
+  projectStore: StoryProjectStore;
+  isConfigured(): boolean;
+}
+
+export function createStoryLabCloudStorage(
+  options: StoryLabCloudStorageConfigOptions = {}
+): StoryLabCloudStorageConfig {
+  const databaseUrl = resolveDatabaseUrl(options);
+  const executor = databaseUrl ? resolveExecutor(databaseUrl, options) : undefined;
+  const profileStore = createPostgresStoryLabProfileStore({
+    databaseUrl,
+    executor,
+    now: options.now
+  });
+  const projectStore = createPostgresStoryProjectStore({
+    databaseUrl,
+    executor,
+    now: options.now
+  });
+
+  return {
+    databaseUrlConfigured: Boolean(databaseUrl),
+    executorConfigured: Boolean(executor),
+    profileStore,
+    projectStore,
+    isConfigured() {
+      return Boolean(databaseUrl && executor && profileStore.isConfigured() && projectStore.isConfigured());
+    }
+  };
+}
+
+function resolveDatabaseUrl(options: StoryLabCloudStorageConfigOptions): string {
+  return options.databaseUrl ?? options.env?.['DATABASE_URL'] ?? process.env['DATABASE_URL'] ?? '';
+}
+
+function resolveExecutor(
+  databaseUrl: string,
+  options: StoryLabCloudStorageConfigOptions
+): StoryLabCloudQueryExecutor | undefined {
+  if (options.executor) {
+    return options.executor;
+  }
+
+  try {
+    return options.createExecutor?.(databaseUrl) ?? createNeonStoryLabQueryExecutor(databaseUrl);
+  } catch {
+    return undefined;
+  }
+}

--- a/api/_lib/story-lab/storage/storyLabCloudStorageConfig.ts
+++ b/api/_lib/story-lab/storage/storyLabCloudStorageConfig.ts
@@ -58,7 +58,15 @@ export function createStoryLabCloudStorage(
 }
 
 function resolveDatabaseUrl(options: StoryLabCloudStorageConfigOptions): string {
-  return options.databaseUrl ?? options.env?.['DATABASE_URL'] ?? process.env['DATABASE_URL'] ?? '';
+  if (options.databaseUrl !== undefined) {
+    return options.databaseUrl;
+  }
+
+  if (options.env) {
+    return options.env['DATABASE_URL'] ?? '';
+  }
+
+  return process.env['DATABASE_URL'] ?? '';
 }
 
 function resolveExecutor(

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@neondatabase/serverless": "^1.1.0",
         "axios": "^1.16.1",
         "dotenv": "^17.2.2"
       },
@@ -429,6 +430,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@neondatabase/serverless": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.1.0.tgz",
+      "integrity": "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=19.0.0"
       }
     },
     "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,15 @@
     "test:story-lab-configured-auth": "tsx tests/story-lab-configured-auth.test.ts",
     "test:story-lab-clerk-auth": "tsx tests/story-lab-clerk-auth.test.ts",
     "test:story-lab-storage-port": "tsx tests/story-lab-storage-port.test.ts",
+    "test:story-lab-cloud-schema": "tsx tests/story-lab-cloud-schema.test.ts",
+    "test:story-lab-cloud-storage-config": "tsx tests/story-lab-cloud-storage-config.test.ts",
+    "test:story-lab-neon-executor": "tsx tests/story-lab-neon-executor.test.ts",
+    "test:story-lab-cloud-schema-migration": "tsx tests/story-lab-cloud-schema-migration.test.ts",
+    "test:story-lab-cloud-db-readiness": "tsx tests/story-lab-cloud-db-readiness.test.ts",
     "test:story-lab-profile-contracts": "tsx tests/story-lab-profile-contracts.test.ts",
     "test:story-lab-profile-store": "tsx tests/story-lab-profile-store.test.ts",
     "test:story-quality": "tsx tests/story-quality-evals.test.ts",
-    "test:all": "npm run test:story && npm run test:tropes && npm run test:cliffhangers && npm run test:story-lab-state && npm run test:story-lab-real-engine && npm run test:story-lab-auth && npm run test:story-lab-configured-auth && npm run test:story-lab-clerk-auth && npm run test:story-lab-storage-port && npm run test:story-lab-profile-contracts && npm run test:story-lab-profile-store && npm run test:story-quality",
+    "test:all": "npm run test:story && npm run test:tropes && npm run test:cliffhangers && npm run test:story-lab-state && npm run test:story-lab-real-engine && npm run test:story-lab-auth && npm run test:story-lab-configured-auth && npm run test:story-lab-clerk-auth && npm run test:story-lab-storage-port && npm run test:story-lab-cloud-schema && npm run test:story-lab-cloud-storage-config && npm run test:story-lab-neon-executor && npm run test:story-lab-cloud-schema-migration && npm run test:story-lab-cloud-db-readiness && npm run test:story-lab-profile-contracts && npm run test:story-lab-profile-store && npm run test:story-quality",
     "smoke:grok": "tsx tests/grok-multi-agent-smoke.test.ts",
     "smoke:grok-multi-agent": "tsx tests/grok-multi-agent-smoke.test.ts",
     "smoke:story-lab-ui": "node scripts/recovery/story-lab-browser-smoke.mjs",
@@ -32,6 +37,7 @@
     "typescript": "~5.9.2"
   },
   "dependencies": {
+    "@neondatabase/serverless": "^1.1.0",
     "axios": "^1.16.1",
     "dotenv": "^17.2.2"
   }

--- a/scripts/recovery/apply-story-lab-cloud-schema.ts
+++ b/scripts/recovery/apply-story-lab-cloud-schema.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env tsx
+// Created: 2026-06-08 11:05 EDT
+
+import { applyStoryLabCloudSchema } from '../../api/_lib/story-lab/storage/storyLabCloudSchemaMigration';
+import { createNeonStoryLabQueryExecutor } from '../../api/_lib/story-lab/storage/neonStoryLabExecutor';
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env['DATABASE_URL']?.trim() ?? '';
+  if (!databaseUrl) {
+    console.error('Story Lab cloud schema was not applied: DATABASE_URL is not configured.');
+    process.exit(1);
+  }
+
+  try {
+    const result = await applyStoryLabCloudSchema(createNeonStoryLabQueryExecutor(databaseUrl));
+    console.log(`Story Lab cloud schema applied: ${result.statementCount} statements at ${result.appliedAt}.`);
+  } catch {
+    console.error('Story Lab cloud schema apply failed. Check database provisioning and schema permissions.');
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/recovery/story-lab-cloud-db-smoke.ts
+++ b/scripts/recovery/story-lab-cloud-db-smoke.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env tsx
+// Created: 2026-06-08 11:10 EDT
+
+import { checkStoryLabCloudDatabaseReadiness } from '../../api/_lib/story-lab/storage/storyLabCloudDatabaseReadiness';
+import { createNeonStoryLabQueryExecutor } from '../../api/_lib/story-lab/storage/neonStoryLabExecutor';
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env['DATABASE_URL']?.trim() ?? '';
+  if (!databaseUrl) {
+    console.error('Story Lab cloud DB smoke was not run: DATABASE_URL is not configured.');
+    process.exit(1);
+  }
+
+  const result = await checkStoryLabCloudDatabaseReadiness(createNeonStoryLabQueryExecutor(databaseUrl));
+  if (!result.ready) {
+    console.error(`Story Lab cloud DB is not ready. Missing: ${result.missing.join(', ') || 'unknown'}.`);
+    process.exit(1);
+  }
+
+  console.log(`Story Lab cloud DB is ready at ${result.checkedAt}.`);
+}
+
+main().catch(() => {
+  console.error('Story Lab cloud DB smoke failed. Check database provisioning and credentials.');
+  process.exit(1);
+});

--- a/tests/story-lab-cloud-db-readiness.test.ts
+++ b/tests/story-lab-cloud-db-readiness.test.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env tsx
+// Created: 2026-06-08 11:10 EDT
+
+import type { StoryLabCloudQueryExecutor } from '../api/_lib/story-lab/storage/storyLabCloudStorageConfig';
+import { checkStoryLabCloudDatabaseReadiness } from '../api/_lib/story-lab/storage/storyLabCloudDatabaseReadiness';
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+class FakeReadinessExecutor implements StoryLabCloudQueryExecutor {
+  readonly queries: Array<{ sql: string; params: readonly unknown[] }> = [];
+  private readonly queuedRows: unknown[][] = [];
+  shouldThrow = false;
+
+  enqueueRows(rows: unknown[]): void {
+    this.queuedRows.push(rows);
+  }
+
+  async query<T = unknown>(sql: string, params: readonly unknown[]): Promise<{ rows: T[] }> {
+    this.queries.push({ sql, params });
+    if (this.shouldThrow) {
+      throw new Error('raw database outage with secret details');
+    }
+
+    return {
+      rows: (this.queuedRows.shift() ?? []) as T[]
+    };
+  }
+}
+
+async function main() {
+  await testReadyDatabaseReportsReady();
+  await testMissingTableOrIndexReportsNotReady();
+  await testDatabaseErrorsFailClosedWithoutLeakingProviderDetails();
+
+  console.log('Story Lab cloud DB readiness tests passed');
+}
+
+async function testReadyDatabaseReportsReady() {
+  const executor = new FakeReadinessExecutor();
+  executor.enqueueRows([
+    {
+      story_lab_profiles: 'story_lab_profiles',
+      story_projects: 'story_projects'
+    }
+  ]);
+  executor.enqueueRows([
+    { indexname: 'story_projects_owner_updated_idx' },
+    { indexname: 'story_projects_owner_story_idx' }
+  ]);
+
+  const result = await checkStoryLabCloudDatabaseReadiness(executor, {
+    now: () => '2026-06-08T11:10:00.000Z'
+  });
+
+  assert(result.ready, 'database with required tables and indexes should be ready');
+  assert(result.checkedAt === '2026-06-08T11:10:00.000Z', 'readiness should use injected clock');
+  assert(result.missing.length === 0, 'ready database should not report missing items');
+  assert(executor.queries[0]?.sql.includes('to_regclass'), 'readiness should check required tables');
+  assert(executor.queries[1]?.sql.includes('pg_indexes'), 'readiness should check required indexes');
+}
+
+async function testMissingTableOrIndexReportsNotReady() {
+  const executor = new FakeReadinessExecutor();
+  executor.enqueueRows([
+    {
+      story_lab_profiles: null,
+      story_projects: 'story_projects'
+    }
+  ]);
+  executor.enqueueRows([{ indexname: 'story_projects_owner_updated_idx' }]);
+
+  const result = await checkStoryLabCloudDatabaseReadiness(executor, {
+    now: () => '2026-06-08T11:10:00.000Z'
+  });
+
+  assert(!result.ready, 'missing table/index should report not ready');
+  assert(result.missing.includes('story_lab_profiles'), 'missing profile table should be reported');
+  assert(result.missing.includes('story_projects_owner_story_idx'), 'missing owner story index should be reported');
+}
+
+async function testDatabaseErrorsFailClosedWithoutLeakingProviderDetails() {
+  const executor = new FakeReadinessExecutor();
+  executor.shouldThrow = true;
+
+  const result = await checkStoryLabCloudDatabaseReadiness(executor, {
+    now: () => '2026-06-08T11:10:00.000Z'
+  });
+
+  assert(!result.ready, 'database errors should report not ready');
+  assert(result.error === 'Story Lab cloud database readiness check failed.', 'readiness error should use safe message');
+  assert(!JSON.stringify(result).includes('secret details'), 'readiness result should not leak provider error details');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/story-lab-cloud-db-readiness.test.ts
+++ b/tests/story-lab-cloud-db-readiness.test.ts
@@ -43,8 +43,8 @@ async function testReadyDatabaseReportsReady() {
   const executor = new FakeReadinessExecutor();
   executor.enqueueRows([
     {
-      story_lab_profiles: 'story_lab_profiles',
-      story_projects: 'story_projects'
+      story_lab_profiles: 'public.story_lab_profiles',
+      story_projects: 'public.story_projects'
     }
   ]);
   executor.enqueueRows([
@@ -60,6 +60,7 @@ async function testReadyDatabaseReportsReady() {
   assert(result.checkedAt === '2026-06-08T11:10:00.000Z', 'readiness should use injected clock');
   assert(result.missing.length === 0, 'ready database should not report missing items');
   assert(executor.queries[0]?.sql.includes('to_regclass'), 'readiness should check required tables');
+  assert(executor.queries[0]?.sql.includes('::text'), 'readiness should cast regclass values to text for drivers');
   assert(executor.queries[1]?.sql.includes('pg_indexes'), 'readiness should check required indexes');
 }
 

--- a/tests/story-lab-cloud-schema-migration.test.ts
+++ b/tests/story-lab-cloud-schema-migration.test.ts
@@ -26,7 +26,9 @@ class FakeSchemaExecutor implements StoryLabCloudQueryExecutor {
 async function main() {
   await testApplyRunsTrackedSchemaStatementsInOrder();
   testSqlSplitterKeepsSemicolonsInsideStrings();
+  testSqlSplitterKeepsSemicolonsInsideBlockCommentsAndDollarQuotes();
   await testEmptySchemaFailsBeforeExecutorCall();
+  testSchemaLoaderIsIndependentOfCurrentWorkingDirectory();
 
   console.log('Story Lab cloud schema migration tests passed');
 }
@@ -58,12 +60,28 @@ create index example_idx on example (id);
   assert(statements[1]?.includes('semicolon; inside text'), 'splitter should keep semicolons inside quoted strings');
 }
 
+function testSqlSplitterKeepsSemicolonsInsideBlockCommentsAndDollarQuotes() {
+  const statements = splitStoryLabCloudSchemaStatements(`
+/* block comment with ; and ' characters */
+create function example_fn() returns text as $$
+begin
+  return 'quoted; value';
+end;
+$$ language plpgsql;
+create table example (id text);
+  `);
+
+  assert(statements.length === 2, 'splitter should ignore semicolons inside block comments and dollar quotes');
+  assert(statements[0]?.includes("return 'quoted; value'"), 'splitter should preserve dollar-quoted function body');
+  assert(statements[1]?.includes('create table example'), 'splitter should continue after dollar-quoted statement');
+}
+
 async function testEmptySchemaFailsBeforeExecutorCall() {
   const executor = new FakeSchemaExecutor();
 
   try {
     await applyStoryLabCloudSchema(executor, {
-      schemaSql: ' -- comments only\n',
+      schemaSql: "/* block comment with ; and ' only */\n -- comments only\n",
       now: () => '2026-06-08T11:05:00.000Z'
     });
     throw new Error('empty schema should throw');
@@ -73,6 +91,18 @@ async function testEmptySchemaFailsBeforeExecutorCall() {
   }
 
   assert(executor.queries.length === 0, 'empty schema should not call executor');
+}
+
+function testSchemaLoaderIsIndependentOfCurrentWorkingDirectory() {
+  const originalCwd = process.cwd();
+
+  try {
+    process.chdir('tests');
+    const loadedSchema = loadStoryLabCloudSchemaSql();
+    assert(loadedSchema.includes('story_lab_profiles'), 'schema loader should use the module-relative schema path');
+  } finally {
+    process.chdir(originalCwd);
+  }
 }
 
 const loadedSchema = loadStoryLabCloudSchemaSql();

--- a/tests/story-lab-cloud-schema-migration.test.ts
+++ b/tests/story-lab-cloud-schema-migration.test.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env tsx
+// Created: 2026-06-08 11:05 EDT
+
+import type { StoryLabCloudQueryExecutor } from '../api/_lib/story-lab/storage/storyLabCloudStorageConfig';
+import {
+  applyStoryLabCloudSchema,
+  loadStoryLabCloudSchemaSql,
+  splitStoryLabCloudSchemaStatements
+} from '../api/_lib/story-lab/storage/storyLabCloudSchemaMigration';
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+class FakeSchemaExecutor implements StoryLabCloudQueryExecutor {
+  readonly queries: Array<{ sql: string; params: readonly unknown[] }> = [];
+
+  async query<T = unknown>(sql: string, params: readonly unknown[]): Promise<{ rows: T[] }> {
+    this.queries.push({ sql, params });
+    return { rows: [] };
+  }
+}
+
+async function main() {
+  await testApplyRunsTrackedSchemaStatementsInOrder();
+  testSqlSplitterKeepsSemicolonsInsideStrings();
+  await testEmptySchemaFailsBeforeExecutorCall();
+
+  console.log('Story Lab cloud schema migration tests passed');
+}
+
+async function testApplyRunsTrackedSchemaStatementsInOrder() {
+  const executor = new FakeSchemaExecutor();
+  const result = await applyStoryLabCloudSchema(executor, {
+    now: () => '2026-06-08T11:05:00.000Z'
+  });
+
+  assert(result.applied, 'schema application should report applied');
+  assert(result.appliedAt === '2026-06-08T11:05:00.000Z', 'schema application should use injected clock');
+  assert(result.statementCount === executor.queries.length, 'result should report executed statement count');
+  assert(executor.queries.length >= 6, 'tracked schema should execute all table, index, and comment statements');
+  assert(executor.queries[0]?.sql.includes('create table if not exists story_lab_profiles'), 'profile table should be applied first');
+  assert(executor.queries[1]?.sql.includes('create table if not exists story_projects'), 'project table should be applied second');
+  assert(executor.queries.every(query => query.params.length === 0), 'schema statements should not use runtime params');
+  assert(executor.queries.every(query => !query.sql.trim().endsWith(';')), 'schema statements should be sent without trailing semicolons');
+}
+
+function testSqlSplitterKeepsSemicolonsInsideStrings() {
+  const statements = splitStoryLabCloudSchemaStatements(`
+create table example (id text);
+comment on table example is 'keep this semicolon; inside text';
+create index example_idx on example (id);
+  `);
+
+  assert(statements.length === 3, 'splitter should return three statements');
+  assert(statements[1]?.includes('semicolon; inside text'), 'splitter should keep semicolons inside quoted strings');
+}
+
+async function testEmptySchemaFailsBeforeExecutorCall() {
+  const executor = new FakeSchemaExecutor();
+
+  try {
+    await applyStoryLabCloudSchema(executor, {
+      schemaSql: ' -- comments only\n',
+      now: () => '2026-06-08T11:05:00.000Z'
+    });
+    throw new Error('empty schema should throw');
+  } catch (error) {
+    assert(error instanceof Error, 'empty schema failure should be an Error');
+    assert(error.message.includes('empty'), 'empty schema error should explain the problem');
+  }
+
+  assert(executor.queries.length === 0, 'empty schema should not call executor');
+}
+
+const loadedSchema = loadStoryLabCloudSchemaSql();
+assert(loadedSchema.includes('story_lab_profiles'), 'schema loader should read the tracked profile table contract');
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/story-lab-cloud-schema.test.ts
+++ b/tests/story-lab-cloud-schema.test.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env tsx
+// Created: 2026-06-08 10:45 EDT
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const schemaPath = resolve('api/_lib/story-lab/storage/storyLabCloudSchema.sql');
+const schema = readFileSync(schemaPath, 'utf8').toLowerCase();
+
+assert(schema.includes('create table if not exists story_lab_profiles'), 'schema should create story_lab_profiles');
+assert(schema.includes('user_id text primary key'), 'profiles should be keyed by auth user id');
+assert(schema.includes('preferences_json jsonb not null'), 'profiles should persist normalized preferences json');
+assert(schema.includes('create table if not exists story_projects'), 'schema should create story_projects');
+assert(schema.includes('owner_user_id text not null'), 'projects should carry owner_user_id');
+assert(schema.includes('project_json jsonb not null'), 'projects should persist full saved project json');
+assert(schema.includes('create index if not exists story_projects_owner_updated_idx'), 'schema should index owner library ordering');
+assert(schema.includes('where owner_user_id is not null'), 'owner index should be explicitly scoped to owner rows');
+
+console.log('Story Lab cloud schema tests passed');

--- a/tests/story-lab-cloud-storage-config.test.ts
+++ b/tests/story-lab-cloud-storage-config.test.ts
@@ -1,0 +1,215 @@
+#!/usr/bin/env tsx
+// Created: 2026-06-08 10:50 EDT
+
+import type { AuthUser } from '../api/_lib/story-lab/auth/authPort';
+import { createDefaultStoryLabUserProfile } from '../api/_lib/story-lab/profile/storyLabProfileStore';
+import { createStoryLabCloudStorage } from '../api/_lib/story-lab/storage/storyLabCloudStorageConfig';
+import type { SavedStoryProject } from '../story-generator/src/app/contracts';
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+interface CapturedQuery {
+  sql: string;
+  params: readonly unknown[];
+}
+
+class FakeCloudExecutor {
+  readonly queries: CapturedQuery[] = [];
+  private readonly queuedRows: unknown[][] = [];
+
+  enqueueRows(rows: unknown[]): void {
+    this.queuedRows.push(rows);
+  }
+
+  async query<T = unknown>(sql: string, params: readonly unknown[]): Promise<{ rows: T[] }> {
+    this.queries.push({ sql, params });
+    return {
+      rows: (this.queuedRows.shift() ?? []) as T[]
+    };
+  }
+}
+
+const owner: AuthUser = {
+  userId: 'user-owner',
+  email: 'owner@example.com'
+};
+const now = '2026-06-08T10:50:00.000Z';
+
+async function main() {
+  await testMissingDatabaseDoesNotCreateExecutor();
+  await testConfiguredExecutorFactoryBuildsProfileAndProjectStores();
+  await testValidDatabaseUrlCreatesBundledNeonExecutor();
+  await testInvalidDatabaseUrlFailsClosed();
+
+  console.log('Story Lab cloud storage config tests passed');
+}
+
+async function testMissingDatabaseDoesNotCreateExecutor() {
+  let factoryCalls = 0;
+  const storage = createStoryLabCloudStorage({
+    env: {},
+    now: () => now,
+    createExecutor() {
+      factoryCalls += 1;
+      throw new Error('executor should not initialize without DATABASE_URL');
+    }
+  });
+
+  assert(!storage.databaseUrlConfigured, 'missing DATABASE_URL should be reported');
+  assert(!storage.executorConfigured, 'missing DATABASE_URL should not create an executor');
+  assert(!storage.isConfigured(), 'cloud storage without DATABASE_URL should not be configured');
+  assert(factoryCalls === 0, 'executor factory should not run without DATABASE_URL');
+
+  const profileResult = await storage.profileStore.loadProfile(owner);
+  assert(!profileResult.success, 'profile store should fail closed without DATABASE_URL');
+  assert(profileResult.error.code === 'STORY_LAB_PROFILE_STORAGE_UNCONFIGURED', 'profile store should expose profile storage config error');
+
+  const projectResult = await storage.projectStore.listProjects(owner);
+  assert(!projectResult.success, 'project store should fail closed without DATABASE_URL');
+  assert(projectResult.error.code === 'STORY_LAB_STORAGE_UNCONFIGURED', 'project store should expose project storage config error');
+}
+
+async function testConfiguredExecutorFactoryBuildsProfileAndProjectStores() {
+  const executor = new FakeCloudExecutor();
+  let factoryCalls = 0;
+  const databaseUrl = 'postgres://example.invalid/story_lab';
+  const storage = createStoryLabCloudStorage({
+    env: { DATABASE_URL: databaseUrl },
+    now: () => now,
+    createExecutor(resolvedDatabaseUrl) {
+      factoryCalls += 1;
+      assert(resolvedDatabaseUrl === databaseUrl, 'executor factory should receive DATABASE_URL');
+      return executor;
+    }
+  });
+
+  assert(storage.databaseUrlConfigured, 'DATABASE_URL should be reported as configured');
+  assert(storage.executorConfigured, 'executor factory should configure an executor');
+  assert(storage.isConfigured(), 'cloud storage should be configured when URL and executor exist');
+  assert(factoryCalls === 1, 'executor factory should be called once for shared stores');
+
+  const profile = createDefaultStoryLabUserProfile(owner, {
+    displayName: 'Avery',
+    now
+  });
+  executor.enqueueRows([createProfileRow(profile)]);
+  const profileResult = await storage.profileStore.loadProfile(owner);
+  assert(profileResult.success, 'profile store should use configured executor');
+  assert(profileResult.data?.profile.displayName === 'Avery', 'profile store should map configured executor row');
+
+  const project = createProject();
+  executor.enqueueRows([createProjectRow(project)]);
+  const listResult = await storage.projectStore.listProjects(owner);
+  assert(listResult.success, 'project store should use configured executor');
+  assert(listResult.data[0]?.projectId === project.id, 'project store should map configured executor row');
+
+  assert(executor.queries.some(query => query.sql.includes('story_lab_profiles')), 'shared executor should receive profile SQL');
+  assert(executor.queries.some(query => query.sql.includes('story_projects')), 'shared executor should receive project SQL');
+}
+
+async function testValidDatabaseUrlCreatesBundledNeonExecutor() {
+  const storage = createStoryLabCloudStorage({
+    env: { DATABASE_URL: 'postgresql://user:password@example.invalid/story_lab' },
+    now: () => now
+  });
+
+  assert(storage.databaseUrlConfigured, 'valid database URL should be detected');
+  assert(storage.executorConfigured, 'valid database URL should create the bundled Neon executor');
+  assert(storage.isConfigured(), 'valid database URL plus bundled driver should configure cloud storage');
+}
+
+async function testInvalidDatabaseUrlFailsClosed() {
+  const storage = createStoryLabCloudStorage({
+    env: { DATABASE_URL: 'postgres://example.invalid/story_lab' },
+    now: () => now
+  });
+
+  assert(storage.databaseUrlConfigured, 'invalid database URL should still be detected as present');
+  assert(!storage.executorConfigured, 'invalid database URL should not configure an executor');
+  assert(!storage.isConfigured(), 'invalid database URL should not claim configured cloud sync');
+
+  const profileResult = await storage.profileStore.loadProfile(owner);
+  assert(!profileResult.success, 'profile store without executor should fail closed');
+  assert(profileResult.error.code === 'STORY_LAB_PROFILE_STORAGE_DRIVER_MISSING', 'profile store should expose driver-missing error');
+
+  const projectResult = await storage.projectStore.listProjects(owner);
+  assert(!projectResult.success, 'project store without executor should fail closed');
+  assert(projectResult.error.code === 'STORY_LAB_STORAGE_DRIVER_MISSING', 'project store should expose driver-missing error');
+}
+
+function createProfileRow(profile: ReturnType<typeof createDefaultStoryLabUserProfile>) {
+  return {
+    user_id: profile.userId,
+    display_name: profile.displayName,
+    preferences_json: JSON.stringify(profile.preferences),
+    created_at: profile.createdAt,
+    updated_at: profile.updatedAt
+  };
+}
+
+function createProjectRow(project: SavedStoryProject) {
+  return {
+    id: project.id,
+    story_id: project.storyId,
+    owner_user_id: owner.userId,
+    project_json: JSON.stringify(project),
+    created_at: project.createdAt,
+    updated_at: project.updatedAt
+  };
+}
+
+function createProject(): SavedStoryProject {
+  return {
+    id: 'project-cloud-config-1',
+    storyId: 'story-cloud-config-1',
+    title: 'Cloud Config Chapel',
+    synopsis: 'A private oath saved through configured storage.',
+    blueprint: {
+      creature: 'witch',
+      themes: [],
+      logline: 'A witch protects a configured cloud library.',
+      spicyLevel: 2,
+      tone: 'gothic_romance',
+      desiredWordBudget: 900,
+      chapterBatchSize: 1,
+      heatContract: {
+        adultOnlyConfirmed: true,
+        tensionMode: 'slow_burn',
+        intimacyBoundary: 'closed_door',
+        noGoContent: ''
+      }
+    },
+    summary: {
+      storyId: 'story-cloud-config-1',
+      title: 'Cloud Config Chapel',
+      synopsis: 'A private oath saved through configured storage.',
+      tone: 'gothic_romance',
+      spicyLevel: 2,
+      createdAt: now,
+      updatedAt: now
+    },
+    state: {
+      storyId: 'story-cloud-config-1',
+      revision: 1,
+      characters: [],
+      threads: [],
+      artifacts: [],
+      beats: [],
+      continuityWarnings: [],
+      narrativeVoice: 'Gothic and precise.',
+      lastUpdatedAt: now
+    },
+    chapters: [],
+    createdAt: now,
+    updatedAt: now
+  };
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/story-lab-cloud-storage-config.test.ts
+++ b/tests/story-lab-cloud-storage-config.test.ts
@@ -41,6 +41,7 @@ const now = '2026-06-08T10:50:00.000Z';
 
 async function main() {
   await testMissingDatabaseDoesNotCreateExecutor();
+  await testExplicitEnvDoesNotFallThroughToProcessEnv();
   await testConfiguredExecutorFactoryBuildsProfileAndProjectStores();
   await testValidDatabaseUrlCreatesBundledNeonExecutor();
   await testInvalidDatabaseUrlFailsClosed();
@@ -71,6 +72,34 @@ async function testMissingDatabaseDoesNotCreateExecutor() {
   const projectResult = await storage.projectStore.listProjects(owner);
   assert(!projectResult.success, 'project store should fail closed without DATABASE_URL');
   assert(projectResult.error.code === 'STORY_LAB_STORAGE_UNCONFIGURED', 'project store should expose project storage config error');
+}
+
+async function testExplicitEnvDoesNotFallThroughToProcessEnv() {
+  const originalDatabaseUrl = process.env['DATABASE_URL'];
+  process.env['DATABASE_URL'] = 'postgresql://user:password@process-env.example.invalid/story_lab';
+  let factoryCalls = 0;
+
+  try {
+    const storage = createStoryLabCloudStorage({
+      env: {},
+      now: () => now,
+      createExecutor() {
+        factoryCalls += 1;
+        throw new Error('explicit empty env should not create an executor from process.env');
+      }
+    });
+
+    assert(!storage.databaseUrlConfigured, 'explicit empty env should keep database URL unconfigured');
+    assert(!storage.executorConfigured, 'explicit empty env should not create an executor');
+    assert(!storage.isConfigured(), 'explicit empty env should not claim cloud storage is configured');
+    assert(factoryCalls === 0, 'explicit env should prevent implicit process.env executor creation');
+  } finally {
+    if (originalDatabaseUrl === undefined) {
+      delete process.env['DATABASE_URL'];
+    } else {
+      process.env['DATABASE_URL'] = originalDatabaseUrl;
+    }
+  }
 }
 
 async function testConfiguredExecutorFactoryBuildsProfileAndProjectStores() {

--- a/tests/story-lab-neon-executor.test.ts
+++ b/tests/story-lab-neon-executor.test.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env tsx
 // Created: 2026-06-08 11:00 EDT
 
+import { neon } from '@neondatabase/serverless';
 import { createNeonStoryLabQueryExecutor } from '../api/_lib/story-lab/storage/neonStoryLabExecutor';
 
 function assert(condition: unknown, message: string): asserts condition {
@@ -10,11 +11,17 @@ function assert(condition: unknown, message: string): asserts condition {
 }
 
 async function main() {
+  testInstalledNeonClientExposesPlaceholderQueryMethod();
   await testInjectedNeonQueryReceivesSqlAndParams();
   await testMissingDatabaseUrlFailsBeforeCreatingQuery();
   await testQueryErrorsPropagateToStores();
 
   console.log('Story Lab Neon executor tests passed');
+}
+
+function testInstalledNeonClientExposesPlaceholderQueryMethod() {
+  const sql = neon('postgresql://user:password@example.invalid/story_lab');
+  assert(typeof sql.query === 'function', 'installed Neon client should expose query(text, params)');
 }
 
 async function testInjectedNeonQueryReceivesSqlAndParams() {

--- a/tests/story-lab-neon-executor.test.ts
+++ b/tests/story-lab-neon-executor.test.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env tsx
+// Created: 2026-06-08 11:00 EDT
+
+import { createNeonStoryLabQueryExecutor } from '../api/_lib/story-lab/storage/neonStoryLabExecutor';
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function main() {
+  await testInjectedNeonQueryReceivesSqlAndParams();
+  await testMissingDatabaseUrlFailsBeforeCreatingQuery();
+  await testQueryErrorsPropagateToStores();
+
+  console.log('Story Lab Neon executor tests passed');
+}
+
+async function testInjectedNeonQueryReceivesSqlAndParams() {
+  let factoryCalls = 0;
+  const calls: Array<{ sql: string; params: readonly unknown[] }> = [];
+  const executor = createNeonStoryLabQueryExecutor('postgres://example.invalid/story_lab', {
+    createQuery(databaseUrl) {
+      factoryCalls += 1;
+      assert(databaseUrl === 'postgres://example.invalid/story_lab', 'Neon factory should receive database URL');
+      return async (sql, params) => {
+        calls.push({ sql, params });
+        return [{ id: 'row-1' }];
+      };
+    }
+  });
+
+  const result = await executor.query<{ id: string }>('select * from story_projects where owner_user_id = $1', [
+    'user-owner'
+  ]);
+
+  assert(factoryCalls === 1, 'Neon query factory should run once');
+  assert(result.rows[0]?.id === 'row-1', 'executor should return query rows');
+  assert(calls[0]?.sql.includes('story_projects'), 'executor should pass SQL text to Neon');
+  assert(calls[0]?.params[0] === 'user-owner', 'executor should pass params to Neon');
+}
+
+async function testMissingDatabaseUrlFailsBeforeCreatingQuery() {
+  let factoryCalls = 0;
+
+  try {
+    createNeonStoryLabQueryExecutor('', {
+      createQuery() {
+        factoryCalls += 1;
+        return async () => [];
+      }
+    });
+    throw new Error('missing database URL should throw');
+  } catch (error) {
+    assert(error instanceof Error, 'missing URL failure should be an Error');
+    assert(error.message.includes('DATABASE_URL'), 'missing URL error should name DATABASE_URL');
+  }
+
+  assert(factoryCalls === 0, 'missing URL should not create a Neon query function');
+}
+
+async function testQueryErrorsPropagateToStores() {
+  const executor = createNeonStoryLabQueryExecutor('postgres://example.invalid/story_lab', {
+    createQuery() {
+      return async () => {
+        throw new Error('database unavailable');
+      };
+    }
+  });
+
+  try {
+    await executor.query('select 1', []);
+    throw new Error('query failure should throw');
+  } catch (error) {
+    assert(error instanceof Error, 'query failure should remain an Error');
+    assert(error.message.includes('database unavailable'), 'query failure should preserve provider error for store handling');
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds a migration-ready Story Lab cloud schema for private profiles and owner-scoped saved projects.
- Adds guarded cloud storage config, a Neon query executor wrapper, schema apply/readiness helpers, and focused tests.
- Updates recovery docs/lessons to mark PR #116 merged and keep this slice storage-only.

## Scope Boundaries
- Does not add the consolidated account route.
- Does not add signed-in UI or cloud library calls.
- Does not execute a database migration or provision a database.
- Does not claim live cloud sync or durable persistence.

## Validation
- RED baseline: all five cloud-storage scripts were missing before this slice.
- `npm run test:story-lab-cloud-schema`
- `npm run test:story-lab-cloud-storage-config`
- `npm run test:story-lab-neon-executor`
- `npm run test:story-lab-cloud-schema-migration`
- `npm run test:story-lab-cloud-db-readiness`
- `npm run test:story-lab-profile-store`
- `npm run test:story-lab-storage-port`
- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`
- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit`
- `git diff --check`
- `scripts/recovery/check-vercel-function-count.sh` (`10/12`)
- `npm run test:all` (mock mode; `XAI_API_KEY` absent)
- `scripts/recovery/preflight.sh --quick --skip-status`

## Summary by Sourcery

Introduce guarded Story Lab cloud storage and database scaffolding for private profiles and owner-scoped projects, without enabling live cloud sync or new user-visible routes.

New Features:
- Add migration-ready SQL schema and migration helper for Story Lab profiles and owner-scoped story projects.
- Add Neon-based query executor wrapper and guarded cloud storage configuration that wires Postgres-backed profile and project stores only when a valid DATABASE_URL and driver are available.
- Add database readiness check and smoke script to verify required tables/indexes before claiming cloud storage readiness.

Enhancements:
- Update Story Lab planning and recovery docs to reflect merged auth/profile contracts, document the storage-only scope of this slice, and record validation steps and lessons learned.

Build:
- Add @neondatabase/serverless dependency and register new Story Lab cloud storage test scripts in package.json.

Tests:
- Add focused tests for the cloud schema contract, schema migration helper, Neon executor, cloud storage configuration behavior, and database readiness checks, and wire them into the aggregated test:all script.