### PR TITLE
Add Story Lab cloud library UI

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -2667,3 +2667,32 @@ Validation:
 - `npm run recovery:preflight -- cloud-library-ui --dry-run`: passed.
 - `npm run recovery:preflight -- story-memory-cards --quick --dry-run`: passed.
 - `git diff --check`: passed.
+
+## 2026-06-21 07:12 EDT - Angular Cloud Library UI Extraction
+
+Actions:
+
+- Extracted the Angular cloud-library service/UI slice from the unpublished Story Lab stack onto `recovery/story-lab-cloud-library-ui`.
+- Added account service methods for profile status and cloud project save/list/load/delete calls.
+- Added UI state and controls for account setup, local-vs-cloud library status, cloud save, cloud project load/delete, and connected-account gating.
+- Kept anonymous browser-local saves as the active user-visible save path.
+- Mapped `non_durable_memory` account storage to cloud-unavailable UI copy so tests and product language do not imply durable sync.
+
+Decision:
+
+- This is a larger slice than a single cherry-pick, but it stays inside one review boundary: Angular service/UI cloud-library honesty.
+- Durable job ownership, story-quality guidance, Proving Grounds reporting, story memory cards, and CSS lazy-loading remain separate slices.
+- The slice does not claim production auth provider wiring, signed-in browser flow, executed migrations, provisioned database, live durable cloud sync, or durable jobs.
+
+Validation:
+
+- `npm run recovery:preflight -- cloud-library-ui --quick`: passed.
+- `npm run recovery:preflight -- cloud-library-ui`: passed and wrote `tmp/recovery/cloud-library-ui-evidence.md`.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `11/12`.
+- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`: passed.
+- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit`: passed.
+- `npm run build`: passed with existing Angular bundle and CSS budget warnings.
+
+Known local proof gap:
+
+- Targeted Angular browser specs built successfully, but local `ChromeHeadless` failed to capture after two retries; browser specs are not claimed as passing from this workstation run.

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -2696,3 +2696,17 @@ Validation:
 Known local proof gap:
 
 - Targeted Angular browser specs built successfully, but local `ChromeHeadless` failed to capture after two retries; browser specs are not claimed as passing from this workstation run.
+
+## 2026-06-21 07:26 EDT - PR 123 Review Follow-Up
+
+Actions:
+
+- Addressed Gemini review feedback on cloud-library state honesty.
+- Preserved the existing connected/cloud-unavailable state when a user tries to cloud-save an empty workbench.
+- Kept cloud load/delete receipts with `non_durable_memory` storage out of the `cloud_synced` UI state.
+- Removed runtime `Array.prototype.at()` usage from `app.ts` chapter selection paths for browser compatibility.
+- Added focused app specs covering empty cloud save, non-durable cloud load, and non-durable cloud delete behavior.
+
+Validation:
+
+- `npm run recovery:preflight -- cloud-library-ui --quick`: passed.

--- a/STORY_LAB_AUTH_PROFILE_CLOUD_LIBRARY_EXEC_PLAN.md
+++ b/STORY_LAB_AUTH_PROFILE_CLOUD_LIBRARY_EXEC_PLAN.md
@@ -17,7 +17,7 @@ The desired user-visible outcome is:
 
 ## Current Reality On Main
 
-This checklist is current after PR #118 and the consolidated account-route change set.
+This checklist is current after PR #118, the consolidated account-route change set, and the Angular cloud-library UI change set.
 
 - `AuthPort` exists and is deny-by-default.
 - `authorizeProjectAccess` exists.
@@ -28,6 +28,8 @@ This checklist is current after PR #118 and the consolidated account-route chang
 - Profile stores exist for non-durable memory and injected Postgres execution.
 - Cloud schema, guarded migration/readiness helpers, guarded cloud storage config, and Neon executor scaffolding exist.
 - One consolidated account route exists for profile and project operations behind injectable auth/profile/project stores.
+- The Angular app can load account status, show local-vs-cloud library state, and call the consolidated account route for profile/project operations.
+- Cloud save/load/delete controls are gated on connected account state, and `non_durable_memory` account storage is shown as cloud-unavailable.
 - Browser-local `StoryWorkspaceStorageService` remains the current user-visible save path.
 - Story Lab jobs are still `non_durable_memory` and not account-owned.
 - Vercel function count is `11/12` with the account route included.
@@ -65,7 +67,7 @@ Not live yet:
 - [x] Land auth/profile contracts through PR #116.
 - [x] Land cloud schema/storage readiness through PR #118.
 - [x] Land consolidated account route.
-- [ ] Land Angular cloud library UI.
+- [x] Land Angular cloud library UI.
 - [ ] Land durable job owner scaffolding only if kept honest as non-durable in the active UI.
 
 ### Phase 1: Auth And Profile Contracts
@@ -248,6 +250,15 @@ Validation on 2026-06-13:
 
 Goal: expose local-vs-cloud library state honestly in the Angular app while preserving anonymous browser-local saves.
 
+Status:
+
+- Implemented by the Angular cloud-library UI change set.
+- Adds account-service methods for profile status and project save/list/load/delete calls against the consolidated account route.
+- Adds cloud-library UI state for account status, setup action, cloud save/load/delete controls, and local-vs-cloud messaging.
+- Gates cloud project actions on connected account state while preserving anonymous browser-local saves.
+- Displays non-durable account storage as unavailable for cloud sync instead of implying durability.
+- Still not live provider auth, signed-in browser flow, executed migration, provisioned database, durable cloud sync proof, or durable jobs.
+
 Candidate local commits:
 
 - `ca79e26 Add Story Lab account service methods`
@@ -273,6 +284,17 @@ Acceptance:
 - cloud calls are gated until account state is connected;
 - failed or unavailable account state does not imply durable cloud sync;
 - non-durable account storage is displayed as cloud-unavailable.
+
+Validation on 2026-06-21:
+
+- `npm run recovery:preflight -- cloud-library-ui --quick`: passed.
+- `npm run recovery:preflight -- cloud-library-ui`: passed and wrote `tmp/recovery/cloud-library-ui-evidence.md`.
+- `git diff --check`: passed.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `11/12`.
+- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`: passed.
+- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.app.json --noEmit`: passed.
+- `npm run build`: passed with existing Angular bundle and CSS budget warnings.
+- Targeted Angular browser specs built successfully, but local `ChromeHeadless` did not capture before timeout after two retries; this was not counted as passing browser-spec proof.
 
 ### Phase 5: Durable Job Owner Scaffolding
 

--- a/STORY_LAB_UNPUBLISHED_BRANCH_SPLIT_PLAN.md
+++ b/STORY_LAB_UNPUBLISHED_BRANCH_SPLIT_PLAN.md
@@ -200,6 +200,8 @@ Validation evidence:
 
 Goal: expose local-vs-cloud library state honestly in the Angular app, while preserving anonymous browser-local saves.
 
+Status: implemented in the Angular cloud-library UI change set. This slice stays frontend/service-only; durable job ownership, story-quality guidance, Proving Grounds reporting, memory cards, and CSS lazy-loading remain separate slices.
+
 Likely commits:
 
 - `ca79e26 Add Story Lab account service methods`
@@ -227,6 +229,14 @@ Validation:
 - targeted Angular app spec if Chrome is stable
 - `npm run build`
 - `scripts/recovery/preflight.sh --quick --skip-status`
+
+Validation evidence:
+
+- `npm run recovery:preflight -- cloud-library-ui --quick`: passed.
+- `npm run recovery:preflight -- cloud-library-ui`: passed and wrote `tmp/recovery/cloud-library-ui-evidence.md`.
+- Function count stayed `11/12`.
+- Targeted Angular browser specs were attempted, but local `ChromeHeadless` failed to capture after the bundle built; no browser-spec pass is claimed.
+- No production auth provider, signed-in browser flow, executed migration, database provisioning, live durable cloud sync, or durable jobs are included.
 
 ### PR 7: Durable Job Owner Scaffolding
 

--- a/story-generator/src/app/app.html
+++ b/story-generator/src/app/app.html
@@ -590,6 +590,9 @@
           <strong>Account </strong>{{ cloudAccountStatusLabel() }}
         </p>
         <div class="story-actions">
+          <button type="button" class="ghost compact" data-testid="cloud-account-action" (click)="showCloudAccountSetupStatus()" [disabled]="isCloudLibraryBusy()">
+            {{ cloudAccountActionLabel() }}
+          </button>
           <button type="button" class="ghost compact" (click)="refreshCloudLibrary()" [disabled]="isCloudLibraryBusy()">
             {{ isCloudLibraryBusy() ? 'Checking' : 'Check cloud' }}
           </button>

--- a/story-generator/src/app/app.html
+++ b/story-generator/src/app/app.html
@@ -603,11 +603,11 @@
         <p class="muted" *ngIf="!cloudProjects().length">No cloud projects loaded.</p>
         <ol class="saved-list" *ngIf="cloudProjects().length">
           <li class="saved-item" *ngFor="let project of cloudProjects(); trackBy: trackCloudProject">
-            <button type="button" class="saved-load" (click)="loadCloudProject(project.projectId)" [disabled]="isCloudLibraryBusy()">
+            <button type="button" class="saved-load" (click)="loadCloudProject(project.projectId)" [disabled]="isCloudLibraryBusy() || !canUseCloudLibrary()">
               <span class="saved-title">{{ project.title }}</span>
               <span class="saved-meta">{{ project.chapterCount }} chapter{{ project.chapterCount === 1 ? '' : 's' }} · {{ project.updatedAt | date:'MMM d, h:mm a' }}</span>
             </button>
-            <button type="button" class="saved-delete" (click)="deleteCloudProject(project.projectId)" [disabled]="isCloudLibraryBusy()">
+            <button type="button" class="saved-delete" (click)="deleteCloudProject(project.projectId)" [disabled]="isCloudLibraryBusy() || !canUseCloudLibrary()">
               Delete
             </button>
           </li>

--- a/story-generator/src/app/app.html
+++ b/story-generator/src/app/app.html
@@ -586,6 +586,9 @@
         <p class="muted" [attr.data-cloud-mode]="cloudLibrarySyncState().mode">
           {{ cloudLibraryStatusMessage() }}
         </p>
+        <p class="muted" data-testid="cloud-account-state">
+          <strong>Account </strong>{{ cloudAccountStatusLabel() }}
+        </p>
         <div class="story-actions">
           <button type="button" class="ghost compact" (click)="refreshCloudLibrary()" [disabled]="isCloudLibraryBusy()">
             {{ isCloudLibraryBusy() ? 'Checking' : 'Check cloud' }}

--- a/story-generator/src/app/app.html
+++ b/story-generator/src/app/app.html
@@ -596,7 +596,7 @@
           <button type="button" class="ghost compact" (click)="refreshCloudLibrary()" [disabled]="isCloudLibraryBusy()">
             {{ isCloudLibraryBusy() ? 'Checking' : 'Check cloud' }}
           </button>
-          <button type="button" class="ghost compact" (click)="saveActiveProjectToCloud()" [disabled]="!workbench().story || isCloudLibraryBusy()">
+          <button type="button" class="ghost compact" (click)="saveActiveProjectToCloud()" [disabled]="!workbench().story || isCloudLibraryBusy() || !canUseCloudLibrary()">
             Save to cloud
           </button>
         </div>

--- a/story-generator/src/app/app.html
+++ b/story-generator/src/app/app.html
@@ -578,6 +578,36 @@
     </ng-template>
 
     <aside class="library-panel" aria-label="Saved stories and story state">
+      <section class="cloud-library-panel" data-testid="cloud-library-panel">
+        <div class="section-heading">
+          <p class="eyebrow">Cloud account</p>
+          <h2>{{ cloudLibraryStatusLabel() }}</h2>
+        </div>
+        <p class="muted" [attr.data-cloud-mode]="cloudLibrarySyncState().mode">
+          {{ cloudLibraryStatusMessage() }}
+        </p>
+        <div class="story-actions">
+          <button type="button" class="ghost compact" (click)="refreshCloudLibrary()" [disabled]="isCloudLibraryBusy()">
+            {{ isCloudLibraryBusy() ? 'Checking' : 'Check cloud' }}
+          </button>
+          <button type="button" class="ghost compact" (click)="saveActiveProjectToCloud()" [disabled]="!workbench().story || isCloudLibraryBusy()">
+            Save to cloud
+          </button>
+        </div>
+        <p class="muted" *ngIf="!cloudProjects().length">No cloud projects loaded.</p>
+        <ol class="saved-list" *ngIf="cloudProjects().length">
+          <li class="saved-item" *ngFor="let project of cloudProjects(); trackBy: trackCloudProject">
+            <button type="button" class="saved-load" (click)="loadCloudProject(project.projectId)" [disabled]="isCloudLibraryBusy()">
+              <span class="saved-title">{{ project.title }}</span>
+              <span class="saved-meta">{{ project.chapterCount }} chapter{{ project.chapterCount === 1 ? '' : 's' }} · {{ project.updatedAt | date:'MMM d, h:mm a' }}</span>
+            </button>
+            <button type="button" class="saved-delete" (click)="deleteCloudProject(project.projectId)" [disabled]="isCloudLibraryBusy()">
+              Delete
+            </button>
+          </li>
+        </ol>
+      </section>
+
       <section>
         <div class="section-heading">
           <p class="eyebrow">Library</p>

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -451,12 +451,15 @@ describe('App', () => {
     fixture.detectChanges();
 
     const panel = fixture.nativeElement.querySelector('[data-testid="cloud-library-panel"]') as HTMLElement | null;
+    const accountState = panel?.querySelector('[data-testid="cloud-account-state"]') as HTMLElement | null;
     const text = panel?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+    const accountText = accountState?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
     const fullText = fixture.nativeElement.textContent.replace(/\s+/g, ' ').trim();
 
     expect(component.cloudLibrarySyncState().mode).toBe('cloud_unavailable');
     expect(text).toContain('Cloud account');
     expect(text).toContain('Cloud unavailable');
+    expect(accountText).toContain('Account Not connected');
     expect(fullText).toContain('Saved here');
   });
 

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -463,6 +463,24 @@ describe('App', () => {
     expect(fullText).toContain('Saved here');
   });
 
+  it('shows an honest account setup action before sign-in is configured', () => {
+    fixture.detectChanges();
+
+    const panel = fixture.nativeElement.querySelector('[data-testid="cloud-library-panel"]') as HTMLElement | null;
+    const accountAction = panel?.querySelector('[data-testid="cloud-account-action"]') as HTMLButtonElement | null;
+
+    expect(accountAction?.textContent?.trim()).toBe('Connect account');
+
+    accountAction?.click();
+    fixture.detectChanges();
+
+    const fullText = fixture.nativeElement.textContent.replace(/\s+/g, ' ').trim();
+    expect(storyService.listCloudStoryProjects).not.toHaveBeenCalled();
+    expect(component.cloudLibrarySyncState().mode).toBe('cloud_unavailable');
+    expect(fullText).toContain('Sign-in setup is not configured yet.');
+    expect(fullText).toContain('Saved here');
+  });
+
   it('refreshes visible cloud projects through the account service', () => {
     const cloudList: CloudStoryProjectList = {
       ownerUserId: 'user-owner',

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -7,14 +7,17 @@ import { StoryService } from './story.service';
 import { ErrorLoggingService } from './error-logging';
 import {
   ApiResponse,
+  CloudStoryProjectDeleteReceipt,
   StoryIterationPayload,
   StoryLabJobCreationResponse,
   StoryLabJobEvent,
   StoryStateSnapshot,
   StorySummary,
   CloudStoryProjectList,
+  CloudStoryProjectLoadResult,
   CloudStoryProjectSaveReceipt,
-  GeneratedChapter
+  GeneratedChapter,
+  SavedStoryProject
 } from './contracts';
 
 const STORAGE_KEY = 'fairytales_story_lab_projects_v1';
@@ -630,6 +633,89 @@ describe('App', () => {
     }));
     expect(component.workspaceSaveStatus()).not.toContain('Cloud');
     expect(component.cloudLibrarySyncState().mode).toBe('cloud_synced');
+  });
+
+  it('keeps connected cloud state when there is no active workbench project to save', () => {
+    component.cloudLibrarySyncState.set({
+      mode: 'cloud_synced',
+      lastSyncedAt: '2026-06-08T08:38:00.000Z'
+    });
+
+    component.saveActiveProjectToCloud();
+
+    expect(storyService.saveCloudStoryProject).not.toHaveBeenCalled();
+    expect(component.cloudLibrarySyncState().mode).toBe('cloud_synced');
+    expect(component.cloudLibrarySyncState().message).toBe('Generate a story before saving to cloud.');
+  });
+
+  it('keeps non-durable loaded projects out of cloud-synced state', () => {
+    const payload = seedWorkbenchForContinuation({
+      summary: createSummary({ storyId: 'story-cloud', title: 'Cloud Chapel' }),
+      state: createState({ storyId: 'story-cloud' }),
+      batch: {
+        chapters: [createChapter({ chapterId: 'chapter-cloud' })],
+        totalWordCount: 900,
+        suggestedNextPrompts: []
+      }
+    });
+    const project: SavedStoryProject = {
+      id: 'project-cloud',
+      storyId: payload.summary.storyId,
+      title: payload.summary.title,
+      synopsis: payload.summary.synopsis,
+      blueprint: component.blueprint(),
+      summary: payload.summary,
+      state: payload.state,
+      chapters: payload.batch.chapters,
+      telemetry: payload.telemetry,
+      createdAt: payload.summary.createdAt,
+      updatedAt: payload.summary.updatedAt
+    };
+    const loadResult: CloudStoryProjectLoadResult = {
+      ownerUserId: 'user-owner',
+      storageMode: 'non_durable_memory',
+      projectId: project.id,
+      storyId: project.storyId,
+      project,
+      createdAt: project.createdAt,
+      updatedAt: project.updatedAt
+    };
+    storyService.loadCloudStoryProject.and.returnValue(of({ success: true, data: loadResult }));
+    component.cloudLibrarySyncState.set({ mode: 'cloud_synced' });
+
+    component.loadCloudProject(project.id);
+
+    expect(storyService.loadCloudStoryProject).toHaveBeenCalledWith(project.id);
+    expect(component.cloudLibrarySyncState().mode).toBe('cloud_unavailable');
+    expect(component.cloudLibrarySyncState().message).toContain('non-durable account storage');
+    expect(component.selectedChapter()?.chapterId).toBe('chapter-cloud');
+  });
+
+  it('keeps non-durable deleted projects out of cloud-synced state', () => {
+    const receipt: CloudStoryProjectDeleteReceipt = {
+      ownerUserId: 'user-owner',
+      storageMode: 'non_durable_memory',
+      projectId: 'project-cloud',
+      deleted: true
+    };
+    component.cloudProjects.set([{
+      projectId: 'project-cloud',
+      storyId: 'story-cloud',
+      title: 'Cloud Chapel',
+      synopsis: 'A cloud route backed by non-durable memory.',
+      chapterCount: 2,
+      createdAt: '2026-06-08T08:37:00.000Z',
+      updatedAt: '2026-06-08T08:38:00.000Z'
+    }]);
+    storyService.deleteCloudStoryProject.and.returnValue(of({ success: true, data: receipt }));
+    component.cloudLibrarySyncState.set({ mode: 'cloud_synced' });
+
+    component.deleteCloudProject('project-cloud');
+
+    expect(storyService.deleteCloudStoryProject).toHaveBeenCalledWith('project-cloud');
+    expect(component.cloudProjects().length).toBe(0);
+    expect(component.cloudLibrarySyncState().mode).toBe('cloud_unavailable');
+    expect(component.cloudLibrarySyncState().message).toContain('non-durable account storage');
   });
 
   it('re-enables cloud controls after an account route error', () => {

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -578,6 +578,32 @@ describe('App', () => {
     expect(fixture.nativeElement.textContent).toContain('Cloud Chapel');
   });
 
+  it('does not mark cloud library synced when account storage is non-durable', () => {
+    const cloudList: CloudStoryProjectList = {
+      ownerUserId: 'user-owner',
+      storageMode: 'non_durable_memory',
+      projects: [{
+        projectId: 'project-cloud',
+        storyId: 'story-cloud',
+        title: 'Cloud Chapel',
+        synopsis: 'A cloud route backed by non-durable memory.',
+        chapterCount: 2,
+        createdAt: '2026-06-08T08:37:00.000Z',
+        updatedAt: '2026-06-08T08:38:00.000Z'
+      }]
+    };
+    storyService.listCloudStoryProjects.and.returnValue(of({ success: true, data: cloudList }));
+
+    component.refreshCloudLibrary();
+    fixture.detectChanges();
+
+    expect(component.cloudProjects().length).toBe(1);
+    expect(component.cloudLibrarySyncState().mode).toBe('cloud_unavailable');
+    expect(component.cloudLibrarySyncState().message).toContain('non-durable account storage');
+    expect(fixture.nativeElement.textContent).toContain('Cloud unavailable');
+    expect(fixture.nativeElement.textContent).toContain('Cloud Chapel');
+  });
+
   it('saves the active workbench project to cloud without disabling local save', () => {
     const payload = seedWorkbenchForContinuation();
     const receipt: CloudStoryProjectSaveReceipt = {

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -610,10 +610,16 @@ describe('App', () => {
     storyService.listCloudStoryProjects.and.returnValue(throwError(() => new Error('offline')));
 
     component.refreshCloudLibrary();
+    fixture.detectChanges();
+    const panel = fixture.nativeElement.querySelector('[data-testid="cloud-library-panel"]') as HTMLElement | null;
+    const checkButton = Array.from(panel?.querySelectorAll('button') ?? [])
+      .find(button => button.textContent?.includes('Check cloud')) as HTMLButtonElement | undefined;
+    const fullText = fixture.nativeElement.textContent.replace(/\s+/g, ' ').trim();
 
     expect(component.isCloudLibraryBusy()).toBeFalse();
     expect(component.cloudLibrarySyncState().mode).toBe('cloud_unavailable');
-    expect(component.workspaceSaveStatus()).toContain('Saved here');
+    expect(checkButton?.disabled).toBeFalse();
+    expect(fullText).toContain('Saved here');
   });
 
   it('updates the Heat Contract without changing the rest of the blueprint', () => {

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -508,6 +508,51 @@ describe('App', () => {
     expect(fullText).toContain('Sign-in setup is not configured yet.');
   });
 
+  it('blocks cloud load and delete until the account is connected', () => {
+    component.cloudProjects.set([{
+      projectId: 'project-cloud',
+      storyId: 'story-cloud',
+      title: 'Cloud Chapel',
+      synopsis: 'A cloud-synced oath.',
+      chapterCount: 2,
+      createdAt: '2026-06-08T08:37:00.000Z',
+      updatedAt: '2026-06-08T08:38:00.000Z'
+    }]);
+    storyService.loadCloudStoryProject.and.returnValue(of({
+      success: false,
+      error: {
+        code: 'UNAUTHORIZED',
+        message: 'Account required.'
+      }
+    } as ApiResponse<any>));
+    storyService.deleteCloudStoryProject.and.returnValue(of({
+      success: false,
+      error: {
+        code: 'UNAUTHORIZED',
+        message: 'Account required.'
+      }
+    } as ApiResponse<any>));
+
+    fixture.detectChanges();
+
+    const panel = fixture.nativeElement.querySelector('[data-testid="cloud-library-panel"]') as HTMLElement | null;
+    const loadButton = panel?.querySelector('.saved-load') as HTMLButtonElement | null;
+    const deleteButton = panel?.querySelector('.saved-delete') as HTMLButtonElement | null;
+
+    expect(loadButton?.disabled).toBeTrue();
+    expect(deleteButton?.disabled).toBeTrue();
+
+    component.loadCloudProject('project-cloud');
+    component.deleteCloudProject('project-cloud');
+    fixture.detectChanges();
+
+    const fullText = fixture.nativeElement.textContent.replace(/\s+/g, ' ').trim();
+    expect(storyService.loadCloudStoryProject).not.toHaveBeenCalled();
+    expect(storyService.deleteCloudStoryProject).not.toHaveBeenCalled();
+    expect(component.cloudLibrarySyncState().mode).toBe('cloud_unavailable');
+    expect(fullText).toContain('Sign-in setup is not configured yet.');
+  });
+
   it('refreshes visible cloud projects through the account service', () => {
     const cloudList: CloudStoryProjectList = {
       ownerUserId: 'user-owner',

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -481,6 +481,33 @@ describe('App', () => {
     expect(fullText).toContain('Saved here');
   });
 
+  it('blocks cloud save until the account is connected', () => {
+    seedWorkbenchForContinuation();
+    storyService.saveCloudStoryProject.and.returnValue(of({
+      success: false,
+      error: {
+        code: 'UNAUTHORIZED',
+        message: 'Account required.'
+      }
+    } as ApiResponse<CloudStoryProjectSaveReceipt>));
+
+    fixture.detectChanges();
+
+    const panel = fixture.nativeElement.querySelector('[data-testid="cloud-library-panel"]') as HTMLElement | null;
+    const saveButton = Array.from(panel?.querySelectorAll('button') ?? [])
+      .find(button => button.textContent?.includes('Save to cloud')) as HTMLButtonElement | undefined;
+
+    expect(saveButton?.disabled).toBeTrue();
+
+    component.saveActiveProjectToCloud();
+    fixture.detectChanges();
+
+    const fullText = fixture.nativeElement.textContent.replace(/\s+/g, ' ').trim();
+    expect(storyService.saveCloudStoryProject).not.toHaveBeenCalled();
+    expect(component.cloudLibrarySyncState().mode).toBe('cloud_unavailable');
+    expect(fullText).toContain('Sign-in setup is not configured yet.');
+  });
+
   it('refreshes visible cloud projects through the account service', () => {
     const cloudList: CloudStoryProjectList = {
       ownerUserId: 'user-owner',
@@ -518,6 +545,10 @@ describe('App', () => {
       }
     };
     storyService.saveCloudStoryProject.and.returnValue(of({ success: true, data: receipt }));
+    component.cloudLibrarySyncState.set({
+      mode: 'cloud_synced',
+      lastSyncedAt: payload.summary.updatedAt
+    });
 
     component.saveActiveProjectToCloud();
 

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ActivatedRoute, convertToParamMap, ParamMap } from '@angular/router';
-import { BehaviorSubject, of, Subject } from 'rxjs';
+import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
 import { App } from './app';
 import { StoryService } from './story.service';
 import { ErrorLoggingService } from './error-logging';
@@ -12,6 +12,8 @@ import {
   StoryLabJobEvent,
   StoryStateSnapshot,
   StorySummary,
+  CloudStoryProjectList,
+  CloudStoryProjectSaveReceipt,
   GeneratedChapter
 } from './contracts';
 
@@ -252,7 +254,11 @@ describe('App', () => {
       'createStoryLabJob',
       'getStoryLabJob',
       'streamStoryLabJobEvents',
-      'streamStoryGeneration'
+      'streamStoryGeneration',
+      'listCloudStoryProjects',
+      'saveCloudStoryProject',
+      'loadCloudStoryProject',
+      'deleteCloudStoryProject'
     ]);
     const errorLoggingSpy = jasmine.createSpyObj<ErrorLoggingService>('ErrorLoggingService', [
       'logInfo',
@@ -439,6 +445,78 @@ describe('App', () => {
 
     expect(component.blueprint().creature).toBe('dragon');
     expect(component.activeSpiceOption().label).toBe('Inferno');
+  });
+
+  it('renders cloud library as unavailable without replacing local browser saves', () => {
+    fixture.detectChanges();
+
+    const panel = fixture.nativeElement.querySelector('[data-testid="cloud-library-panel"]') as HTMLElement | null;
+    const text = panel?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+    const fullText = fixture.nativeElement.textContent.replace(/\s+/g, ' ').trim();
+
+    expect(component.cloudLibrarySyncState().mode).toBe('cloud_unavailable');
+    expect(text).toContain('Cloud account');
+    expect(text).toContain('Cloud unavailable');
+    expect(fullText).toContain('Saved here');
+  });
+
+  it('refreshes visible cloud projects through the account service', () => {
+    const cloudList: CloudStoryProjectList = {
+      ownerUserId: 'user-owner',
+      storageMode: 'cloud_postgres',
+      projects: [{
+        projectId: 'project-cloud',
+        storyId: 'story-cloud',
+        title: 'Cloud Chapel',
+        synopsis: 'A cloud-synced oath.',
+        chapterCount: 2,
+        createdAt: '2026-06-08T08:37:00.000Z',
+        updatedAt: '2026-06-08T08:38:00.000Z'
+      }]
+    };
+    storyService.listCloudStoryProjects.and.returnValue(of({ success: true, data: cloudList }));
+
+    component.refreshCloudLibrary();
+    fixture.detectChanges();
+
+    expect(storyService.listCloudStoryProjects).toHaveBeenCalled();
+    expect(component.cloudProjects().length).toBe(1);
+    expect(component.cloudLibrarySyncState().mode).toBe('cloud_synced');
+    expect(fixture.nativeElement.textContent).toContain('Cloud Chapel');
+  });
+
+  it('saves the active workbench project to cloud without disabling local save', () => {
+    const payload = seedWorkbenchForContinuation();
+    const receipt: CloudStoryProjectSaveReceipt = {
+      projectId: payload.summary.storyId,
+      storyId: payload.summary.storyId,
+      savedAt: payload.summary.updatedAt,
+      syncState: {
+        mode: 'cloud_synced',
+        lastSyncedAt: payload.summary.updatedAt
+      }
+    };
+    storyService.saveCloudStoryProject.and.returnValue(of({ success: true, data: receipt }));
+
+    component.saveActiveProjectToCloud();
+
+    expect(storyService.saveCloudStoryProject).toHaveBeenCalledWith(jasmine.objectContaining({
+      id: payload.summary.storyId,
+      storyId: payload.summary.storyId,
+      title: payload.summary.title
+    }));
+    expect(component.workspaceSaveStatus()).not.toContain('Cloud');
+    expect(component.cloudLibrarySyncState().mode).toBe('cloud_synced');
+  });
+
+  it('re-enables cloud controls after an account route error', () => {
+    storyService.listCloudStoryProjects.and.returnValue(throwError(() => new Error('offline')));
+
+    component.refreshCloudLibrary();
+
+    expect(component.isCloudLibraryBusy()).toBeFalse();
+    expect(component.cloudLibrarySyncState().mode).toBe('cloud_unavailable');
+    expect(component.workspaceSaveStatus()).toContain('Saved here');
   });
 
   it('updates the Heat Contract without changing the rest of the blueprint', () => {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -10,6 +10,8 @@ import {
   BatchProgressState,
   ChapterBatchSize,
   ChapterTimelineEntry,
+  CloudLibrarySyncState,
+  CloudStoryProjectListItem,
   ContinuityPanelViewModel,
   CreatureArchetype,
   GeneratedChapter,
@@ -340,6 +342,12 @@ export class App implements OnDestroy {
   readonly statusMessage = signal<string>('Tell us what kind of enchanted, spicy story you want.');
   readonly workspaceSaveStatus = signal<string>('No saved stories in this browser yet.');
   readonly savedProjects = signal<SavedStoryProject[]>([]);
+  readonly cloudProjects = signal<CloudStoryProjectListItem[]>([]);
+  readonly cloudLibrarySyncState = signal<CloudLibrarySyncState>({
+    mode: 'cloud_unavailable',
+    message: 'Account sync is not connected yet.'
+  });
+  readonly isCloudLibraryBusy = signal(false);
   readonly generationProgress = signal<GenerationProgressState>({
     active: false,
     percent: 0,
@@ -504,6 +512,40 @@ export class App implements OnDestroy {
     return telemetry.reasoningEffort
       ? `${modelLabel} · ${telemetry.reasoningEffort}`
       : modelLabel;
+  });
+  readonly cloudLibraryStatusLabel = computed(() => {
+    switch (this.cloudLibrarySyncState().mode) {
+      case 'cloud_synced':
+        return 'Cloud synced';
+      case 'sync_failed':
+        return 'Cloud sync failed';
+      case 'local_only':
+        return 'Local only';
+      case 'cloud_unavailable':
+        return 'Cloud unavailable';
+    }
+  });
+  readonly cloudLibraryStatusMessage = computed(() => {
+    const state = this.cloudLibrarySyncState();
+    if (state.message) {
+      return state.message;
+    }
+
+    if (state.mode === 'cloud_synced') {
+      return state.lastSyncedAt
+        ? `Last checked ${new Date(state.lastSyncedAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}.`
+        : 'Cloud library is available.';
+    }
+
+    if (state.mode === 'sync_failed') {
+      return 'Cloud sync failed. Local browser saves are still available.';
+    }
+
+    if (state.mode === 'local_only') {
+      return 'This story is saved in this browser.';
+    }
+
+    return 'Account sync is not connected yet.';
   });
   readonly chapterGroups = computed<ChapterGroupViewModel[]>(() => {
     const chapters = this.workbench().chapterHistory;
@@ -890,6 +932,161 @@ ${chapters}
       }));
     }
     this.workspaceSaveStatus.set('Saved story removed from this browser.');
+  }
+
+  refreshCloudLibrary() {
+    if (this.isCloudLibraryBusy()) {
+      return;
+    }
+
+    this.isCloudLibraryBusy.set(true);
+    this.storyService.listCloudStoryProjects().subscribe({
+      next: response => {
+        if (!response.success || !response.data) {
+          this.cloudLibrarySyncState.set({
+            mode: 'sync_failed',
+            message: this.formatApiError(response.error, 'Cloud library is unavailable.')
+          });
+          return;
+        }
+
+        this.cloudProjects.set(response.data.projects);
+        this.cloudLibrarySyncState.set({
+          mode: 'cloud_synced',
+          lastSyncedAt: new Date().toISOString(),
+          message: `${response.data.projects.length} cloud project${response.data.projects.length === 1 ? '' : 's'} loaded.`
+        });
+      },
+      error: error => {
+        this.errorLogging.logError(error, 'App.refreshCloudLibrary');
+        this.cloudLibrarySyncState.set({
+          mode: 'cloud_unavailable',
+          message: this.formatHttpError(error, 'Cloud library is unavailable until account sync is configured.')
+        });
+        this.isCloudLibraryBusy.set(false);
+      },
+      complete: () => {
+        this.isCloudLibraryBusy.set(false);
+      }
+    });
+  }
+
+  saveActiveProjectToCloud() {
+    if (this.isCloudLibraryBusy()) {
+      return;
+    }
+
+    const project = this.buildSavedProjectFromSession(this.workbench());
+    if (!project) {
+      this.notificationService.warning('Nothing to save', 'Generate a story before saving to cloud.');
+      this.cloudLibrarySyncState.set({
+        mode: 'local_only',
+        message: 'Generate a story before saving to cloud.'
+      });
+      return;
+    }
+
+    this.isCloudLibraryBusy.set(true);
+    this.storyService.saveCloudStoryProject(project).subscribe({
+      next: response => {
+        if (!response.success || !response.data) {
+          this.cloudLibrarySyncState.set({
+            mode: 'sync_failed',
+            message: this.formatApiError(response.error, 'Cloud save failed.')
+          });
+          return;
+        }
+
+        this.upsertCloudProject(project, response.data.projectId);
+        this.cloudLibrarySyncState.set(response.data.syncState);
+        this.notificationService.success('Cloud save requested', project.title);
+      },
+      error: error => {
+        this.errorLogging.logError(error, 'App.saveActiveProjectToCloud');
+        this.cloudLibrarySyncState.set({
+          mode: 'cloud_unavailable',
+          message: this.formatHttpError(error, 'Cloud save is unavailable until account sync is configured.')
+        });
+        this.isCloudLibraryBusy.set(false);
+      },
+      complete: () => {
+        this.isCloudLibraryBusy.set(false);
+      }
+    });
+  }
+
+  loadCloudProject(projectId: string) {
+    if (this.isCloudLibraryBusy()) {
+      return;
+    }
+
+    this.isCloudLibraryBusy.set(true);
+    this.storyService.loadCloudStoryProject(projectId).subscribe({
+      next: response => {
+        if (!response.success || !response.data) {
+          this.cloudLibrarySyncState.set({
+            mode: 'sync_failed',
+            message: this.formatApiError(response.error, 'Cloud story could not be loaded.')
+          });
+          return;
+        }
+
+        this.hydrateCloudProject(response.data.project);
+        this.cloudLibrarySyncState.set({
+          mode: 'cloud_synced',
+          lastSyncedAt: new Date().toISOString(),
+          message: `Loaded "${response.data.project.title}" from cloud.`
+        });
+      },
+      error: error => {
+        this.errorLogging.logError(error, 'App.loadCloudProject');
+        this.cloudLibrarySyncState.set({
+          mode: 'sync_failed',
+          message: this.formatHttpError(error, 'Cloud story could not be loaded.')
+        });
+        this.isCloudLibraryBusy.set(false);
+      },
+      complete: () => {
+        this.isCloudLibraryBusy.set(false);
+      }
+    });
+  }
+
+  deleteCloudProject(projectId: string) {
+    if (this.isCloudLibraryBusy()) {
+      return;
+    }
+
+    this.isCloudLibraryBusy.set(true);
+    this.storyService.deleteCloudStoryProject(projectId).subscribe({
+      next: response => {
+        if (!response.success || !response.data) {
+          this.cloudLibrarySyncState.set({
+            mode: 'sync_failed',
+            message: this.formatApiError(response.error, 'Cloud delete failed.')
+          });
+          return;
+        }
+
+        this.cloudProjects.set(this.cloudProjects().filter(project => project.projectId !== projectId));
+        this.cloudLibrarySyncState.set({
+          mode: 'cloud_synced',
+          lastSyncedAt: new Date().toISOString(),
+          message: response.data.deleted ? 'Cloud story deleted.' : 'Cloud story was already absent.'
+        });
+      },
+      error: error => {
+        this.errorLogging.logError(error, 'App.deleteCloudProject');
+        this.cloudLibrarySyncState.set({
+          mode: 'sync_failed',
+          message: this.formatHttpError(error, 'Cloud delete failed.')
+        });
+        this.isCloudLibraryBusy.set(false);
+      },
+      complete: () => {
+        this.isCloudLibraryBusy.set(false);
+      }
+    });
   }
 
   private applyIteration(payload: StoryIterationPayload, batchSize: ChapterBatchSize, batchId?: string) {
@@ -1520,6 +1717,29 @@ ${chapters}
     }
   }
 
+  private hydrateCloudProject(project: SavedStoryProject) {
+    this.blueprint.set({
+      ...project.blueprint,
+      heatContract: this.normalizeHeatContract(project.blueprint.heatContract),
+      narrativeDirectives: project.blueprint.narrativeDirectives ?? ''
+    });
+    this.workbench.set({
+      story: project.summary,
+      state: project.state,
+      chapterHistory: project.chapters,
+      activeBatchSize: project.blueprint.chapterBatchSize,
+      lastTelemetry: project.telemetry,
+      lastContinuityExtraction: project.continuityExtraction,
+      lastSuggestedPrompts: [],
+      batchQueue: [],
+      savedProjectId: project.id
+    });
+    this.selectedChapterId.set(project.chapters.at(-1)?.chapterId ?? null);
+    this.collapsedChapterGroups.set(new Set());
+    this.statusMessage.set('Cloud story loaded. Continue the saga whenever you are ready.');
+    this.notificationService.info('Cloud story loaded', project.title);
+  }
+
   private findSavedProjectByStoryId(storyId: string): SavedStoryProject | null {
     return this.workspaceStorage.loadProject(storyId)
       ?? this.workspaceStorage.listProjects().find(project => project.storyId === storyId)
@@ -1733,14 +1953,33 @@ ${chapters}
   }
 
   private persistSession(session: StoryWorkbenchSession): string | undefined {
-    if (!session.story || !session.state || !session.chapterHistory.length) {
+    const project = this.buildSavedProjectFromSession(session);
+    if (!project) {
       return undefined;
+    }
+
+    const result = this.workspaceStorage.saveProject(project);
+
+    if (!result.success) {
+      this.workspaceSaveStatus.set(result.message);
+      return undefined;
+    }
+
+    this.refreshSavedProjects();
+    this.workspaceSaveStatus.set('Saved in this browser.');
+    return result.data.id;
+  }
+
+  private buildSavedProjectFromSession(session: StoryWorkbenchSession): SavedStoryProject | null {
+    if (!session.story || !session.state || !session.chapterHistory.length) {
+      return null;
     }
 
     const now = new Date().toISOString();
     const currentProjectId = session.savedProjectId ?? session.story.storyId;
     const existingProject = this.workspaceStorage.loadProject(currentProjectId);
-    const project: SavedStoryProject = {
+
+    return {
       id: currentProjectId,
       storyId: session.story.storyId,
       title: session.story.title,
@@ -1754,16 +1993,20 @@ ${chapters}
       createdAt: existingProject?.createdAt ?? session.story.createdAt ?? now,
       updatedAt: now
     };
-    const result = this.workspaceStorage.saveProject(project);
+  }
 
-    if (!result.success) {
-      this.workspaceSaveStatus.set(result.message);
-      return undefined;
-    }
-
-    this.refreshSavedProjects();
-    this.workspaceSaveStatus.set('Saved in this browser.');
-    return result.data.id;
+  private upsertCloudProject(project: SavedStoryProject, projectId = project.id) {
+    const nextItem: CloudStoryProjectListItem = {
+      projectId,
+      storyId: project.storyId,
+      title: project.title,
+      synopsis: project.synopsis,
+      chapterCount: project.chapters.length,
+      createdAt: project.createdAt,
+      updatedAt: project.updatedAt
+    };
+    const existing = this.cloudProjects().filter(item => item.projectId !== projectId);
+    this.cloudProjects.set([nextItem, ...existing]);
   }
 
   clearFinishedBatchQueue() {
@@ -1772,6 +2015,10 @@ ${chapters}
 
   trackBatch(_index: number, batch: BatchProgressState): string {
     return batch.id;
+  }
+
+  trackCloudProject(_index: number, project: CloudStoryProjectListItem): string {
+    return project.projectId;
   }
 
   formatBatchStatus(status: BatchProgressState['status']): string {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -1069,6 +1069,11 @@ ${chapters}
       return;
     }
 
+    if (!this.canUseCloudLibrary()) {
+      this.showCloudAccountSetupStatus();
+      return;
+    }
+
     this.isCloudLibraryBusy.set(true);
     this.storyService.loadCloudStoryProject(projectId).subscribe({
       next: response => {
@@ -1103,6 +1108,11 @@ ${chapters}
 
   deleteCloudProject(projectId: string) {
     if (this.isCloudLibraryBusy()) {
+      return;
+    }
+
+    if (!this.canUseCloudLibrary()) {
+      this.showCloudAccountSetupStatus();
       return;
     }
 

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -569,6 +569,7 @@ export class App implements OnDestroy {
         return 'Connect account';
     }
   });
+  readonly canUseCloudLibrary = computed(() => this.cloudLibrarySyncState().mode === 'cloud_synced');
   readonly chapterGroups = computed<ChapterGroupViewModel[]>(() => {
     const chapters = this.workbench().chapterHistory;
     if (!chapters.length) {
@@ -1026,6 +1027,11 @@ ${chapters}
         mode: 'local_only',
         message: 'Generate a story before saving to cloud.'
       });
+      return;
+    }
+
+    if (!this.canUseCloudLibrary()) {
+      this.showCloudAccountSetupStatus();
       return;
     }
 

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -974,6 +974,14 @@ ${chapters}
         }
 
         this.cloudProjects.set(response.data.projects);
+        if (response.data.storageMode === 'non_durable_memory') {
+          this.cloudLibrarySyncState.set({
+            mode: 'cloud_unavailable',
+            message: `Cloud library is using non-durable account storage. ${response.data.projects.length} project${response.data.projects.length === 1 ? '' : 's'} loaded for inspection.`
+          });
+          return;
+        }
+
         this.cloudLibrarySyncState.set({
           mode: 'cloud_synced',
           lastSyncedAt: new Date().toISOString(),

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -547,6 +547,17 @@ export class App implements OnDestroy {
 
     return 'Account sync is not connected yet.';
   });
+  readonly cloudAccountStatusLabel = computed(() => {
+    switch (this.cloudLibrarySyncState().mode) {
+      case 'cloud_synced':
+        return 'Connected';
+      case 'sync_failed':
+        return 'Needs attention';
+      case 'local_only':
+      case 'cloud_unavailable':
+        return 'Not connected';
+    }
+  });
   readonly chapterGroups = computed<ChapterGroupViewModel[]>(() => {
     const chapters = this.workbench().chapterHistory;
     if (!chapters.length) {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -423,7 +423,8 @@ export class App implements OnDestroy {
   readonly selectedChapter = computed(() => {
     const id = this.selectedChapterId();
     if (!id) {
-      return this.workbench().chapterHistory.at(-1) ?? null;
+      const chapters = this.workbench().chapterHistory;
+      return chapters[chapters.length - 1] ?? null;
     }
 
     return this.workbench().chapterHistory.find(chapter => chapter.chapterId === id) ?? null;
@@ -1031,10 +1032,10 @@ ${chapters}
     const project = this.buildSavedProjectFromSession(this.workbench());
     if (!project) {
       this.notificationService.warning('Nothing to save', 'Generate a story before saving to cloud.');
-      this.cloudLibrarySyncState.set({
-        mode: 'local_only',
+      this.cloudLibrarySyncState.update(state => ({
+        ...state,
         message: 'Generate a story before saving to cloud.'
-      });
+      }));
       return;
     }
 
@@ -1094,11 +1095,18 @@ ${chapters}
         }
 
         this.hydrateCloudProject(response.data.project);
-        this.cloudLibrarySyncState.set({
-          mode: 'cloud_synced',
-          lastSyncedAt: new Date().toISOString(),
-          message: `Loaded "${response.data.project.title}" from cloud.`
-        });
+        if (response.data.storageMode === 'non_durable_memory') {
+          this.cloudLibrarySyncState.set({
+            mode: 'cloud_unavailable',
+            message: `Loaded "${response.data.project.title}" from non-durable account storage.`
+          });
+        } else {
+          this.cloudLibrarySyncState.set({
+            mode: 'cloud_synced',
+            lastSyncedAt: new Date().toISOString(),
+            message: `Loaded "${response.data.project.title}" from cloud.`
+          });
+        }
       },
       error: error => {
         this.errorLogging.logError(error, 'App.loadCloudProject');
@@ -1136,11 +1144,20 @@ ${chapters}
         }
 
         this.cloudProjects.set(this.cloudProjects().filter(project => project.projectId !== projectId));
-        this.cloudLibrarySyncState.set({
-          mode: 'cloud_synced',
-          lastSyncedAt: new Date().toISOString(),
-          message: response.data.deleted ? 'Cloud story deleted.' : 'Cloud story was already absent.'
-        });
+        if (response.data.storageMode === 'non_durable_memory') {
+          this.cloudLibrarySyncState.set({
+            mode: 'cloud_unavailable',
+            message: response.data.deleted
+              ? 'Cloud story deleted from non-durable account storage.'
+              : 'Cloud story was already absent from non-durable account storage.'
+          });
+        } else {
+          this.cloudLibrarySyncState.set({
+            mode: 'cloud_synced',
+            lastSyncedAt: new Date().toISOString(),
+            message: response.data.deleted ? 'Cloud story deleted.' : 'Cloud story was already absent.'
+          });
+        }
       },
       error: error => {
         this.errorLogging.logError(error, 'App.deleteCloudProject');
@@ -1774,7 +1791,7 @@ ${chapters}
       batchQueue: [],
       savedProjectId: project.id
     });
-    this.selectedChapterId.set(project.chapters.at(-1)?.chapterId ?? null);
+    this.selectedChapterId.set(project.chapters[project.chapters.length - 1]?.chapterId ?? null);
     this.collapsedChapterGroups.set(new Set());
     this.workspaceSaveStatus.set(`Loaded "${project.title}" from this browser.`);
     this.statusMessage.set('Saved story loaded. Continue the saga whenever you are ready.');
@@ -1801,7 +1818,7 @@ ${chapters}
       batchQueue: [],
       savedProjectId: project.id
     });
-    this.selectedChapterId.set(project.chapters.at(-1)?.chapterId ?? null);
+    this.selectedChapterId.set(project.chapters[project.chapters.length - 1]?.chapterId ?? null);
     this.collapsedChapterGroups.set(new Set());
     this.statusMessage.set('Cloud story loaded. Continue the saga whenever you are ready.');
     this.notificationService.info('Cloud story loaded', project.title);

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -558,6 +558,17 @@ export class App implements OnDestroy {
         return 'Not connected';
     }
   });
+  readonly cloudAccountActionLabel = computed(() => {
+    switch (this.cloudLibrarySyncState().mode) {
+      case 'cloud_synced':
+        return 'Profile';
+      case 'sync_failed':
+        return 'Account status';
+      case 'local_only':
+      case 'cloud_unavailable':
+        return 'Connect account';
+    }
+  });
   readonly chapterGroups = computed<ChapterGroupViewModel[]>(() => {
     const chapters = this.workbench().chapterHistory;
     if (!chapters.length) {
@@ -980,6 +991,27 @@ ${chapters}
         this.isCloudLibraryBusy.set(false);
       }
     });
+  }
+
+  showCloudAccountSetupStatus() {
+    if (this.isCloudLibraryBusy()) {
+      return;
+    }
+
+    if (this.cloudLibrarySyncState().mode === 'cloud_synced') {
+      this.cloudLibrarySyncState.update(state => ({
+        ...state,
+        message: state.message ?? 'Account is connected.'
+      }));
+      this.notificationService.info('Account connected', 'Cloud sync is available.');
+      return;
+    }
+
+    this.cloudLibrarySyncState.set({
+      mode: 'cloud_unavailable',
+      message: 'Sign-in setup is not configured yet. Local browser saves are still available.'
+    });
+    this.notificationService.info('Account setup pending', 'Sign-in setup is not configured yet.');
   }
 
   saveActiveProjectToCloud() {

--- a/story-generator/src/app/story.service.spec.ts
+++ b/story-generator/src/app/story.service.spec.ts
@@ -9,6 +9,10 @@ import {
   StoryLabJobCreationRequest,
   StoryLabJobCreationResponse,
   StoryLabJobEvent,
+  StoryLabUserProfile,
+  CloudStoryProjectList,
+  CloudStoryProjectSaveReceipt,
+  SavedStoryProject,
   StorySummary,
   StoryStateSnapshot
 } from './contracts';
@@ -57,6 +61,45 @@ function createState(): StoryStateSnapshot {
     continuityWarnings: [],
     narrativeVoice: 'Whispers in velvet',
     lastUpdatedAt: now
+  };
+}
+
+function createProfile(): StoryLabUserProfile {
+  const now = new Date().toISOString();
+  return {
+    userId: 'user-owner',
+    displayName: 'Avery',
+    preferences: {
+      defaultHeatContract: {
+        adultOnlyConfirmed: false,
+        tensionMode: 'slow_burn',
+        intimacyBoundary: 'closed_door'
+      },
+      favoriteCreatures: ['witch'],
+      favoriteTones: ['dark_romance'],
+      librarySort: 'updated_desc'
+    },
+    createdAt: now,
+    updatedAt: now
+  };
+}
+
+function createSavedProject(): SavedStoryProject {
+  const now = new Date().toISOString();
+  const input = createGenesisInput();
+  const summary = createSummary();
+
+  return {
+    id: 'project-cloud-1',
+    storyId: summary.storyId,
+    title: summary.title,
+    synopsis: summary.synopsis,
+    blueprint: input,
+    summary,
+    state: createState(),
+    chapters: [],
+    createdAt: now,
+    updatedAt: now
   };
 }
 
@@ -286,6 +329,105 @@ describe('StoryService', () => {
     const req = httpMock.expectOne(`/api/story-lab/jobs/${jobId}`);
     expect(req.request.method).toBe('GET');
     req.flush({ success: true, data: payload });
+  });
+
+  it('gets and updates the Story Lab account profile', () => {
+    const profile = createProfile();
+
+    service.getStoryLabProfile().subscribe(response => {
+      expect(response.success).toBeTrue();
+      expect(response.data?.userId).toBe(profile.userId);
+    });
+
+    const getReq = httpMock.expectOne('/api/story-lab/account/profile');
+    expect(getReq.request.method).toBe('GET');
+    getReq.flush({ success: true, data: profile });
+
+    service.updateStoryLabProfile(profile).subscribe(response => {
+      expect(response.success).toBeTrue();
+      expect(response.data?.displayName).toBe('Avery');
+    });
+
+    const putReq = httpMock.expectOne('/api/story-lab/account/profile');
+    expect(putReq.request.method).toBe('PUT');
+    expect(putReq.request.body).toEqual({ profile });
+    putReq.flush({ success: true, data: profile });
+  });
+
+  it('lists, saves, loads, and deletes cloud Story Lab projects', () => {
+    const project = createSavedProject();
+    const list: CloudStoryProjectList = {
+      ownerUserId: 'user-owner',
+      storageMode: 'cloud_postgres',
+      projects: [{
+        projectId: project.id,
+        storyId: project.storyId,
+        title: project.title,
+        synopsis: project.synopsis,
+        chapterCount: 0,
+        createdAt: project.createdAt,
+        updatedAt: project.updatedAt
+      }]
+    };
+    const saveReceipt: CloudStoryProjectSaveReceipt = {
+      projectId: project.id,
+      storyId: project.storyId,
+      savedAt: project.updatedAt,
+      syncState: {
+        mode: 'cloud_synced',
+        lastSyncedAt: project.updatedAt
+      }
+    };
+
+    service.listCloudStoryProjects().subscribe(response => {
+      expect(response.success).toBeTrue();
+      expect(response.data?.projects.length).toBe(1);
+    });
+    const listReq = httpMock.expectOne('/api/story-lab/account/projects');
+    expect(listReq.request.method).toBe('GET');
+    listReq.flush({ success: true, data: list });
+
+    service.saveCloudStoryProject(project).subscribe(response => {
+      expect(response.success).toBeTrue();
+      expect(response.data?.projectId).toBe(project.id);
+    });
+    const saveReq = httpMock.expectOne('/api/story-lab/account/projects');
+    expect(saveReq.request.method).toBe('POST');
+    expect(saveReq.request.body).toEqual({ project });
+    saveReq.flush({ success: true, data: saveReceipt });
+
+    service.loadCloudStoryProject(project.id).subscribe(response => {
+      expect(response.success).toBeTrue();
+      expect(response.data?.project.id).toBe(project.id);
+    });
+    const loadReq = httpMock.expectOne(`/api/story-lab/account/projects/${project.id}`);
+    expect(loadReq.request.method).toBe('GET');
+    loadReq.flush({
+      success: true,
+      data: {
+        projectId: project.id,
+        storyId: project.storyId,
+        ownerUserId: 'user-owner',
+        project,
+        createdAt: project.createdAt,
+        updatedAt: project.updatedAt,
+        storageMode: 'postgres'
+      }
+    });
+
+    service.deleteCloudStoryProject(project.id).subscribe(response => {
+      expect(response.success).toBeTrue();
+      expect(response.data?.deleted).toBeTrue();
+    });
+    const deleteReq = httpMock.expectOne(`/api/story-lab/account/projects/${project.id}`);
+    expect(deleteReq.request.method).toBe('DELETE');
+    deleteReq.flush({
+      success: true,
+      data: {
+        projectId: project.id,
+        deleted: true
+      }
+    });
   });
 
   it('streams Story Lab job events by opaque job id', () => {

--- a/story-generator/src/app/story.service.ts
+++ b/story-generator/src/app/story.service.ts
@@ -4,12 +4,18 @@ import { Observable, throwError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 import {
   ApiResponse,
+  CloudStoryProjectDeleteReceipt,
+  CloudStoryProjectList,
+  CloudStoryProjectLoadResult,
+  CloudStoryProjectSaveReceipt,
+  SavedStoryProject,
   StoryGenerationSeam,
   StoryIterationPayload,
   StoryContinuationSeam,
   StoryLabJobCreationRequest,
   StoryLabJobCreationResponse,
   StoryLabJobEvent,
+  StoryLabUserProfile,
   StreamingProgressChunk
 } from './contracts';
 import { ErrorLoggingService } from './error-logging';
@@ -103,6 +109,85 @@ export class StoryService {
     return this.http
       .get<ApiResponse<StoryLabJobCreationResponse<TResult>>>(`${this.apiUrl}/jobs/${encodeURIComponent(jobId)}`)
       .pipe(catchError(error => this.handleHttpError(error, 'getStoryLabJob')));
+  }
+
+  /**
+   * Read the signed-in Story Lab profile through the account route.
+   */
+  getStoryLabProfile(): Observable<ApiResponse<StoryLabUserProfile>> {
+    this.errorLogging.logInfo('Reading Story Lab profile', 'StoryService.getStoryLabProfile');
+
+    return this.http
+      .get<ApiResponse<StoryLabUserProfile>>(`${this.apiUrl}/account/profile`)
+      .pipe(catchError(error => this.handleHttpError(error, 'getStoryLabProfile')));
+  }
+
+  /**
+   * Update the signed-in Story Lab profile through the account route.
+   */
+  updateStoryLabProfile(profile: StoryLabUserProfile): Observable<ApiResponse<StoryLabUserProfile>> {
+    this.errorLogging.logInfo('Updating Story Lab profile', 'StoryService.updateStoryLabProfile', {
+      userId: profile.userId
+    });
+
+    return this.http
+      .put<ApiResponse<StoryLabUserProfile>>(`${this.apiUrl}/account/profile`, { profile })
+      .pipe(catchError(error => this.handleHttpError(error, 'updateStoryLabProfile')));
+  }
+
+  /**
+   * List the signed-in user's cloud Story Lab projects.
+   */
+  listCloudStoryProjects(): Observable<ApiResponse<CloudStoryProjectList>> {
+    this.errorLogging.logInfo('Listing Story Lab cloud projects', 'StoryService.listCloudStoryProjects');
+
+    return this.http
+      .get<ApiResponse<CloudStoryProjectList>>(`${this.apiUrl}/account/projects`)
+      .pipe(catchError(error => this.handleHttpError(error, 'listCloudStoryProjects')));
+  }
+
+  /**
+   * Save the current project to the signed-in user's cloud library.
+   */
+  saveCloudStoryProject(project: SavedStoryProject): Observable<ApiResponse<CloudStoryProjectSaveReceipt>> {
+    this.errorLogging.logInfo('Saving Story Lab cloud project', 'StoryService.saveCloudStoryProject', {
+      projectId: project.id,
+      storyId: project.storyId
+    });
+
+    return this.http
+      .post<ApiResponse<CloudStoryProjectSaveReceipt>>(`${this.apiUrl}/account/projects`, { project })
+      .pipe(catchError(error => this.handleHttpError(error, 'saveCloudStoryProject')));
+  }
+
+  /**
+   * Load a single signed-in cloud Story Lab project.
+   */
+  loadCloudStoryProject(projectId: string): Observable<ApiResponse<CloudStoryProjectLoadResult>> {
+    this.errorLogging.logInfo('Loading Story Lab cloud project', 'StoryService.loadCloudStoryProject', {
+      projectId
+    });
+
+    return this.http
+      .get<ApiResponse<CloudStoryProjectLoadResult>>(
+        `${this.apiUrl}/account/projects/${encodeURIComponent(projectId)}`
+      )
+      .pipe(catchError(error => this.handleHttpError(error, 'loadCloudStoryProject')));
+  }
+
+  /**
+   * Delete a signed-in cloud Story Lab project.
+   */
+  deleteCloudStoryProject(projectId: string): Observable<ApiResponse<CloudStoryProjectDeleteReceipt>> {
+    this.errorLogging.logInfo('Deleting Story Lab cloud project', 'StoryService.deleteCloudStoryProject', {
+      projectId
+    });
+
+    return this.http
+      .delete<ApiResponse<CloudStoryProjectDeleteReceipt>>(
+        `${this.apiUrl}/account/projects/${encodeURIComponent(projectId)}`
+      )
+      .pipe(catchError(error => this.handleHttpError(error, 'deleteCloudStoryProject')));
   }
 
   /**


### PR DESCRIPTION
## Summary

- Adds Angular account service methods for Story Lab profile status and cloud project save/list/load/delete calls.
- Adds cloud library UI state for account status, setup action, cloud save, cloud project load/delete, and connected-account gating.
- Preserves anonymous browser-local saves and reports `non_durable_memory` account storage as cloud unavailable instead of implying durable sync.
- Updates the recovery split/checklist docs with the exact validation evidence and remaining slices.

## Non-claims

- No production auth provider wiring or signed-in browser flow is included.
- No database provisioning, executed migration, or live durable cloud sync proof is included.
- No durable job storage/workflow behavior is included.
- Durable job ownership, story-quality guidance, Proving Grounds reporting, memory cards, and CSS lazy-loading stay in later slices.

## Validation

- `npm run recovery:preflight -- cloud-library-ui --quick`: passed.
- `npm run recovery:preflight -- cloud-library-ui`: passed.
- Evidence: `tmp/recovery/cloud-library-ui-evidence.md`.
- Function budget: `scripts/recovery/check-vercel-function-count.sh` passed at `11/12`.
- Typechecks: spec and app TypeScript passed under Node 20 via the recovery preflight.
- Build: `npm run build` passed with existing Angular bundle/CSS budget warnings.

## Browser-spec note

- Targeted Angular browser specs were attempted with `npx -p node@20 node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include src/app/app.spec.ts --include src/app/story.service.spec.ts`. The bundle built, but local `ChromeHeadless` failed to capture after two retries, so I am not claiming browser-spec proof from this workstation run.

## Next slice

- `durable-job-owner`.

## Summary by Sourcery

Add cloud library UI and account-backed project operations for Story Lab while preserving browser-local saves and honest non-durable storage messaging.

New Features:
- Introduce cloud library panel in the Angular app with account status messaging and controls for checking cloud status and managing cloud projects.
- Add Story Lab account service methods for profile retrieval/update and cloud project list/save/load/delete operations over the consolidated account route.

Enhancements:
- Gate cloud save/load/delete actions on connected account state and treat non-durable account storage as cloud-unavailable to avoid implying durable sync.
- Refactor local session persistence to share project-building logic with new cloud save flows while keeping browser-local saves as the primary user-visible path.

Documentation:
- Update Story Lab execution and recovery documentation to record the cloud-library UI slice, its honesty constraints, and validation evidence.

Tests:
- Add unit tests covering cloud library UI behavior, account gating, and non-durable storage messaging in the Angular app.
- Extend StoryService tests to cover profile/account calls and cloud project list/save/load/delete HTTP interactions.