### PR TITLE
Add Story Lab story quality guidance

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -2842,3 +2842,27 @@ Validation:
 - `bash -n scripts/recovery/slice-preflight.sh`: passed.
 - `npm run recovery:preflight -- durable-job-owner --dry-run`: passed and showed the simplified branch-diff command plus Node 20 API typecheck.
 - `npm run recovery:preflight -- durable-job-owner --quick`: passed and wrote `tmp/recovery/durable-job-owner-evidence.md`.
+
+## 2026-06-21 08:31 EDT - Story Quality Guidance Slice
+
+Actions:
+
+- Extracted the Story Lab story-output quality slice from the unpublished stack without bringing in the later Proving Grounds report or memory-card work.
+- Added activation-aware continuation courtroom guidance for threads, artifacts, relationships, and warnings, with a preview source map that explains why anchors were selected.
+- Seeded protagonist-antagonist relationship edges so relationship pressure can reach continuation guidance.
+- Tightened chapter-ending, cliche-avoidance, scene-pressure, and subtext-receipt guidance while preserving the compact hidden-guidance budget.
+- Expanded mock generation and continuation bodies so fallback story output stays closer to requested word-count ranges.
+
+Self-review:
+
+- Good: The conflict resolution kept story-quality guidance separate from Proving Grounds and memory cards instead of checking out the mega-branch file wholesale.
+- Problem found: the first extraction pass missed selected hunks for relationship seeding and shorter secret-exposed wording; the focused tests caught both before commit.
+- Process correction: for future slices, compare selected commits against current diff by behavior as well as file paths, because patch replay can silently skip hunks once a file is conflicted.
+
+Validation:
+
+- `npm run test:story-lab-real-engine`: passed.
+- `npm run test:story-quality`: passed.
+- `npm run test:story`: passed.
+- `npm run recovery:preflight -- story-quality-guidance`: passed and wrote `tmp/recovery/story-quality-guidance-evidence.md`.
+- Function count stayed `11/12`.

--- a/api/_lib/services/storyService.ts
+++ b/api/_lib/services/storyService.ts
@@ -45,6 +45,7 @@ interface GeneratedChaptersResult {
 }
 
 const EXTRA_BATCH_CHAPTER_TIMEOUT_MS = 9000;
+const MOCK_CONTINUATION_TARGET_BODY_WORDS = 450;
 
 export class StoryService {
   private readonly xaiClient = new XaiTextClient();
@@ -652,6 +653,10 @@ export class StoryService {
     tropeSelection?: TropeSelection,
     chapterOptions?: ChapterGenerationOptions
   ): Promise<GeneratedTextResult> {
+    const targetWordCount = chapterOptions
+      ? Math.max(200, Math.ceil(input.wordCount / Math.max(1, chapterOptions.totalChapters)))
+      : input.wordCount;
+
     if (!this.xaiClient.hasApiKey()) {
       if (this.isProductionRuntime()) {
         throw this.missingProviderError();
@@ -661,14 +666,11 @@ export class StoryService {
       // Fallback to mock generation if no API key
       return {
         content: chapterOptions
-          ? this.generateMockInitialChapter(input, chapterOptions.chapterNumber)
+          ? this.generateMockInitialChapter(input, chapterOptions.chapterNumber, targetWordCount)
           : this.generateMockStory(input, tropeSelection)
       };
     }
 
-    const targetWordCount = chapterOptions
-      ? Math.max(200, Math.ceil(input.wordCount / Math.max(1, chapterOptions.totalChapters)))
-      : input.wordCount;
     const systemPrompt = this.buildSystemPrompt(input, tropeSelection, chapterOptions);
     const userPrompt = chapterOptions
       ? this.buildChapterUserPrompt(input, chapterOptions)
@@ -1602,59 +1604,105 @@ Write 400-600 words for this chapter. Use HTML: <h3> for chapter title, <p> for 
   private generateMockStory(input: StoryGenerationSeam['input'], _tropeSelection?: TropeSelection): string {
     const creatureName = this.getCreatureDisplayName(input.creature);
     const spicyLabel = this.getSpicyLabel(input.spicyLevel);
+    const targetBodyWords = Math.max(200, Math.floor(input.wordCount * 0.9));
+    const paragraphs = [
+      `In the shadowed alleys of Victorian London, Lady Arabella Worthington found herself drawn to the mysterious stranger who haunted her dreams. His eyes, crimson as fresh-spilled wine, held secrets that both terrified and exhilarated her.`,
+      `"You shouldn't be here," he whispered, his voice like velvet over steel. But Arabella, with her corset straining against propriety and her heart pounding with forbidden desire, stepped closer.`,
+      `The ${creatureName.toLowerCase()} prince revealed himself slowly, each layer of deception peeling away like the petals of a night-blooming flower. His touch was electric, sending sparks through her veins that made her gasp with a pleasure bordering on pain.`,
+      `As the gas lamps flickered in the fog-shrouded streets, their bodies entwined in a dance as old as time itself. Arabella discovered that some hungers could never be satisfied, only temporarily sated.`,
+      `The ${spicyLabel.toLowerCase()} intensity of their encounter left her breathless, her skin flushed and marked by his passionate embrace. She knew she should run, should scream for help, but the pull was too strong.`,
+      `In that moment, Lady Arabella Worthington ceased to be a proper Victorian lady and became something far more dangerous - the willing consort of a creature of the night.`
+    ];
+    const expansionBeats = [
+      `By midnight, the first complication arrived: a sealed note from her father's solicitor, warning that the family estate had been promised to a rival suitor by dawn. Arabella folded the paper into her glove and understood that desire had become a legal problem as much as a spiritual one.`,
+      `The prince led her through a chapel whose saints had no faces, only silver mirrors polished by generations of terrified lovers. In every reflection she saw a different version of herself: obedient daughter, ruined bride, hungry accomplice, and queen of a country no mapmaker dared to draw.`,
+      `Their bargain gained shape between them. He would protect her name from the men who wanted to trade it like property; she would carry his secret through the morning world, where daylight made every supernatural promise look like madness or scandal.`,
+      `Arabella asked what he truly wanted, and the question changed the room. The prince smiled as if nobody had asked him that in a century. When he answered, his voice held more loneliness than seduction, and that frightened her more than the fangs.`,
+      `The rival suitor found them near the river, flanked by constables and carrying a priest's black book. He called Arabella compromised, cursed, and stolen. She surprised herself by laughing, because every word he chose was smaller than what had actually happened to her.`,
+      `The ${creatureName.toLowerCase()} did not attack. He offered terms with a courtier's restraint, each sentence wrapped in threat and etiquette. Arabella watched the men recoil from politeness sharpened into a weapon and realized power could enter a room without raising its voice.`,
+      `When the first bell of dawn sounded, the prince weakened. The color drained from his mouth, and for one terrible second Arabella saw what eternity cost him. She could leave then. She could step into respectable daylight and pretend the night had been an illness.`,
+      `Instead, she took his signet ring and pressed it into her palm until the crest left a mark. It was not a wedding vow, not yet, but it was evidence. By sunrise everyone would know Lady Arabella had chosen the scandal herself, and chosen it with a steady hand.`
+    ];
+
+    const renderBody = () => paragraphs.map(paragraph => `<p>${paragraph}</p>`).join('\n\n');
+    let beatIndex = 0;
+    while (this.countWords(renderBody()) < targetBodyWords) {
+      paragraphs.push(expansionBeats[beatIndex % expansionBeats.length]);
+      beatIndex += 1;
+    }
 
     return `<h3>The ${creatureName}'s Forbidden Passion</h3>
 
-<p>In the shadowed alleys of Victorian London, Lady Arabella Worthington found herself drawn to the mysterious stranger who haunted her dreams. His eyes, crimson as fresh-spilled wine, held secrets that both terrified and exhilarated her.</p>
-
-<p>"You shouldn't be here," he whispered, his voice like velvet over steel. But Arabella, with her corset straining against propriety and her heart pounding with forbidden desire, stepped closer.</p>
-
-<p>The ${creatureName.toLowerCase()} prince revealed himself slowly, each layer of deception peeling away like the petals of a night-blooming flower. His touch was electric, sending sparks through her veins that made her gasp with a pleasure bordering on pain.</p>
-
-<p>As the gas lamps flickered in the fog-shrouded streets, their bodies entwined in a dance as old as time itself. Arabella discovered that some hungers could never be satisfied, only temporarily sated.</p>
-
-<p>The ${spicyLabel.toLowerCase()} intensity of their encounter left her breathless, her skin flushed and marked by his passionate embrace. She knew she should run, should scream for help, but the pull was too strong.</p>
-
-<p>In that moment, Lady Arabella Worthington ceased to be a proper Victorian lady and became something far more dangerous - the willing consort of a creature of the night.</p>
+${renderBody()}
 
 <p><em>This is a mock story generated without AI. Add XAI_API_KEY to use real AI generation.</em></p>`;
   }
 
-  private generateMockInitialChapter(input: StoryGenerationSeam['input'], chapterNumber: number): string {
+  private generateMockInitialChapter(input: StoryGenerationSeam['input'], chapterNumber: number, targetWordCount: number): string {
     const creatureName = this.getCreatureDisplayName(input.creature);
     const baseTitle = chapterNumber === 1
       ? `The ${creatureName}'s Forbidden Passion`
       : `Secrets of the ${creatureName} - Part ${chapterNumber}`;
+    const targetBodyWords = Math.max(160, Math.floor(targetWordCount * 0.9));
+    const paragraphs = [
+      `[Narrator]: Moonlight dripped across the manor's stone balustrades as whispers of destiny curled around our lovers. The ${creatureName.toLowerCase()} aristocrat studied their prey with patient hunger, weighing desire against the oaths that bound their bloodline.`,
+      `[Narrator]: Each chapter in this mock sequence leans into danger, seduction, and supernatural stakes. Expect clandestine meetings beneath stained glass, confessions that scorch the night air, and the steady escalation of ${creatureName.toLowerCase()} power games.`,
+      `[Narrator]: This placeholder chapter lets the application exercise multi-chapter flows without live Grok calls. In production the AI will weave bespoke intrigue, but here we provide atmospheric beats and a tidy cliffhanger.`,
+      `[Narrator]: Just before dawn, a coded message slips beneath the chamber door promising either salvation or ruin. Our heroes must decide whether to follow it, setting up the next chapter's peril.`
+    ];
+    const expansionBeats = [
+      `[Narrator]: Chapter ${chapterNumber} also tracks a concrete emotional turn. One lover asks for trust, the other asks for proof, and neither request can be answered without giving the enemy a weakness to exploit.`,
+      `[Narrator]: A secondary bargain tightens the plot. Servants move through the halls with lowered eyes, carrying letters, keys, and warnings that make the romance feel watched from every doorway.`,
+      `[Narrator]: By the end of the scene, the ${creatureName.toLowerCase()} power dynamic has changed hands. What began as pursuit becomes negotiation, and what looked like surrender becomes a deliberate tactical choice.`,
+      `[Narrator]: The chapter closes with a visible consequence: a torn glove, a missing signet, a witness who should have been asleep. The next chapter has something specific to answer.`
+    ];
+
+    const renderBody = () => paragraphs.map(paragraph => `<p>${paragraph}</p>`).join('\n\n');
+    let beatIndex = 0;
+    while (this.countWords(renderBody()) < targetBodyWords) {
+      paragraphs.push(expansionBeats[beatIndex % expansionBeats.length]);
+      beatIndex += 1;
+    }
 
     return `<h3>Chapter ${chapterNumber}: ${baseTitle}</h3>
 
-<p>[Narrator]: Moonlight dripped across the manor's stone balustrades as whispers of destiny curled around our lovers. The ${creatureName.toLowerCase()} aristocrat studied their prey with patient hunger, weighing desire against the oaths that bound their bloodline.</p>
-
-<p>[Narrator]: Each chapter in this mock sequence leans into danger, seduction, and supernatural stakes. Expect clandestine meetings beneath stained glass, confessions that scorch the night air, and the steady escalation of ${creatureName.toLowerCase()} power games.</p>
-
-<p>[Narrator]: This placeholder chapter lets the application exercise multi-chapter flows without live Grok calls. In production the AI will weave bespoke intrigue, but here we provide atmospheric beats and a tidy cliffhanger.</p>
-
-<p>[Narrator]: Just before dawn, a coded message slips beneath the chamber door promising either salvation or ruin. Our heroes must decide whether to follow it, setting up the next chapter's peril.</p>`;
+${renderBody()}`;
   }
 
   private generateMockChapter(input: ChapterContinuationSeam['input'], chapterNumber?: number): string {
     const nextNumber = chapterNumber ?? input.currentChapterCount + 1;
+    const paragraphs = [
+      `The morning light pierced through heavy velvet curtains, but Arabella felt no warmth from its golden rays. Instead, a strange energy coursed through her veins, awakening senses she never knew existed.`,
+      `Every sound was amplified - the distant clip-clop of carriage horses, the rustle of leaves in the garden, even the steady beat of her own heart. And beneath it all, a hunger that gnawed at her very soul.`,
+      `Her reflection in the mirror showed a woman transformed. Her skin glowed with an otherworldly luminescence, her eyes held a predatory gleam. The creature had given her a gift... or was it a curse?`,
+      `As night fell once more, she waited impatiently for his return. The hours stretched like taffy, each minute an eternity of anticipation. When he finally appeared at her balcony, silent as a shadow, Arabella knew there was no turning back.`,
+      `Their second encounter was even more intense than the first. His hands explored her body with a possessiveness that made her arch and cry out. The passion burned hotter, threatening to consume them both.`,
+      `But in the aftermath, as they lay entwined in sweat-dampened sheets, Arabella began to question the true cost of her transformation. What price would she pay for eternal passion?`
+    ];
+    const expansionBeats = [
+      `The answer did not arrive as a grand prophecy. It came as a practical problem: a servant waiting outside the door with breakfast she could no longer stomach, a visiting aunt asking why the curtains stayed drawn, and a letter sealed in black wax on the breakfast tray.`,
+      `Arabella broke the seal with fingers that still remembered his touch. The note named three debts: the ring she had accepted, the rival she had humiliated, and the family name she had placed between herself and the creature who now owned half her future.`,
+      `She tried to rehearse a lie for the household, but every version sounded like a child covering a broken vase. The truth was worse and steadier. She had chosen this, and choice made a stronger cage than force ever could.`,
+      `When dusk returned, he found her in the library with ledgers spread across the floor. She had traced the estate's debts to a lender who used no human bank. The supernatural world had not seduced her away from danger; it had merely given danger better handwriting.`,
+      `He reached for the papers, and she stopped him with one hand on his wrist. The gesture startled them both. Last night she had been prey, guest, lover, and fool by turns. Tonight she needed to become someone whose questions could not be dismissed.`,
+      `The chapter turned when she named the cost out loud. If he wanted her beside him, he would answer like a partner, not a prince visiting a distraction. The silence after that sentence felt sharper than any kiss they had shared.`,
+      `Outside, the first carriage rolled through the fog. Someone had come early, and whoever waited below carried enough authority to make every servant in the house fall quiet. Arabella looked at him and understood the next choice would have witnesses.`,
+      `He offered her one escape. She refused it before he finished speaking, because escape had started to sound too much like being managed. Instead she took the black-wax letter, folded it into her bodice, and walked toward the stairs.`
+    ];
+
+    const renderBody = () => [
+      ...paragraphs.map(paragraph => `<p>${paragraph}</p>`),
+      '<p><em>This is a mock chapter generated without AI.</em></p>'
+    ].join('\n\n');
+    let beatIndex = 0;
+    while (this.countWords(renderBody()) < MOCK_CONTINUATION_TARGET_BODY_WORDS) {
+      paragraphs.push(expansionBeats[beatIndex % expansionBeats.length]);
+      beatIndex += 1;
+    }
 
     return `<h3>Chapter ${nextNumber}: The Deeper Shadows</h3>
 
-<p>The morning light pierced through heavy velvet curtains, but Arabella felt no warmth from its golden rays. Instead, a strange energy coursed through her veins, awakening senses she never knew existed.</p>
-
-<p>Every sound was amplified - the distant clip-clop of carriage horses, the rustle of leaves in the garden, even the steady beat of her own heart. And beneath it all, a hunger that gnawed at her very soul.</p>
-
-<p>Her reflection in the mirror showed a woman transformed. Her skin glowed with an otherworldly luminescence, her eyes held a predatory gleam. The creature had given her a gift... or was it a curse?</p>
-
-<p>As night fell once more, she waited impatiently for his return. The hours stretched like taffy, each minute an eternity of anticipation. When he finally appeared at her balcony, silent as a shadow, Arabella knew there was no turning back.</p>
-
-<p>Their second encounter was even more intense than the first. His hands explored her body with a possessiveness that made her arch and cry out. The passion burned hotter, threatening to consume them both.</p>
-
-<p>But in the aftermath, as they lay entwined in sweat-dampened sheets, Arabella began to question the true cost of her transformation. What price would she pay for eternal passion?</p>
-
-<p><em>This is a mock chapter generated without AI.</em></p>`;
+${renderBody()}`;
   }
 
   private getCreatureDisplayName(creature: string): string {

--- a/api/_lib/story-lab/storyLabEngine.ts
+++ b/api/_lib/story-lab/storyLabEngine.ts
@@ -38,7 +38,66 @@ interface StoryLabEngineOptions {
   serviceFactory?: () => StoryServiceLike;
 }
 
+export interface StoryLabContinuationGuidancePreview {
+  originalBrief: string;
+  providerBrief: string;
+  hiddenGuidance: string;
+  anchorHeadings: string[];
+  contextSourceMap: StoryLabContinuationSourceMapEntry[];
+  characterCount: number;
+}
+
+type StoryLabContinuationSourceKind = 'thread' | 'relationship' | 'artifact' | 'warning';
+
+export interface StoryLabContinuationSourceMapEntry {
+  kind: StoryLabContinuationSourceKind;
+  label: string;
+  anchorLabel: string;
+  reason: string;
+  activationScore: number;
+}
+
 const MOCK_FLAG_VALUES = new Set(['1', 'true', 'yes']);
+const CONTINUITY_COURTROOM_MAX_THREADS = 3;
+const CONTINUITY_COURTROOM_MAX_ARTIFACTS = 2;
+const CONTINUITY_COURTROOM_MAX_WARNINGS = 2;
+const CONTINUITY_COURTROOM_MAX_DETAIL_LENGTH = 180;
+const WORLD_ARTIFACT_MAX_NAME_WORDS = 4;
+type ChapterEndingPressureId = 'emotional_reveal' | 'danger_escalation' | 'secret_exposed';
+type ScenePressureLabel = 'Emotional' | 'Secret' | 'Deadline' | 'Social' | 'Setting';
+interface ChapterEndingPressure {
+  id: ChapterEndingPressureId;
+  label: string;
+  candidateLabel: string;
+  instruction: string;
+}
+const CHAPTER_ENDING_PRESSURES: readonly ChapterEndingPressure[] = [
+  {
+    id: 'emotional_reveal',
+    label: 'Emotional reveal',
+    candidateLabel: 'emotional reveal',
+    instruction: 'end on a private truth the characters cannot comfortably take back.'
+  },
+  {
+    id: 'danger_escalation',
+    label: 'Danger escalation',
+    candidateLabel: 'danger escalation',
+    instruction: 'end with the outside threat entering the scene in a way that forces motion.'
+  },
+  {
+    id: 'secret_exposed',
+    label: 'Secret exposed',
+    candidateLabel: 'secret exposed',
+    instruction: 'expose a secret that changes the next chapter.'
+  }
+];
+const SCENE_PRESSURE_VARIANTS: Record<ScenePressureLabel, readonly string[]> = {
+  Emotional: ['private truth costs status', 'want changes the bargain', 'affection becomes leverage'],
+  Secret: ['truth changes leverage', 'hidden motive costs safety', 'named lie changes power'],
+  Deadline: ['clock forces choice', 'delay costs safety', 'time makes refusal visible'],
+  Social: ['witnesses make retreat costly', 'status turns into pressure', 'audience changes the bargain'],
+  Setting: ['place enforces cost', 'room becomes leverage', 'world rule tightens']
+};
 const CLASSIC_THEME_TYPES: readonly ThemeType[] = [
   'betrayal',
   'obsession',
@@ -65,6 +124,23 @@ const DEFAULT_CLASSIC_THEME: ThemeType = 'forbidden_love';
 export function shouldUseMockStoryLab(): boolean {
   const forceMock = process.env['STORY_LAB_FORCE_MOCK'] ?? '';
   return !isProductionRuntime() && (MOCK_FLAG_VALUES.has(forceMock.toLowerCase()) || !process.env['XAI_API_KEY']);
+}
+
+export function previewStoryLabContinuationGuidance(input: {
+  continuationBrief?: string;
+  storyState: StoryStateSnapshot;
+}): StoryLabContinuationGuidancePreview {
+  const originalBrief = input.continuationBrief?.trim() ?? '';
+  const providerBrief = withContinuationStrategyBrief(input.continuationBrief, input.storyState) ?? originalBrief;
+  const hiddenGuidance = extractHiddenContinuationGuidance(providerBrief, originalBrief);
+  return {
+    originalBrief,
+    providerBrief,
+    hiddenGuidance,
+    anchorHeadings: extractAnchorHeadings(hiddenGuidance),
+    contextSourceMap: buildContinuationContextSourceMap(input.storyState, originalBrief),
+    characterCount: providerBrief.length
+  };
 }
 
 function isProductionRuntime(): boolean {
@@ -224,11 +300,12 @@ export async function continueStoryLab(
   const service = options.serviceFactory?.() ?? new StoryService();
   const currentChapterCount = Math.max(...previousChapters.map(chapter => chapter.chapterNumber));
   const existingContent = previousChapters.map(chapter => chapter.rawContent || chapter.htmlContent).join('\n\n');
+  const continuationBrief = withContinuationStrategyBrief(input.continuationBrief, storyState);
   const result = await service.continueChapter({
     storyId: input.storyId,
     currentChapterCount,
     existingContent,
-    userInput: input.continuationBrief,
+    userInput: continuationBrief,
     maintainTone: true,
     tropeMetadata: existingSummary?.tropeMetadata,
     requestedChapterCount: input.chapterBatchSize,
@@ -301,6 +378,538 @@ export function buildStoryLabPayloadFromGeneratedStory(
     stateDelta: buildStateDelta(story.storyId, null, state, chapters),
     telemetry: buildGrokTelemetry(metadata, chapters.length)
   };
+}
+
+function withContinuationStrategyBrief(continuationBrief: string | undefined, storyState: StoryStateSnapshot): string | undefined {
+  const trimmedBrief = continuationBrief?.trim();
+  return [
+    trimmedBrief,
+    buildContinuityCourtroomBrief(storyState, trimmedBrief),
+    buildChapterEndingStressTestBrief(storyState, trimmedBrief),
+    buildClicheAlarmBrief(storyState, trimmedBrief)
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join('\n\n') || undefined;
+}
+
+function extractHiddenContinuationGuidance(providerBrief: string, originalBrief: string): string {
+  if (!originalBrief || !providerBrief.startsWith(originalBrief)) {
+    return providerBrief.trim();
+  }
+
+  return providerBrief.slice(originalBrief.length).trim();
+}
+
+function extractAnchorHeadings(hiddenGuidance: string): string[] {
+  return hiddenGuidance
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => /^[A-Za-z][A-Za-z ]+:$/.test(line))
+    .map(line => line.slice(0, -1));
+}
+
+function buildContinuityCourtroomBrief(storyState: StoryStateSnapshot, continuationBrief: string | undefined): string | undefined {
+  const lines: string[] = [];
+
+  for (const thread of selectCourtroomThreads(storyState, continuationBrief)) {
+    lines.push(`- ${formatThreadDebtLabel(thread)}: ${compactPromptLine(thread.label)}${formatCourtroomDetail(thread.description)}`);
+  }
+
+  const relationshipPressure = selectRelationshipPressure(storyState, continuationBrief);
+  if (relationshipPressure) {
+    lines.push(formatRelationshipPressureLine(relationshipPressure));
+  }
+
+  for (const artifact of selectCourtroomArtifacts(storyState, continuationBrief)) {
+    lines.push(`- World clue: ${compactPromptLine(artifact.name)}${formatCourtroomDetail(artifact.significance)}`);
+  }
+
+  for (const warning of selectCourtroomWarnings(storyState, continuationBrief)) {
+    lines.push(`- Continuity note: ${compactPromptLine(warning)}`);
+  }
+
+  if (lines.length === 0) {
+    return undefined;
+  }
+
+  return [
+    'Continuity Courtroom:',
+    ...lines
+  ].join('\n');
+}
+
+function buildContinuationContextSourceMap(
+  storyState: StoryStateSnapshot,
+  continuationBrief: string | undefined
+): StoryLabContinuationSourceMapEntry[] {
+  const entries: StoryLabContinuationSourceMapEntry[] = [];
+
+  for (const item of selectScoredCourtroomThreads(storyState, continuationBrief)) {
+    entries.push({
+      kind: 'thread',
+      label: item.thread.label,
+      anchorLabel: formatThreadDebtLabel(item.thread),
+      reason: formatActivationReason(item.activationScore),
+      activationScore: item.activationScore
+    });
+  }
+
+  const relationshipPressure = selectRelationshipPressure(storyState, continuationBrief);
+  if (relationshipPressure) {
+    entries.push({
+      kind: 'relationship',
+      label: `${relationshipPressure.sourceCharacter.displayName} and ${relationshipPressure.targetCharacter.displayName}`,
+      anchorLabel: 'Relationship pressure',
+      reason: formatActivationReason(relationshipPressure.activationScore),
+      activationScore: relationshipPressure.activationScore
+    });
+  }
+
+  for (const item of selectScoredCourtroomArtifacts(storyState, continuationBrief)) {
+    entries.push({
+      kind: 'artifact',
+      label: item.artifact.name,
+      anchorLabel: 'World clue',
+      reason: formatActivationReason(item.activationScore),
+      activationScore: item.activationScore
+    });
+  }
+
+  for (const item of selectScoredCourtroomWarnings(storyState, continuationBrief)) {
+    entries.push({
+      kind: 'warning',
+      label: item.warning,
+      anchorLabel: 'Continuity note',
+      reason: formatActivationReason(item.activationScore),
+      activationScore: item.activationScore
+    });
+  }
+
+  return entries;
+}
+
+function formatActivationReason(activationScore: number): string {
+  return activationScore > 0
+    ? 'Matched words from the continuation brief.'
+    : 'Included by unresolved-story priority.';
+}
+
+function selectCourtroomThreads(storyState: StoryStateSnapshot, continuationBrief: string | undefined): PlotThread[] {
+  return selectScoredCourtroomThreads(storyState, continuationBrief).map(item => item.thread);
+}
+
+function selectScoredCourtroomThreads(storyState: StoryStateSnapshot, continuationBrief: string | undefined): Array<{
+  thread: PlotThread;
+  index: number;
+  activationScore: number;
+}> {
+  const source = normalizeActivationText(continuationBrief ?? '');
+  return storyState.threads
+    .filter(isUnresolvedThread)
+    .map((thread, index) => ({
+      thread,
+      index,
+      activationScore: scoreThreadActivation(thread, source)
+    }))
+    .sort((left, right) => (right.activationScore - left.activationScore) || (left.index - right.index))
+    .slice(0, CONTINUITY_COURTROOM_MAX_THREADS);
+}
+
+function selectCourtroomArtifacts(storyState: StoryStateSnapshot, continuationBrief: string | undefined): LoreArtifact[] {
+  return selectScoredCourtroomArtifacts(storyState, continuationBrief).map(item => item.artifact);
+}
+
+function selectScoredCourtroomArtifacts(storyState: StoryStateSnapshot, continuationBrief: string | undefined): Array<{
+  artifact: LoreArtifact;
+  index: number;
+  activationScore: number;
+}> {
+  const source = normalizeActivationText(continuationBrief ?? '');
+  return storyState.artifacts
+    .filter(artifact => !artifact.resolvedInChapter)
+    .map((artifact, index) => ({
+      artifact,
+      index,
+      activationScore: scoreArtifactActivation(artifact, source)
+    }))
+    .sort((left, right) => (right.activationScore - left.activationScore) || (left.index - right.index))
+    .slice(0, CONTINUITY_COURTROOM_MAX_ARTIFACTS);
+}
+
+function scoreThreadActivation(thread: PlotThread, source: string): number {
+  if (!source) {
+    return 0;
+  }
+
+  const candidates = [
+    thread.label,
+    thread.description,
+    ...thread.foreshadowedDevices
+  ].map(normalizeActivationText).filter(Boolean);
+  let score = 0;
+
+  for (const candidate of candidates) {
+    if (source.includes(candidate)) {
+      score += 6;
+    }
+
+    for (const token of candidate.split(' ').filter(value => value.length > 3)) {
+      if (source.includes(token)) {
+        score += 1;
+      }
+    }
+  }
+
+  return score;
+}
+
+function scoreArtifactActivation(artifact: LoreArtifact, source: string): number {
+  if (!source) {
+    return 0;
+  }
+
+  const candidates = [
+    artifact.name,
+    artifact.significance
+  ].map(normalizeActivationText).filter(Boolean);
+  let score = 0;
+
+  for (const candidate of candidates) {
+    if (source.includes(candidate)) {
+      score += 6;
+    }
+
+    for (const token of candidate.split(' ').filter(value => value.length > 3)) {
+      if (source.includes(token)) {
+        score += 1;
+      }
+    }
+  }
+
+  return score;
+}
+
+function selectCourtroomWarnings(storyState: StoryStateSnapshot, continuationBrief: string | undefined): string[] {
+  return selectScoredCourtroomWarnings(storyState, continuationBrief).map(item => item.warning);
+}
+
+function selectScoredCourtroomWarnings(storyState: StoryStateSnapshot, continuationBrief: string | undefined): Array<{
+  warning: string;
+  index: number;
+  activationScore: number;
+}> {
+  const source = normalizeActivationText(continuationBrief ?? '');
+  return storyState.continuityWarnings
+    .map((warning, index) => ({
+      warning,
+      index,
+      activationScore: scoreWarningActivation(warning, source)
+    }))
+    .sort((left, right) => (right.activationScore - left.activationScore) || (left.index - right.index))
+    .slice(0, CONTINUITY_COURTROOM_MAX_WARNINGS);
+}
+
+function scoreWarningActivation(warning: string, source: string): number {
+  if (!source) {
+    return 0;
+  }
+
+  const candidate = normalizeActivationText(warning);
+  if (!candidate) {
+    return 0;
+  }
+
+  let score = source.includes(candidate) ? 6 : 0;
+  for (const token of candidate.split(' ').filter(value => value.length > 3)) {
+    if (source.includes(token)) {
+      score += 1;
+    }
+  }
+
+  return score;
+}
+
+function normalizeActivationText(value: string): string {
+  return collapseWhitespace(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function isUnresolvedThread(thread: PlotThread): boolean {
+  return thread.status !== 'resolved';
+}
+
+function formatThreadDebtLabel(thread: PlotThread): string {
+  if (thread.status === 'escalating') {
+    return 'Pressure rising';
+  }
+  if (thread.status === 'dormant') {
+    return 'Quiet promise';
+  }
+  return 'Open promise';
+}
+
+interface RelationshipPressureSelection {
+  sourceCharacter: CharacterProfile;
+  targetCharacter: CharacterProfile;
+  relationship: CharacterProfile['relationships'][number];
+  index: number;
+  activationScore: number;
+}
+
+function selectRelationshipPressure(
+  storyState: StoryStateSnapshot,
+  continuationBrief: string | undefined
+): RelationshipPressureSelection | undefined {
+  const source = normalizeActivationText(continuationBrief ?? '');
+  const candidates: RelationshipPressureSelection[] = [];
+
+  for (const sourceCharacter of storyState.characters) {
+    for (const relationship of sourceCharacter.relationships) {
+      const targetCharacter = storyState.characters.find(candidate => candidate.id === relationship.characterId);
+      if (targetCharacter) {
+        candidates.push({
+          sourceCharacter,
+          targetCharacter,
+          relationship,
+          index: candidates.length,
+          activationScore: scoreRelationshipActivation(sourceCharacter, targetCharacter, relationship, source)
+        });
+      }
+    }
+  }
+
+  return candidates.sort((left, right) => (right.activationScore - left.activationScore) || (left.index - right.index))[0];
+}
+
+function formatRelationshipPressureLine(selected: RelationshipPressureSelection): string {
+  return `- Relationship pressure: ${compactPromptLine(selected.sourceCharacter.displayName)} and ${compactPromptLine(selected.targetCharacter.displayName)}.`;
+}
+
+function scoreRelationshipActivation(
+  sourceCharacter: CharacterProfile,
+  targetCharacter: CharacterProfile,
+  relationship: CharacterProfile['relationships'][number],
+  source: string
+): number {
+  if (!source) {
+    return 0;
+  }
+
+  const candidates = [
+    sourceCharacter.displayName,
+    targetCharacter.displayName,
+    relationship.relationship,
+    relationship.notes
+  ].map(normalizeActivationText).filter(Boolean);
+  let score = 0;
+
+  for (const candidate of candidates) {
+    if (source.includes(candidate)) {
+      score += 6;
+    }
+
+    for (const token of candidate.split(' ').filter(value => value.length > 3)) {
+      if (source.includes(token)) {
+        score += 1;
+      }
+    }
+  }
+
+  return score;
+}
+
+function formatCourtroomDetail(value: string): string {
+  const detail = compactPromptLine(value);
+  return detail ? ` - ${detail}` : '';
+}
+
+function compactPromptLine(value: string): string {
+  const compacted = collapseWhitespace(value).trim();
+  if (compacted.length <= CONTINUITY_COURTROOM_MAX_DETAIL_LENGTH) {
+    return compacted;
+  }
+
+  return `${compacted.slice(0, CONTINUITY_COURTROOM_MAX_DETAIL_LENGTH - 3).trim()}...`;
+}
+
+function buildChapterEndingStressTestBrief(storyState: StoryStateSnapshot, continuationBrief: string | undefined): string {
+  const selectedPressure = chooseChapterEndingPressure(storyState, continuationBrief);
+  return [
+    'Chapter Ending Stress Test:',
+    `- Endings: ${CHAPTER_ENDING_PRESSURES.map(pressure => pressure.candidateLabel).join(', ')}.`,
+    `- Chosen: ${selectedPressure.label} - ${selectedPressure.instruction}`,
+    `- Scene pressure mix: ${chooseScenePressureMix(storyState, continuationBrief, selectedPressure)}.`,
+    '- Answer one question; leave one sharper.'
+  ].join('\n');
+}
+
+function chooseChapterEndingPressure(storyState: StoryStateSnapshot, continuationBrief: string | undefined): ChapterEndingPressure {
+  const unresolvedThreads = storyState.threads.filter(isUnresolvedThread);
+  const unresolvedArtifacts = storyState.artifacts.filter(artifact => !artifact.resolvedInChapter);
+  const pressureSource = buildContinuationPressureSource(storyState, continuationBrief);
+  const scores: Record<ChapterEndingPressureId, number> = {
+    emotional_reveal: 1,
+    danger_escalation: 1,
+    secret_exposed: 1
+  };
+
+  if (containsAny(pressureSource, ['love', 'kiss', 'desire', 'choose', 'confess', 'heart', 'boundary', 'want', 'betray'])) {
+    scores.emotional_reveal += 2;
+  }
+
+  if (containsAny(pressureSource, ['danger', 'attack', 'threat', 'trap', 'hunt', 'deadline', 'demand', 'force', 'blood'])) {
+    scores.danger_escalation += 2;
+  }
+
+  if (unresolvedThreads.some(thread => thread.status === 'escalating')) {
+    scores.danger_escalation += 2;
+  }
+
+  if (containsAny(pressureSource, ['secret', 'hidden', 'truth', 'lie', 'name', 'bargain', 'debt', 'payment', 'price', 'vow'])) {
+    scores.secret_exposed += 3;
+  }
+
+  if (unresolvedArtifacts.length > 0 || storyState.continuityWarnings.length > 0) {
+    scores.secret_exposed += 2;
+  }
+
+  return CHAPTER_ENDING_PRESSURES.reduce((best, candidate) =>
+    scores[candidate.id] > scores[best.id] ? candidate : best
+  );
+}
+
+function chooseScenePressureMix(
+  storyState: StoryStateSnapshot,
+  continuationBrief: string | undefined,
+  selectedPressure: ChapterEndingPressure
+): string {
+  const primary = mapEndingPressureToScenePressure(selectedPressure.id);
+  const pressureSource = buildContinuationPressureSource(storyState, continuationBrief);
+  const secondaryCandidates: ScenePressureLabel[] = [];
+
+  if (containsAny(pressureSource, ['deadline', 'clock', 'tonight', 'hour', 'sunrise'])) {
+    secondaryCandidates.push('Deadline');
+  }
+
+  if (storyState.artifacts.some(artifact => !artifact.resolvedInChapter)
+    || containsAny(pressureSource, ['court', 'room', 'place', 'reef', 'shell', 'song', 'door', 'hall'])) {
+    secondaryCandidates.push('Setting');
+  }
+
+  if (storyState.characters.length > 1
+    || containsAny(pressureSource, ['family', 'crowd', 'witness', 'lord', 'queen', 'council'])) {
+    secondaryCandidates.push('Social');
+  }
+
+  if (containsAny(pressureSource, ['secret', 'hidden', 'truth', 'lie', 'bargain', 'debt', 'payment', 'price', 'vow'])) {
+    secondaryCandidates.push('Secret');
+  }
+
+  if (containsAny(pressureSource, ['love', 'kiss', 'desire', 'choose', 'confess', 'heart', 'betray'])) {
+    secondaryCandidates.push('Emotional');
+  }
+
+  const secondary = secondaryCandidates.find(candidate => candidate !== primary)
+    ?? (primary === 'Setting' ? 'Social' : 'Setting');
+  return `${primary} + ${secondary}; ${chooseScenePressureVariant(storyState, continuationBrief, primary, secondary)}`;
+}
+
+function mapEndingPressureToScenePressure(pressureId: ChapterEndingPressureId): ScenePressureLabel {
+  if (pressureId === 'emotional_reveal') {
+    return 'Emotional';
+  }
+  if (pressureId === 'danger_escalation') {
+    return 'Deadline';
+  }
+  return 'Secret';
+}
+
+function chooseScenePressureVariant(
+  storyState: StoryStateSnapshot,
+  continuationBrief: string | undefined,
+  primary: ScenePressureLabel,
+  secondary: ScenePressureLabel
+): string {
+  const variants = SCENE_PRESSURE_VARIANTS[secondary];
+  const seed = `${storyState.storyId}|${storyState.revision}|${continuationBrief ?? ''}|${primary}|${secondary}`;
+  return variants[stableSeedIndex(seed, variants.length)] ?? variants[0];
+}
+
+function stableSeedIndex(seed: string, modulo: number): number {
+  let hash = 0;
+  for (const char of seed) {
+    hash = ((hash * 31) + char.charCodeAt(0)) >>> 0;
+  }
+  return modulo > 0 ? hash % modulo : 0;
+}
+
+function containsAny(value: string, needles: readonly string[]): boolean {
+  return needles.some(needle => value.includes(needle));
+}
+
+function buildContinuationPressureSource(storyState: StoryStateSnapshot, continuationBrief: string | undefined): string {
+  const unresolvedThreads = storyState.threads.filter(isUnresolvedThread);
+  const unresolvedArtifacts = storyState.artifacts.filter(artifact => !artifact.resolvedInChapter);
+  return [
+    continuationBrief ?? '',
+    ...unresolvedThreads.flatMap(thread => [thread.label, thread.description, ...thread.foreshadowedDevices]),
+    ...unresolvedArtifacts.map(artifact => `${artifact.name} ${artifact.significance}`),
+    ...storyState.continuityWarnings
+  ].join(' ').toLowerCase();
+}
+
+function buildClicheAlarmBrief(storyState: StoryStateSnapshot, continuationBrief: string | undefined): string {
+  return [
+    'Cliche Alarm:',
+    `- Avoid: ${chooseClicheAlarmPath(storyState, continuationBrief)}`,
+    `- Freshness: turn ${chooseFreshnessTarget(storyState)} with visible cost.`,
+    `- Subtext receipt: prove ${chooseSubtextReceiptTarget(storyState, continuationBrief)} by behavior before explanation.`
+  ].join('\n');
+}
+
+function chooseClicheAlarmPath(storyState: StoryStateSnapshot, continuationBrief: string | undefined): string {
+  const source = buildContinuationPressureSource(storyState, continuationBrief);
+  if (containsAny(source, ['debt', 'payment', 'price', 'bargain', 'vow', 'court', 'demand'])) {
+    return 'formal demand with no personal cost.';
+  }
+
+  if (containsAny(source, ['love', 'kiss', 'desire', 'choose', 'confess', 'heart', 'want'])) {
+    return 'confession of what they already know.';
+  }
+
+  if (containsAny(source, ['danger', 'attack', 'threat', 'trap', 'hunt', 'deadline', 'force', 'blood'])) {
+    return 'threat that changes no relationship.';
+  }
+
+  return 'repeat of the last chapter without new cost.';
+}
+
+function chooseFreshnessTarget(storyState: StoryStateSnapshot): string {
+  const thread = storyState.threads.find(candidate => candidate.status === 'escalating')
+    ?? storyState.threads.find(candidate => candidate.status === 'active')
+    ?? storyState.threads.find(isUnresolvedThread);
+  if (thread) {
+    return compactPromptLine(thread.label);
+  }
+
+  const artifact = storyState.artifacts.find(candidate => !candidate.resolvedInChapter);
+  if (artifact) {
+    return compactPromptLine(artifact.name);
+  }
+
+  return 'the most recent unresolved choice';
+}
+
+function chooseSubtextReceiptTarget(storyState: StoryStateSnapshot, continuationBrief: string | undefined): string {
+  const relationshipPressure = selectRelationshipPressure(storyState, continuationBrief);
+  if (relationshipPressure) {
+    return `${compactPromptLine(relationshipPressure.sourceCharacter.displayName)} and ${compactPromptLine(relationshipPressure.targetCharacter.displayName)}`;
+  }
+
+  return chooseFreshnessTarget(storyState);
 }
 
 function buildStoryLabPayloadFromContinuation(
@@ -440,32 +1049,43 @@ function buildStateSnapshot(
 
 function buildInitialCharacters(storyId: string, input: LabGenerationSeam['input']): CharacterProfile[] {
   const protagonistName = input.protagonistName?.trim() || `${capitalize(input.creature)} protagonist`;
+  const antagonistName = input.antagonistName?.trim();
+  const protagonistId = `${storyId}-protagonist`;
+  const antagonistId = `${storyId}-antagonist`;
   const characters: CharacterProfile[] = [
     {
-      id: `${storyId}-protagonist`,
+      id: protagonistId,
       displayName: protagonistName,
       archetype: 'protagonist',
       summary: `${protagonistName} anchors the ${input.creature} story promised by the blueprint.`,
       currentGoal: input.logline,
       internalConflict: 'Desire and self-protection pull in opposite directions.',
-      externalConflict: input.antagonistName?.trim() || 'The supernatural world resists the romance.',
+      externalConflict: antagonistName || 'The supernatural world resists the romance.',
       secrets: [],
-      relationships: [],
+      relationships: antagonistName ? [{
+        characterId: antagonistId,
+        relationship: 'rival',
+        notes: `${antagonistName} pressures ${protagonistName} into a costly choice.`
+      }] : [],
       spiceCompatibilities: [input.spicyLevel]
     }
   ];
 
-  if (input.antagonistName?.trim()) {
+  if (antagonistName) {
     characters.push({
-      id: `${storyId}-antagonist`,
-      displayName: input.antagonistName.trim(),
+      id: antagonistId,
+      displayName: antagonistName,
       archetype: 'antagonist',
       summary: 'An opposing force named in the Story Lab blueprint.',
       currentGoal: 'Pressure the protagonist into a costly choice.',
       internalConflict: 'Their own desire complicates the threat they represent.',
       externalConflict: input.logline,
       secrets: [],
-      relationships: [],
+      relationships: [{
+        characterId: protagonistId,
+        relationship: 'rival',
+        notes: `${protagonistName} can expose or refuse the costly choice.`
+      }],
       spiceCompatibilities: [input.spicyLevel]
     });
   }
@@ -496,10 +1116,44 @@ function buildInitialThreads(storyId: string, input: LabGenerationSeam['input'])
 function buildWorldArtifact(storyId: string, worldDetails: string): LoreArtifact {
   return {
     id: `${storyId}-world-details`,
-    name: 'World Details',
+    name: deriveWorldArtifactName(worldDetails),
     significance: worldDetails,
     introducedInChapter: 1
   };
+}
+
+function deriveWorldArtifactName(worldDetails: string): string {
+  const compacted = collapseWhitespace(worldDetails).replace(/[.!?]+$/g, '').trim();
+  const whereMatch = compacted.match(/\bwhere\s+(.+?)(?:\s+(?:record|records|rule|rules|bind|binds|hold|holds|keep|keeps|hide|hides|guard|guards|demand|demands|remember|remembers|change|changes|cost|costs|make|makes)\b|$)/i);
+  if (whereMatch?.[1]) {
+    return formatWorldArtifactName(whereMatch[1]);
+  }
+
+  const byMatch = compacted.match(/\b(?:ruled|bound|guarded|haunted|recorded|kept|protected)\s+by\s+(.+?)(?:[.,;:]|$)/i);
+  if (byMatch?.[1]) {
+    return formatWorldArtifactName(byMatch[1]);
+  }
+
+  const withoutArticle = compacted.replace(/^(?:a|an|the)\s+/i, '');
+  const beforeRelation = withoutArticle.split(/\b(?:where|ruled by|bound by|guarded by|with|whose|that)\b/i)[0] ?? withoutArticle;
+  return formatWorldArtifactName(beforeRelation);
+}
+
+function formatWorldArtifactName(value: string): string {
+  const cleaned = value
+    .replace(/^(?:a|an|the)\s+/i, '')
+    .replace(/[.!?,;:]+$/g, '')
+    .trim();
+  const words = cleaned.split(/\s+/).filter(Boolean).slice(0, WORLD_ARTIFACT_MAX_NAME_WORDS);
+  if (!words.length) {
+    return 'World Texture';
+  }
+
+  return words.map(formatWorldArtifactWord).join(' ');
+}
+
+function formatWorldArtifactWord(word: string): string {
+  return word.split('-').map(capitalize).join('-');
 }
 
 function buildChapterDelta(

--- a/tests/story-lab-real-engine.test.ts
+++ b/tests/story-lab-real-engine.test.ts
@@ -10,7 +10,11 @@ import {
 } from '../api/_lib/story-lab/storyLabEngine';
 import { getAuthorStylesForCreature } from '../api/_lib/config/authorStyles';
 import type { StoryGenerationSeam as LabGenerationSeam } from '../api/_lib/story-lab/contracts';
-import type { CreatureType, StoryGenerationSeam as ClassicGenerationSeam } from '../api/_lib/types/contracts';
+import type {
+  ChapterContinuationSeam as ClassicContinuationSeam,
+  CreatureType,
+  StoryGenerationSeam as ClassicGenerationSeam
+} from '../api/_lib/types/contracts';
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -200,6 +204,15 @@ assert(payload.batch.chapters.length === 1, 'real chapters should be mapped into
 assert(payload.batch.chapters[0].rawContent?.includes('[Mira'), 'raw speaker-tag content should survive');
 assert(payload.batch.suggestedNextPrompts.some(prompt => prompt.includes('Reveal what waits')), 'next chapter hint should become a prompt');
 assert(payload.state.characters.some(character => character.displayName === 'Mira'), 'protagonist should seed continuity state');
+assert(
+  payload.state.characters.some(character =>
+    character.displayName === 'Mira'
+    && character.relationships.some(relationship =>
+      relationship.characterId === 'story-test-antagonist'
+      && relationship.relationship === 'rival'
+      && relationship.notes.includes('costly choice'))),
+  'protagonist should seed a typed relationship edge to the antagonist'
+);
 assert(payload.state.threads.some(thread => thread.label === 'Court Intrigue'), 'theme seeds should become continuity threads');
 assert(payload.telemetry.engine === 'grok', 'real StoryService mapping should report grok telemetry');
 assert(payload.telemetry.totalLatencyMs === 2000, 'real StoryService latency metadata should reach Story Lab telemetry');
@@ -401,6 +414,106 @@ withEnv({ XAI_API_KEY: 'test-key', STORY_LAB_FORCE_MOCK: 'true' }, () => {
 
     assert(response.success, 'continuation with Heat Contract should succeed through service seam');
     assert(sawHeatContract, 'continuation service input should receive the original Heat Contract');
+  });
+
+  await withEnvAsync({ XAI_API_KEY: 'test-key', STORY_LAB_FORCE_MOCK: undefined, NODE_ENV: undefined, VERCEL_ENV: undefined }, async () => {
+    let capturedInput: ClassicContinuationSeam['input'] | undefined;
+    const courtroomState = {
+      ...payload.state,
+      threads: [
+        ...payload.state.threads,
+        {
+          id: 'story-test-thread-resolved',
+          label: 'Settled Debt',
+          status: 'resolved' as const,
+          description: 'This bargain has already been paid.',
+          foreshadowedDevices: []
+        }
+      ],
+      artifacts: [
+        ...payload.state.artifacts,
+        {
+          id: 'story-test-paid-charm',
+          name: 'Paid Charm',
+          significance: 'A charm whose bargain has already closed.',
+          introducedInChapter: 1,
+          resolvedInChapter: 1
+        }
+      ],
+      continuityWarnings: [
+        'Resolve the vow-binding song before changing courts.'
+      ]
+    };
+
+    const response = await continueStoryLab({
+      storyId: payload.summary.storyId,
+      chapterBatchSize: 1,
+      storyState: courtroomState,
+      previouslyGeneratedChapters: payload.batch.chapters,
+      continuationBrief: 'Let the court demand payment.',
+      existingSummary: payload.summary
+    }, {
+      serviceFactory: () => ({
+        generateStory: async () => {
+          throw new Error('generateStory should not be called by continuity courtroom test');
+        },
+        continueChapter: async input => {
+          capturedInput = input;
+          return {
+            success: true,
+            data: {
+              chapterId: 'chapter-2',
+              chapterNumber: 2,
+              title: 'Court Payment',
+              content: '<h3>Chapter 2: Court Payment</h3><p>The court called the debt due.</p>',
+              rawContent: '<p>[Mira]: "Name the price."</p>',
+              wordCount: 8,
+              cliffhangerEnding: true,
+              themesContinued: ['forbidden_love'],
+              spicyLevelMaintained: 3,
+              appendedToStory: '<h3>Chapter 2: Court Payment</h3><p>The court called the debt due.</p>',
+              tropeMetadata: payload.summary.tropeMetadata,
+              chapters: [{
+                chapterId: 'chapter-2',
+                chapterNumber: 2,
+                title: 'Court Payment',
+                content: '<h3>Chapter 2: Court Payment</h3><p>The court called the debt due.</p>',
+                rawContent: '<p>[Mira]: "Name the price."</p>',
+                wordCount: 8,
+                generatedAt: new Date(),
+                hasAudio: false,
+                cliffhangerEnding: true
+              }],
+              totalWordCount: 8
+            }
+          };
+        }
+      })
+    });
+
+    assert(response.success, 'continuation with continuity courtroom anchors should succeed');
+    assert(capturedInput?.userInput?.includes('Let the court demand payment.'), 'original continuation brief should stay in service input');
+    assert(capturedInput?.userInput?.includes('Continuity Courtroom:'), 'service input should include the continuity courtroom anchor');
+    assert(capturedInput?.userInput?.includes('Pressure rising: Forbidden Love'), 'escalating threads should be named for payoff');
+    assert(capturedInput?.userInput?.includes('Open promise: Court Intrigue'), 'active threads should be named for payoff');
+    assert(capturedInput?.userInput?.includes('World clue: Vow-Binding Songs'), 'unresolved artifacts should be named for payoff');
+    assert(capturedInput?.userInput?.includes('Continuity note: Resolve the vow-binding song before changing courts.'), 'continuity warnings should be carried into the next chapter request');
+    assert(!capturedInput?.userInput?.includes('Settled Debt'), 'resolved threads should not be repeated as open courtroom debts');
+    assert(!capturedInput?.userInput?.includes('Paid Charm'), 'resolved artifacts should not be repeated as unresolved courtroom debts');
+    assert(capturedInput?.userInput?.includes('Chapter Ending Stress Test:'), 'service input should include the chapter ending stress-test anchor');
+    assert(capturedInput?.userInput?.includes('Endings: emotional reveal, danger escalation, secret exposed.'), 'ending stress test should keep the candidate set visible to the model');
+    assert(capturedInput?.userInput?.includes('Chosen: Secret exposed'), 'unresolved lore and debt language should choose the secret-exposed ending pressure');
+    assert(capturedInput?.userInput?.includes('Scene pressure mix: Secret + Setting;'), 'scene pressure mixer should reuse the ending anchor');
+    assert(capturedInput?.userInput?.includes('leave one sharper'), 'ending stress test should preserve serialized momentum');
+    assert(capturedInput?.userInput?.includes('Cliche Alarm:'), 'service input should include the cliche alarm anchor');
+    assert(capturedInput?.userInput?.includes('Avoid: formal demand with no personal cost.'), 'debt/payment continuation should avoid the obvious formal-demand scene');
+    assert(capturedInput?.userInput?.includes('Freshness: turn Forbidden Love'), 'cliche alarm should tie freshness to a concrete unresolved story thread');
+    assert(!capturedInput?.userInput?.includes('Subtext Receipt:'), 'subtext receipt should not add a fourth hidden anchor block');
+    assert(
+      capturedInput?.userInput?.includes('Subtext receipt: prove Mira and Lord Brine by behavior before explanation.'),
+      'subtext receipt should reach the real continuation seam as behavior-first guidance'
+    );
+    assert((capturedInput?.userInput?.length ?? 0) <= 900, 'hidden continuation anchors should stay under the compactness budget');
   });
 
   console.log('Story Lab real-engine mapping tests passed');

--- a/tests/story-quality-evals.test.ts
+++ b/tests/story-quality-evals.test.ts
@@ -4,6 +4,7 @@
 import {
   buildStoryLabPayloadFromGeneratedStory,
   continueStoryLab,
+  previewStoryLabContinuationGuidance,
   toClassicGenerationInput
 } from '../api/_lib/story-lab/storyLabEngine';
 import { extractContinuity } from '../api/_lib/story-lab/continuityExtractor';
@@ -130,6 +131,189 @@ async function main(): Promise<void> {
   assert(continuity.receipt.source === 'heuristic', 'continuity extraction should label heuristic fallback.');
   assert(continuity.receipt.warning?.includes('heuristic'), 'heuristic fallback should be visible.');
 
+  const guidancePreview = previewStoryLabContinuationGuidance({
+    continuationBrief: 'Pay off the witness shell and make Lord Brine escalate.',
+    storyState: genesisPayload.state
+  });
+  assert(guidancePreview.providerBrief.includes('Pay off the witness shell'), 'guidance preview should preserve the user continuation brief.');
+  assert(guidancePreview.hiddenGuidance.includes('Continuity Courtroom:'), 'guidance preview should expose hidden continuity anchors for future UI preview work.');
+  assert(guidancePreview.anchorHeadings.length === 3, 'guidance preview should report the three hidden anchor blocks.');
+  assert(guidancePreview.characterCount <= 900, 'guidance preview should expose the same compactness budget guarded by real-engine tests.');
+  const activationPreview = previewStoryLabContinuationGuidance({
+    continuationBrief: 'Bring the blood oath into the next room.',
+    storyState: {
+      ...genesisPayload.state,
+      threads: [
+        {
+          id: 'thread-weather-tax',
+          label: 'Weather Tax',
+          status: 'active',
+          description: 'The court taxes every storm that crosses the reef.',
+          foreshadowedDevices: []
+        },
+        {
+          id: 'thread-kitchen-claim',
+          label: 'Kitchen Claim',
+          status: 'active',
+          description: 'The servants know who stole the silver ladle.',
+          foreshadowedDevices: []
+        },
+        {
+          id: 'thread-silent-harbor',
+          label: 'Silent Harbor',
+          status: 'active',
+          description: 'The harbor stopped answering ships at midnight.',
+          foreshadowedDevices: []
+        },
+        {
+          id: 'thread-blood-oath',
+          label: 'Blood Oath',
+          status: 'active',
+          description: 'The old vow follows Mira into every negotiation.',
+          foreshadowedDevices: []
+        }
+      ],
+      artifacts: [],
+      continuityWarnings: []
+    }
+  });
+  assert(activationPreview.hiddenGuidance.includes('Open promise: Blood Oath'), 'continuation guidance should prioritize a brief-matched thread when the courtroom is compacted.');
+  assert(
+    activationPreview.contextSourceMap.some(item =>
+      item.kind === 'thread'
+      && item.label === 'Blood Oath'
+      && item.anchorLabel === 'Open promise'
+      && item.reason.includes('Matched words from the continuation brief')),
+    'guidance preview should explain why the Blood Oath thread was activated.'
+  );
+  const artifactActivationPreview = previewStoryLabContinuationGuidance({
+    continuationBrief: 'Use the glass key now; make it unlock the forbidden tide door.',
+    storyState: {
+      ...genesisPayload.state,
+      threads: [],
+      artifacts: [
+        {
+          id: 'artifact-silver-ladle',
+          name: 'Silver Ladle',
+          significance: 'The kitchen staff hid it after the court dinner.',
+          introducedInChapter: 1
+        },
+        {
+          id: 'artifact-storm-ledger',
+          name: 'Storm Ledger',
+          significance: 'The reef court taxes storms by moon phase.',
+          introducedInChapter: 1
+        },
+        {
+          id: 'artifact-glass-key',
+          name: 'Glass Key',
+          significance: 'A brittle key that opens the forbidden tide door only once.',
+          introducedInChapter: 1
+        }
+      ],
+      continuityWarnings: []
+    }
+  });
+  assert(artifactActivationPreview.hiddenGuidance.includes('World clue: Glass Key'), 'continuation guidance should prioritize a brief-matched artifact when the courtroom is compacted.');
+  assert(
+    artifactActivationPreview.contextSourceMap.some(item =>
+      item.kind === 'artifact'
+      && item.label === 'Glass Key'
+      && item.anchorLabel === 'World clue'
+      && item.reason.includes('Matched words from the continuation brief')),
+    'guidance preview should explain why the Glass Key artifact was activated.'
+  );
+  const relationshipActivationPreview = previewStoryLabContinuationGuidance({
+    continuationBrief: 'Let Coral Scribe betray Mira with the court ledger.',
+    storyState: {
+      ...genesisPayload.state,
+      characters: [
+        {
+          id: 'mira',
+          displayName: 'Mira',
+          archetype: 'protagonist',
+          summary: 'A siren diplomat carrying a forbidden oath.',
+          currentGoal: 'Keep the reef court from owning her lover.',
+          internalConflict: 'She wants help but fears being seen needing it.',
+          externalConflict: 'The court wants the oath made public.',
+          secrets: [],
+          relationships: [
+            {
+              characterId: 'lord-brine',
+              relationship: 'rival',
+              notes: 'Lord Brine can turn the vow into leverage.'
+            },
+            {
+              characterId: 'coral-scribe',
+              relationship: 'ally',
+              notes: 'Coral Scribe knows which ledger proves the betrayal.'
+            }
+          ],
+          spiceCompatibilities: [3]
+        },
+        {
+          id: 'lord-brine',
+          displayName: 'Lord Brine',
+          archetype: 'antagonist',
+          summary: 'A reef lord with a claim on the oath.',
+          currentGoal: 'Own the court record.',
+          internalConflict: 'He wants Mira to choose him and the court.',
+          externalConflict: 'Mira can make him look desperate.',
+          secrets: [],
+          relationships: [],
+          spiceCompatibilities: [3]
+        },
+        {
+          id: 'coral-scribe',
+          displayName: 'Coral Scribe',
+          archetype: 'supporting',
+          summary: 'A court recordkeeper who knows which ledger can hurt Mira.',
+          currentGoal: 'Survive whichever side wins.',
+          internalConflict: 'Loyalty costs more than silence.',
+          externalConflict: 'Both Mira and Lord Brine need the ledger.',
+          secrets: [],
+          relationships: [],
+          spiceCompatibilities: [3]
+        }
+      ],
+      threads: [],
+      artifacts: [],
+      continuityWarnings: []
+    }
+  });
+  assert(relationshipActivationPreview.hiddenGuidance.includes('Relationship pressure: Mira and Coral Scribe'), 'continuation guidance should prioritize a brief-matched relationship pair.');
+  assert(
+    relationshipActivationPreview.contextSourceMap.some(item =>
+      item.kind === 'relationship'
+      && item.label === 'Mira and Coral Scribe'
+      && item.anchorLabel === 'Relationship pressure'
+      && item.reason.includes('Matched words from the continuation brief')),
+    'guidance preview should explain why the Coral Scribe relationship was activated.'
+  );
+  const warningActivationPreview = previewStoryLabContinuationGuidance({
+    continuationBrief: 'Make Coral Scribe honor the ledger warning before the court leaves.',
+    storyState: {
+      ...genesisPayload.state,
+      characters: [],
+      threads: [],
+      artifacts: [],
+      continuityWarnings: [
+        'Do not move the storm tax before the reef bell rings.',
+        'Keep the kitchen staff out of the oath scene.',
+        'Coral Scribe must betray Mira before the ledger leaves court.'
+      ]
+    }
+  });
+  assert(warningActivationPreview.hiddenGuidance.includes('Continuity note: Coral Scribe must betray Mira before the ledger leaves court.'), 'continuation guidance should prioritize a brief-matched continuity warning when the courtroom is compacted.');
+  assert(
+    warningActivationPreview.contextSourceMap.some(item =>
+      item.kind === 'warning'
+      && item.label === 'Coral Scribe must betray Mira before the ledger leaves court.'
+      && item.anchorLabel === 'Continuity note'
+      && item.reason.includes('Matched words from the continuation brief')),
+    'guidance preview should explain why the Coral Scribe warning was activated.'
+  );
+
   let continuationInput: ClassicContinuationSeam['input'] | null = null;
   const continuationResponse = await withEnv({ XAI_API_KEY: 'test-key', STORY_LAB_FORCE_MOCK: undefined }, () => continueStoryLab({
       storyId: genesisPayload.summary.storyId,
@@ -186,6 +370,25 @@ async function main(): Promise<void> {
     `continuation should receive previous chapter context. Received: ${continuationInput?.existingContent ?? 'none'}`
   );
   assert(continuationInput?.userInput?.includes('Lord Brine'), 'continuation brief should reach the story service.');
+  const hiddenGuidance = continuationInput?.userInput ?? '';
+  assert(hiddenGuidance.includes('Continuity Courtroom:'), 'continuation guidance should include continuity anchors.');
+  assert(hiddenGuidance.includes('Chapter Ending Stress Test:'), 'continuation guidance should include ending pressure.');
+  assert(hiddenGuidance.includes('Cliche Alarm:'), 'continuation guidance should include stale-path avoidance.');
+  assert(!hiddenGuidance.includes('Scene Pressure Mixer:'), 'scene pressure should reuse an existing anchor instead of adding a fourth hidden block.');
+  assert(!hiddenGuidance.includes('Subtext Receipt:'), 'subtext receipt should stay inside an existing hidden block.');
+  assert(hiddenGuidance.includes('Scene pressure mix: Secret + Setting;'), 'continuation guidance should add a compact pressure mix inside the ending anchor.');
+  assert(!hiddenGuidance.includes('Scene pressure mix: Secret + Setting.'), 'scene pressure should include a concrete seeded variant, not just labels.');
+  assert(
+    hiddenGuidance.includes('Subtext receipt: prove Mira and Lord Brine by behavior before explanation.'),
+    'continuation guidance should force emotional change to show through behavior before explanation.'
+  );
+  assert(!hiddenGuidance.includes('Escalating thread:'), 'continuation guidance should not expose mechanical thread labels.');
+  assert(!hiddenGuidance.includes('Open thread:'), 'continuation guidance should not expose mechanical thread labels.');
+  assert(!hiddenGuidance.includes('Unresolved artifact:'), 'continuation guidance should not expose mechanical artifact labels.');
+  assert(!hiddenGuidance.includes('Warning to honor:'), 'continuation guidance should not expose mechanical warning labels.');
+  assert(!hiddenGuidance.includes('generic conflict'), 'continuation guidance should not ask the model to avoid generic conflict with generic wording.');
+  assert(!hiddenGuidance.includes('World clue: World Details'), 'continuation guidance should not use a generic world artifact name.');
+  assert(hiddenGuidance.includes('World clue: Witness Shells'), 'continuation guidance should name the concrete world clue.');
   assert(continuationResponse.data.batch.chapters[0].chapterNumber === 2, 'continuation should append the next chapter number.');
   assert(continuationResponse.data.continuityExtraction?.source === 'heuristic', 'test-injected service should keep heuristic continuity labeling.');
 

--- a/tests/story-service-improved.test.ts
+++ b/tests/story-service-improved.test.ts
@@ -242,33 +242,42 @@ const testSuite = {
   
   // Test 5: Different word counts
   testWordCounts: test('Different Word Count Targets', async () => {
-    const service = new StoryService();
-    const wordCounts: Array<700 | 900 | 1200> = [700, 900, 1200];
-    
-    for (const wordCount of wordCounts) {
-      console.log(`   Testing ${wordCount} words...`);
-      
-      const input: StoryGenerationSeam['input'] = {
-        creature: 'vampire',
-        themes: ['romance'],
-        userInput: 'Test story',
-        spicyLevel: 2,
-        wordCount
-      };
-      
-      const result = await service.generateStory(input);
-      
-      if (!result.success) {
-        throw new Error(`Failed to generate ${wordCount}-word story: ${result.error?.message}`);
+    await withMockGrok(async () => {
+      const service = new StoryService();
+      const wordCounts: Array<700 | 900 | 1200> = [700, 900, 1200];
+      const tolerance = 0.3;
+
+      for (const wordCount of wordCounts) {
+        console.log(`   Testing ${wordCount} words...`);
+
+        const input: StoryGenerationSeam['input'] = {
+          creature: 'vampire',
+          themes: ['romance'],
+          userInput: 'Test story',
+          spicyLevel: 2,
+          wordCount
+        };
+
+        const result = await service.generateStory(input);
+
+        if (!result.success) {
+          throw new Error(`Failed to generate ${wordCount}-word story: ${result.error?.message}`);
+        }
+
+        const actualWords = result.data!.actualWordCount;
+        const variance = Math.abs(actualWords - wordCount) / wordCount * 100;
+        const minWords = wordCount * (1 - tolerance);
+        const maxWords = wordCount * (1 + tolerance);
+
+        console.log(`   ✓ Target ${wordCount}, actual ${actualWords} (${variance.toFixed(1)}% variance)`);
+
+        if (actualWords < minWords || actualWords > maxWords) {
+          throw new Error(`Mock story word count ${actualWords} should be within 30% of ${wordCount}`);
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
       }
-      
-      const actualWords = result.data!.actualWordCount;
-      const variance = Math.abs(actualWords - wordCount) / wordCount * 100;
-      
-      console.log(`   ✓ Target ${wordCount}, actual ${actualWords} (${variance.toFixed(1)}% variance)`);
-      
-      await new Promise(resolve => setTimeout(resolve, 1000));
-    }
+    });
   }),
   
   // Test 6: Invalid inputs
@@ -386,6 +395,12 @@ const testSuite = {
       expect(story.appendedToStory).toContain('Chapter 3');
       expect(story.failedChapters).toBeUndefined();
 
+      const minWords = input.wordCount * 0.7;
+      const maxWords = input.wordCount * 1.3;
+      if (story.totalWordCount < minWords || story.totalWordCount > maxWords) {
+        throw new Error(`Multi-chapter mock total ${story.totalWordCount} should be within 30% of ${input.wordCount}`);
+      }
+
       console.log(`   ✓ Generated chapters: ${story.chapters!.map(chapter => chapter.chapterNumber).join(', ')}`);
       console.log(`   ✓ Total word count: ${story.totalWordCount}`);
     });
@@ -419,6 +434,11 @@ const testSuite = {
       expect(continuation.appendedToStory).toContain('Chapter 3');
       expect(continuation.totalWordCount).toBeGreaterThan(0);
       expect(continuation.cliffhangerAnalysis).toBeDefined();
+      for (const chapter of continuation.chapters!) {
+        if (chapter.wordCount < 400 || chapter.wordCount > 600) {
+          throw new Error(`Mock continuation chapter ${chapter.chapterNumber} word count ${chapter.wordCount} should stay within the 400-600 prompt target`);
+        }
+      }
 
       console.log(`   ✓ Continued chapters: ${continuation.chapters!.map(chapter => chapter.chapterNumber).join(', ')}`);
       console.log(`   ✓ Appended story word count: ${continuation.totalWordCount}`);


### PR DESCRIPTION
## Summary
- improves Story Lab continuation guidance with activation-aware courtroom anchors, relationship pressure, scene pressure, cliche avoidance, and subtext receipt guidance
- adds continuation preview source-map entries explaining why thread/artifact/relationship/warning anchors were selected
- expands mock story/continuation output so fallback paths stay within requested word-count ranges
- records slice validation and self-review in `PR70_RECOVERY_CHANGELOG.md`

## Validation
- `npm run test:story-lab-real-engine` passed
- `npm run test:story-quality` passed
- `npm run test:story` passed
- `npm run recovery:preflight -- story-quality-guidance` passed and wrote `tmp/recovery/story-quality-guidance-evidence.md`
- Vercel function count stayed `11/12`

## Non-Claims
- Does not include Proving Grounds quality report UI/API work
- Does not include accepted/pinned memory cards
- Does not prove live cloud sync, executed migrations, durable jobs, or process-loss recovery

## Next Slice
- `quality-report-proving-grounds`