### PR TITLE
Clean up Story Lab auth database review debt

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -2932,6 +2932,32 @@ Validation:
 - `npm run recovery:preflight -- story-memory-cards`: passed and wrote `tmp/recovery/story-memory-cards-evidence.md`.
 - `npm run recovery:preflight -- css-lazy-loading --quick`: passed and wrote `tmp/recovery/css-lazy-loading-evidence.md`.
 - Function count stayed `11/12`.
+
+## 2026-06-21 14:06 EDT - Auth/Database Review Debt Cleanup
+
+Actions:
+
+- Audited the remaining PR #118/#119 Sonar follow-up issue after the memory-card slice merged.
+- Closed #145 as a false-positive Neon executor follow-up after confirming `@neondatabase/serverless@1.1.0` exposes `NeonQueryFunction.query(queryWithPlaceholders, params?)` and `npm run test:story-lab-neon-executor` passes.
+- Refactored the Story Lab cloud schema SQL splitter into small scanner helpers so schema migration readiness remains testable without a live database.
+- Replaced account route project-id path parsing with `RegExp.exec()`.
+- Reworked profile/project body parsing to use explicit record helpers instead of broad final return casts.
+- Added regression coverage that malformed `profile` or `project` wrapper bodies are rejected instead of falling back to outer fields.
+
+Self-review:
+
+- Good: This cleanup stayed inside the auth/database seam and did not add provider dependencies, routes, secrets, or real database migration behavior.
+- Problem found: a generic review issue asked for a Neon API change that contradicts the locked package type surface; future review triage should verify provider API claims against the installed package before opening defect issues.
+- Problem found: `npm run install:all` modifies tracked `node_modules` in this repository; install artifacts must be restored before source diffs are reviewed or committed.
+
+Validation:
+
+- `npm run test:story-lab-cloud-schema-migration`: passed.
+- `npm run test:story-lab-account-routes`: passed.
+- `npm run test:story-lab-cloud-storage-config`: passed.
+- `npm run test:story-lab-neon-executor`: passed.
+- `git diff --check`: passed.
+- `scripts/recovery/preflight.sh --quick --skip-status`: passed.
 - `npm run build` passed inside memory-card preflight; the initial browser bundle dropped to 484.71 kB and Proving Grounds moved into a lazy chunk.
 
 ## 2026-06-21 11:35 EDT - Memory Cards Review Fix Pass

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -2945,6 +2945,7 @@ Actions:
 - Added regression coverage that malformed `profile` or `project` wrapper bodies are rejected instead of falling back to outer fields.
 - Follow-up review pass: asserted the `INVALID_REQUEST` error code for malformed wrapper regressions, renamed the wrapped-or-bare body helper to make direct body compatibility explicit, and replaced per-character dollar-quote substring matching with an in-place tag parser.
 - Gemini follow-up: restored optional wire compatibility for profile timestamps and project synopsis/timestamps while still rejecting malformed provided values, with regression coverage for missing optional fields and numeric malformed values.
+- Sonar follow-up: removed the schema splitter loop-counter assignment and replaced the route parser own-property check with an ES2020-safe key check.
 
 Self-review:
 

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -2943,12 +2943,14 @@ Actions:
 - Replaced account route project-id path parsing with `RegExp.exec()`.
 - Reworked profile/project body parsing to use explicit record helpers instead of broad final return casts.
 - Added regression coverage that malformed `profile` or `project` wrapper bodies are rejected instead of falling back to outer fields.
+- Follow-up review pass: asserted the `INVALID_REQUEST` error code for malformed wrapper regressions, renamed the wrapped-or-bare body helper to make direct body compatibility explicit, and replaced per-character dollar-quote substring matching with an in-place tag parser.
 
 Self-review:
 
 - Good: This cleanup stayed inside the auth/database seam and did not add provider dependencies, routes, secrets, or real database migration behavior.
 - Problem found: a generic review issue asked for a Neon API change that contradicts the locked package type surface; future review triage should verify provider API claims against the installed package before opening defect issues.
 - Problem found: `npm run install:all` modifies tracked `node_modules` in this repository; install artifacts must be restored before source diffs are reviewed or committed.
+- Problem found: the first wrapper regression tests asserted only HTTP status; review was right that route tests should assert the typed API error contract too.
 
 Validation:
 

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -2944,6 +2944,7 @@ Actions:
 - Reworked profile/project body parsing to use explicit record helpers instead of broad final return casts.
 - Added regression coverage that malformed `profile` or `project` wrapper bodies are rejected instead of falling back to outer fields.
 - Follow-up review pass: asserted the `INVALID_REQUEST` error code for malformed wrapper regressions, renamed the wrapped-or-bare body helper to make direct body compatibility explicit, and replaced per-character dollar-quote substring matching with an in-place tag parser.
+- Gemini follow-up: restored optional wire compatibility for profile timestamps and project synopsis/timestamps while still rejecting malformed provided values, with regression coverage for missing optional fields and numeric malformed values.
 
 Self-review:
 
@@ -2951,6 +2952,7 @@ Self-review:
 - Problem found: a generic review issue asked for a Neon API change that contradicts the locked package type surface; future review triage should verify provider API claims against the installed package before opening defect issues.
 - Problem found: `npm run install:all` modifies tracked `node_modules` in this repository; install artifacts must be restored before source diffs are reviewed or committed.
 - Problem found: the first wrapper regression tests asserted only HTTP status; review was right that route tests should assert the typed API error contract too.
+- Problem found: the first typed-parser cleanup made optional wire fields mandatory; the route parser now lets store normalization fill omitted values while rejecting malformed values.
 
 Validation:
 

--- a/api/_lib/story-lab/account/accountRouteHandlers.ts
+++ b/api/_lib/story-lab/account/accountRouteHandlers.ts
@@ -369,16 +369,16 @@ function readProfileFromBody(body: unknown): StoryLabUserProfile | null {
 
   const userId = candidate.userId;
   const displayName = candidate.displayName;
-  const createdAt = candidate.createdAt;
-  const updatedAt = candidate.updatedAt;
+  const createdAt = readOptionalString(candidate.createdAt);
+  const updatedAt = readOptionalString(candidate.updatedAt);
   if (
     typeof userId !== 'string' ||
     !userId.trim() ||
     typeof displayName !== 'string' ||
     !displayName.trim() ||
     !isObjectRecord(candidate.preferences) ||
-    typeof createdAt !== 'string' ||
-    typeof updatedAt !== 'string'
+    createdAt === null ||
+    updatedAt === null
   ) {
     return null;
   }
@@ -387,8 +387,8 @@ function readProfileFromBody(body: unknown): StoryLabUserProfile | null {
     userId,
     displayName,
     preferences: normalizeStoryLabProfilePreferences(candidate.preferences),
-    createdAt,
-    updatedAt
+    createdAt: createdAt ?? '',
+    updatedAt: updatedAt ?? ''
   };
 }
 
@@ -403,13 +403,16 @@ function readProjectFromBody(body: unknown): SavedStoryProject | null {
   }
 
   const projectId = normalizeProjectId(candidate.id);
+  const synopsis = readOptionalString(candidate.synopsis);
+  const createdAt = readOptionalString(candidate.createdAt);
+  const updatedAt = readOptionalString(candidate.updatedAt);
   if (
     !projectId ||
     !isNonBlankString(candidate.storyId) ||
     !isNonBlankString(candidate.title) ||
-    !isNonBlankString(candidate.synopsis) ||
-    !isNonBlankString(candidate.createdAt) ||
-    !isNonBlankString(candidate.updatedAt) ||
+    synopsis === null ||
+    createdAt === null ||
+    updatedAt === null ||
     !isObjectRecord(candidate.summary) ||
     !isObjectRecord(candidate.state) ||
     !isObjectRecord(candidate.blueprint) ||
@@ -422,7 +425,7 @@ function readProjectFromBody(body: unknown): SavedStoryProject | null {
     id: projectId,
     storyId: candidate.storyId,
     title: candidate.title,
-    synopsis: candidate.synopsis,
+    synopsis: synopsis ?? '',
     blueprint: candidate.blueprint as unknown as SavedStoryProject['blueprint'],
     summary: candidate.summary as unknown as SavedStoryProject['summary'],
     state: candidate.state as unknown as SavedStoryProject['state'],
@@ -431,8 +434,8 @@ function readProjectFromBody(body: unknown): SavedStoryProject | null {
     continuityExtraction: candidate.continuityExtraction as SavedStoryProject['continuityExtraction'],
     pinnedMemoryCardDraftIds: candidate.pinnedMemoryCardDraftIds as SavedStoryProject['pinnedMemoryCardDraftIds'],
     acceptedMemoryCards: candidate.acceptedMemoryCards as SavedStoryProject['acceptedMemoryCards'],
-    createdAt: candidate.createdAt,
-    updatedAt: candidate.updatedAt
+    createdAt: createdAt ?? '',
+    updatedAt: updatedAt ?? ''
   };
 }
 
@@ -446,6 +449,14 @@ function readWrappedOrBareBodyRecord(body: Record<string, unknown>, key: string)
 
 function isNonBlankString(value: unknown): value is string {
   return typeof value === 'string' && Boolean(value.trim());
+}
+
+function readOptionalString(value: unknown): string | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return typeof value === 'string' ? value : null;
 }
 
 function normalizeProjectId(projectId: unknown): string | null {

--- a/api/_lib/story-lab/account/accountRouteHandlers.ts
+++ b/api/_lib/story-lab/account/accountRouteHandlers.ts
@@ -17,6 +17,7 @@ import type {
 import { applyCorsPolicy } from '../../http/corsPolicy';
 import {
   createDefaultStoryLabUserProfile,
+  normalizeStoryLabProfilePreferences,
   StoryLabProfileStore,
   StoryLabProfileStoreError
 } from '../profile/storyLabProfileStore';
@@ -68,6 +69,7 @@ interface StoryLabAccountRouteContext {
 }
 
 const MAX_PROJECT_ID_LENGTH = 128;
+const PROJECT_ID_ROUTE_PATTERN = /\/account\/projects\/([^/]+)$/;
 
 export function createStoryLabAccountRouteHandler(
   dependencies: StoryLabAccountRouteDependencies = {}
@@ -343,7 +345,7 @@ function readAccountRouteTargetFromUrl(url: string | undefined): AccountRouteTar
 
 function readProjectIdFromUrl(url: string | undefined): string | undefined {
   const pathname = url?.split('?')[0] ?? '';
-  const match = pathname.match(/\/account\/projects\/([^/]+)$/);
+  const match = PROJECT_ID_ROUTE_PATTERN.exec(pathname);
   if (!match) {
     return undefined;
   }
@@ -356,63 +358,94 @@ function readProjectIdFromUrl(url: string | undefined): string | undefined {
 }
 
 function readProfileFromBody(body: unknown): StoryLabUserProfile | null {
-  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+  if (!isObjectRecord(body)) {
     return null;
   }
 
-  const candidate = 'profile' in body ? (body as { profile?: unknown }).profile : body;
-  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+  const candidate = readBodyRecord(body, 'profile');
+  if (!isObjectRecord(candidate)) {
     return null;
   }
 
-  const profile = candidate as Partial<StoryLabUserProfile>;
+  const userId = candidate.userId;
+  const displayName = candidate.displayName;
+  const createdAt = candidate.createdAt;
+  const updatedAt = candidate.updatedAt;
   if (
-    typeof profile.userId !== 'string' ||
-    !profile.userId.trim() ||
-    typeof profile.displayName !== 'string' ||
-    !profile.displayName.trim() ||
-    !profile.preferences ||
-    typeof profile.preferences !== 'object' ||
-    Array.isArray(profile.preferences)
+    typeof userId !== 'string' ||
+    !userId.trim() ||
+    typeof displayName !== 'string' ||
+    !displayName.trim() ||
+    !isObjectRecord(candidate.preferences) ||
+    typeof createdAt !== 'string' ||
+    typeof updatedAt !== 'string'
   ) {
     return null;
   }
 
-  return profile as StoryLabUserProfile;
+  return {
+    userId,
+    displayName,
+    preferences: normalizeStoryLabProfilePreferences(candidate.preferences),
+    createdAt,
+    updatedAt
+  };
 }
 
 function readProjectFromBody(body: unknown): SavedStoryProject | null {
-  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+  if (!isObjectRecord(body)) {
     return null;
   }
 
-  const candidate = 'project' in body ? (body as { project?: unknown }).project : body;
-  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+  const candidate = readBodyRecord(body, 'project');
+  if (!isObjectRecord(candidate)) {
     return null;
   }
 
-  const project = candidate as Partial<SavedStoryProject>;
+  const projectId = normalizeProjectId(candidate.id);
   if (
-    !normalizeProjectId(project.id) ||
-    typeof project.storyId !== 'string' ||
-    !project.storyId.trim() ||
-    typeof project.title !== 'string' ||
-    !project.title.trim() ||
-    !project.summary ||
-    typeof project.summary !== 'object' ||
-    Array.isArray(project.summary) ||
-    !project.state ||
-    typeof project.state !== 'object' ||
-    Array.isArray(project.state) ||
-    !project.blueprint ||
-    typeof project.blueprint !== 'object' ||
-    Array.isArray(project.blueprint) ||
-    !Array.isArray(project.chapters)
+    !projectId ||
+    !isNonBlankString(candidate.storyId) ||
+    !isNonBlankString(candidate.title) ||
+    !isNonBlankString(candidate.synopsis) ||
+    !isNonBlankString(candidate.createdAt) ||
+    !isNonBlankString(candidate.updatedAt) ||
+    !isObjectRecord(candidate.summary) ||
+    !isObjectRecord(candidate.state) ||
+    !isObjectRecord(candidate.blueprint) ||
+    !Array.isArray(candidate.chapters)
   ) {
     return null;
   }
 
-  return project as SavedStoryProject;
+  return {
+    id: projectId,
+    storyId: candidate.storyId,
+    title: candidate.title,
+    synopsis: candidate.synopsis,
+    blueprint: candidate.blueprint as unknown as SavedStoryProject['blueprint'],
+    summary: candidate.summary as unknown as SavedStoryProject['summary'],
+    state: candidate.state as unknown as SavedStoryProject['state'],
+    chapters: candidate.chapters as SavedStoryProject['chapters'],
+    telemetry: candidate.telemetry as SavedStoryProject['telemetry'],
+    continuityExtraction: candidate.continuityExtraction as SavedStoryProject['continuityExtraction'],
+    pinnedMemoryCardDraftIds: candidate.pinnedMemoryCardDraftIds as SavedStoryProject['pinnedMemoryCardDraftIds'],
+    acceptedMemoryCards: candidate.acceptedMemoryCards as SavedStoryProject['acceptedMemoryCards'],
+    createdAt: candidate.createdAt,
+    updatedAt: candidate.updatedAt
+  };
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function readBodyRecord(body: Record<string, unknown>, key: string): unknown {
+  return Object.prototype.hasOwnProperty.call(body, key) ? body[key] : body;
+}
+
+function isNonBlankString(value: unknown): value is string {
+  return typeof value === 'string' && Boolean(value.trim());
 }
 
 function normalizeProjectId(projectId: unknown): string | null {

--- a/api/_lib/story-lab/account/accountRouteHandlers.ts
+++ b/api/_lib/story-lab/account/accountRouteHandlers.ts
@@ -362,7 +362,7 @@ function readProfileFromBody(body: unknown): StoryLabUserProfile | null {
     return null;
   }
 
-  const candidate = readBodyRecord(body, 'profile');
+  const candidate = readWrappedOrBareBodyRecord(body, 'profile');
   if (!isObjectRecord(candidate)) {
     return null;
   }
@@ -397,7 +397,7 @@ function readProjectFromBody(body: unknown): SavedStoryProject | null {
     return null;
   }
 
-  const candidate = readBodyRecord(body, 'project');
+  const candidate = readWrappedOrBareBodyRecord(body, 'project');
   if (!isObjectRecord(candidate)) {
     return null;
   }
@@ -440,7 +440,7 @@ function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
 }
 
-function readBodyRecord(body: Record<string, unknown>, key: string): unknown {
+function readWrappedOrBareBodyRecord(body: Record<string, unknown>, key: string): unknown {
   return Object.prototype.hasOwnProperty.call(body, key) ? body[key] : body;
 }
 

--- a/api/_lib/story-lab/account/accountRouteHandlers.ts
+++ b/api/_lib/story-lab/account/accountRouteHandlers.ts
@@ -444,7 +444,7 @@ function isObjectRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function readWrappedOrBareBodyRecord(body: Record<string, unknown>, key: string): unknown {
-  return Object.prototype.hasOwnProperty.call(body, key) ? body[key] : body;
+  return Object.keys(body).includes(key) ? body[key] : body;
 }
 
 function isNonBlankString(value: unknown): value is string {

--- a/api/_lib/story-lab/profile/storyLabProfileStore.ts
+++ b/api/_lib/story-lab/profile/storyLabProfileStore.ts
@@ -117,7 +117,7 @@ export function normalizeStoryLabUserProfile(
     userId: user.userId,
     displayName: profile.displayName || 'Story Lab Writer',
     preferences: normalizeStoryLabProfilePreferences(profile.preferences),
-    createdAt: existingCreatedAt ?? profile.createdAt ?? now,
+    createdAt: (existingCreatedAt ?? profile.createdAt) || now,
     updatedAt: now
   };
 }

--- a/api/_lib/story-lab/storage/storyLabCloudSchemaMigration.ts
+++ b/api/_lib/story-lab/storage/storyLabCloudSchemaMigration.ts
@@ -51,8 +51,9 @@ export function splitStoryLabCloudSchemaStatements(schemaSql: string): string[] 
     dollarQuoteTag: null
   };
 
-  for (let index = 0; index < schemaSql.length; index += 1) {
-    index = consumeSchemaSqlCharacter(schemaSql, index, state, statements);
+  let index = 0;
+  while (index < schemaSql.length) {
+    index = consumeSchemaSqlCharacter(schemaSql, index, state, statements) + 1;
   }
 
   pushStatement(statements, state.current);

--- a/api/_lib/story-lab/storage/storyLabCloudSchemaMigration.ts
+++ b/api/_lib/story-lab/storage/storyLabCloudSchemaMigration.ts
@@ -43,89 +43,172 @@ export function loadStoryLabCloudSchemaSql(): string {
 
 export function splitStoryLabCloudSchemaStatements(schemaSql: string): string[] {
   const statements: string[] = [];
-  let current = '';
-  let inSingleQuote = false;
-  let inLineComment = false;
-  let inBlockComment = false;
-  let dollarQuoteTag: string | null = null;
+  const state: SchemaSqlSplitState = {
+    current: '',
+    inSingleQuote: false,
+    inLineComment: false,
+    inBlockComment: false,
+    dollarQuoteTag: null
+  };
 
   for (let index = 0; index < schemaSql.length; index += 1) {
-    const char = schemaSql[index] ?? '';
-    const next = schemaSql[index + 1] ?? '';
-
-    if (dollarQuoteTag) {
-      if (schemaSql.startsWith(dollarQuoteTag, index)) {
-        current += dollarQuoteTag;
-        index += dollarQuoteTag.length - 1;
-        dollarQuoteTag = null;
-      } else {
-        current += char;
-      }
-      continue;
-    }
-
-    if (inLineComment) {
-      current += char;
-      if (char === '\n') {
-        inLineComment = false;
-      }
-      continue;
-    }
-
-    if (inBlockComment) {
-      current += char;
-      if (char === '*' && next === '/') {
-        current += next;
-        index += 1;
-        inBlockComment = false;
-      }
-      continue;
-    }
-
-    if (!inSingleQuote && char === '-' && next === '-') {
-      inLineComment = true;
-      current += char;
-      continue;
-    }
-
-    if (!inSingleQuote && char === '/' && next === '*') {
-      inBlockComment = true;
-      current += char;
-      continue;
-    }
-
-    const openingDollarQuoteTag = !inSingleQuote ? readDollarQuoteTag(schemaSql, index) : null;
-    if (openingDollarQuoteTag) {
-      dollarQuoteTag = openingDollarQuoteTag;
-      current += openingDollarQuoteTag;
-      index += openingDollarQuoteTag.length - 1;
-      continue;
-    }
-
-    if (char === "'") {
-      current += char;
-      if (inSingleQuote && next === "'") {
-        current += next;
-        index += 1;
-        continue;
-      }
-
-      inSingleQuote = !inSingleQuote;
-      continue;
-    }
-
-    if (char === ';' && !inSingleQuote) {
-      pushStatement(statements, current);
-      current = '';
-      continue;
-    }
-
-    current += char;
+    index = consumeSchemaSqlCharacter(schemaSql, index, state, statements);
   }
 
-  pushStatement(statements, current);
+  pushStatement(statements, state.current);
 
   return statements.filter(statement => hasSqlBody(statement));
+}
+
+interface SchemaSqlSplitState {
+  current: string;
+  inSingleQuote: boolean;
+  inLineComment: boolean;
+  inBlockComment: boolean;
+  dollarQuoteTag: string | null;
+}
+
+function consumeSchemaSqlCharacter(
+  schemaSql: string,
+  index: number,
+  state: SchemaSqlSplitState,
+  statements: string[]
+): number {
+  const contextIndex = consumeActiveSqlContext(schemaSql, index, state);
+  if (contextIndex !== null) {
+    return contextIndex;
+  }
+
+  const openingIndex = consumeOpeningSqlContext(schemaSql, index, state);
+  if (openingIndex !== null) {
+    return openingIndex;
+  }
+
+  return consumePlainSqlCharacter(schemaSql, index, state, statements);
+}
+
+function consumeActiveSqlContext(schemaSql: string, index: number, state: SchemaSqlSplitState): number | null {
+  if (state.dollarQuoteTag) {
+    return consumeDollarQuotedSql(schemaSql, index, state);
+  }
+
+  if (state.inLineComment) {
+    return consumeLineComment(schemaSql, index, state);
+  }
+
+  if (state.inBlockComment) {
+    return consumeBlockComment(schemaSql, index, state);
+  }
+
+  return null;
+}
+
+function consumeDollarQuotedSql(schemaSql: string, index: number, state: SchemaSqlSplitState): number {
+  const tag = state.dollarQuoteTag ?? '';
+  if (schemaSql.startsWith(tag, index)) {
+    state.current += tag;
+    state.dollarQuoteTag = null;
+    return index + tag.length - 1;
+  }
+
+  state.current += schemaSql[index] ?? '';
+  return index;
+}
+
+function consumeLineComment(schemaSql: string, index: number, state: SchemaSqlSplitState): number {
+  const char = schemaSql[index] ?? '';
+  state.current += char;
+  if (char === '\n') {
+    state.inLineComment = false;
+  }
+
+  return index;
+}
+
+function consumeBlockComment(schemaSql: string, index: number, state: SchemaSqlSplitState): number {
+  const char = schemaSql[index] ?? '';
+  const next = schemaSql[index + 1] ?? '';
+  state.current += char;
+  if (char === '*' && next === '/') {
+    state.current += next;
+    state.inBlockComment = false;
+    return index + 1;
+  }
+
+  return index;
+}
+
+function consumeOpeningSqlContext(schemaSql: string, index: number, state: SchemaSqlSplitState): number | null {
+  const char = schemaSql[index] ?? '';
+  const next = schemaSql[index + 1] ?? '';
+
+  if (state.inSingleQuote) {
+    return null;
+  }
+
+  if (char === '-' && next === '-') {
+    state.inLineComment = true;
+    state.current += char;
+    return index;
+  }
+
+  if (char === '/' && next === '*') {
+    state.inBlockComment = true;
+    state.current += char;
+    return index;
+  }
+
+  return consumeOpeningDollarQuote(schemaSql, index, state);
+}
+
+function consumeOpeningDollarQuote(schemaSql: string, index: number, state: SchemaSqlSplitState): number | null {
+  const openingDollarQuoteTag = readDollarQuoteTag(schemaSql, index);
+  if (!openingDollarQuoteTag) {
+    return null;
+  }
+
+  state.dollarQuoteTag = openingDollarQuoteTag;
+  state.current += openingDollarQuoteTag;
+  return index + openingDollarQuoteTag.length - 1;
+}
+
+function consumePlainSqlCharacter(
+  schemaSql: string,
+  index: number,
+  state: SchemaSqlSplitState,
+  statements: string[]
+): number {
+  const char = schemaSql[index] ?? '';
+  const next = schemaSql[index + 1] ?? '';
+
+  if (char === "'") {
+    return consumeSingleQuote(schemaSql, index, state, next);
+  }
+
+  if (char === ';' && !state.inSingleQuote) {
+    pushStatement(statements, state.current);
+    state.current = '';
+    return index;
+  }
+
+  state.current += char;
+  return index;
+}
+
+function consumeSingleQuote(
+  schemaSql: string,
+  index: number,
+  state: SchemaSqlSplitState,
+  next: string
+): number {
+  state.current += schemaSql[index] ?? '';
+  if (state.inSingleQuote && next === "'") {
+    state.current += next;
+    return index + 1;
+  }
+
+  state.inSingleQuote = !state.inSingleQuote;
+  return index;
 }
 
 function pushStatement(statements: string[], statement: string): void {
@@ -145,7 +228,7 @@ function hasSqlBody(statement: string): boolean {
 }
 
 function readDollarQuoteTag(schemaSql: string, index: number): string | null {
-  const match = schemaSql.slice(index).match(/^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$/);
+  const match = /^\$(?:[A-Za-z_]\w*)?\$/.exec(schemaSql.slice(index));
   return match?.[0] ?? null;
 }
 

--- a/api/_lib/story-lab/storage/storyLabCloudSchemaMigration.ts
+++ b/api/_lib/story-lab/storage/storyLabCloudSchemaMigration.ts
@@ -228,8 +228,46 @@ function hasSqlBody(statement: string): boolean {
 }
 
 function readDollarQuoteTag(schemaSql: string, index: number): string | null {
-  const match = /^\$(?:[A-Za-z_]\w*)?\$/.exec(schemaSql.slice(index));
-  return match?.[0] ?? null;
+  if (schemaSql[index] !== '$') {
+    return null;
+  }
+
+  const closingIndex = findDollarQuoteTagEnd(schemaSql, index + 1);
+  return closingIndex === null ? null : schemaSql.slice(index, closingIndex + 1);
+}
+
+function findDollarQuoteTagEnd(schemaSql: string, index: number): number | null {
+  const firstTagChar = schemaSql[index] ?? '';
+  if (firstTagChar === '$') {
+    return index;
+  }
+
+  if (!isDollarQuoteTagStart(firstTagChar)) {
+    return null;
+  }
+
+  let cursor = index + 1;
+  while (cursor < schemaSql.length && isDollarQuoteTagPart(schemaSql[cursor] ?? '')) {
+    cursor += 1;
+  }
+
+  return schemaSql[cursor] === '$' ? cursor : null;
+}
+
+function isDollarQuoteTagStart(char: string): boolean {
+  return char === '_' || isAsciiLetter(char);
+}
+
+function isDollarQuoteTagPart(char: string): boolean {
+  return char === '_' || isAsciiLetter(char) || isAsciiDigit(char);
+}
+
+function isAsciiLetter(char: string): boolean {
+  return (char >= 'A' && char <= 'Z') || (char >= 'a' && char <= 'z');
+}
+
+function isAsciiDigit(char: string): boolean {
+  return char >= '0' && char <= '9';
 }
 
 function stripBlockComments(statement: string): string {

--- a/api/_lib/story-lab/storage/storyProjectStore.ts
+++ b/api/_lib/story-lab/storage/storyProjectStore.ts
@@ -93,7 +93,7 @@ export function normalizeSavedStoryProject(
     id: project.id || project.storyId,
     title: project.title || project.summary?.title || 'Untitled Story Lab Project',
     synopsis: project.synopsis || project.summary?.synopsis || '',
-    createdAt: existingCreatedAt ?? project.createdAt ?? now,
+    createdAt: (existingCreatedAt ?? project.createdAt) || now,
     updatedAt: now
   };
 

--- a/tests/story-lab-account-routes.test.ts
+++ b/tests/story-lab-account-routes.test.ts
@@ -208,6 +208,15 @@ async function testMalformedProfileBodyFailsClosed() {
   const body = response.body as any;
   assert(body.error.code === 'INVALID_REQUEST', 'malformed profile body should use invalid request code');
   assert(!body.error.message.includes(owner.email ?? ''), 'malformed profile body error should not leak user email');
+
+  const malformedWrapperResponse = new FakeResponse();
+  await handler(createRequest('PUT', 'profile', {
+    profile: 'not-a-profile-object',
+    userId: owner.userId,
+    displayName: 'Avery',
+    preferences: {}
+  }), malformedWrapperResponse);
+  assert(malformedWrapperResponse.statusCode === 400, 'malformed profile wrapper should not fall back to outer fields');
 }
 
 async function testProjectSaveListLoadDeleteUsesAuthenticatedOwner() {
@@ -388,6 +397,13 @@ async function testInvalidProjectBodyFailsClosedBeforeStoreAccess() {
     (arrayShapeResponse.body as any).error.code === 'INVALID_REQUEST',
     'project save with array-shaped internals should use invalid request code'
   );
+
+  const malformedWrapperResponse = new FakeResponse();
+  await handler(createRequest('POST', 'projects', {
+    project: 'not-a-project-object',
+    ...createProject()
+  }), malformedWrapperResponse);
+  assert(malformedWrapperResponse.statusCode === 400, 'malformed project wrapper should not fall back to outer fields');
 }
 
 async function testInjectedStoreErrorMessageIsSanitized() {

--- a/tests/story-lab-account-routes.test.ts
+++ b/tests/story-lab-account-routes.test.ts
@@ -79,9 +79,11 @@ async function main() {
   await testDisallowedCorsOriginFailsClosed();
   await testProfileReadWriteUsesAuthenticatedOwner();
   await testProfileCrossOwnerSaveIsForbidden();
+  await testProfileSaveAllowsMissingOptionalTimestamps();
   await testMalformedProfileBodyFailsClosed();
   await testProjectSaveListLoadDeleteUsesAuthenticatedOwner();
   await testProjectCrossOwnerReadIsForbidden();
+  await testProjectSaveAllowsMissingOptionalMetadata();
   await testMissingStorageConfigFailsClosed();
   await testMalformedProjectIdFailsClosed();
   await testInvalidProjectIdsFailClosedBeforeStoreAccess();
@@ -193,6 +195,24 @@ async function testProfileCrossOwnerSaveIsForbidden() {
   assert(!body.error.message.includes(owner.email ?? ''), 'cross-owner profile error should not leak owner email');
 }
 
+async function testProfileSaveAllowsMissingOptionalTimestamps() {
+  const handler = createTestHandler(owner);
+  const profile = createDefaultStoryLabUserProfile(owner, {
+    displayName: 'Avery',
+    now
+  }) as Partial<ReturnType<typeof createDefaultStoryLabUserProfile>>;
+  delete profile.createdAt;
+  delete profile.updatedAt;
+
+  const response = new FakeResponse();
+  await handler(createRequest('PUT', 'profile', { profile }), response);
+
+  assert(response.statusCode === 200, 'profile save without timestamps should still return 200');
+  const body = response.body as any;
+  assert(body.data.createdAt === now, 'profile save should fill missing createdAt through store normalization');
+  assert(body.data.updatedAt === now, 'profile save should fill missing updatedAt through store normalization');
+}
+
 async function testMalformedProfileBodyFailsClosed() {
   const handler = createTestHandler(owner);
   const response = new FakeResponse();
@@ -220,6 +240,21 @@ async function testMalformedProfileBodyFailsClosed() {
   assert(
     (malformedWrapperResponse.body as any).error.code === 'INVALID_REQUEST',
     'malformed profile wrapper should use invalid request code'
+  );
+
+  const malformedTimestampResponse = new FakeResponse();
+  await handler(createRequest('PUT', 'profile', {
+    profile: {
+      userId: owner.userId,
+      displayName: 'Avery',
+      preferences: {},
+      createdAt: 42
+    }
+  }), malformedTimestampResponse);
+  assert(malformedTimestampResponse.statusCode === 400, 'profile save with malformed timestamp should return 400');
+  assert(
+    (malformedTimestampResponse.body as any).error.code === 'INVALID_REQUEST',
+    'malformed profile timestamp should use invalid request code'
   );
 }
 
@@ -295,6 +330,27 @@ async function testProjectCrossOwnerReadIsForbidden() {
   const body = otherLoadResponse.body as any;
   assert(body.error.code === 'STORY_LAB_PROJECT_FORBIDDEN', 'cross-owner project read should be forbidden');
   assert(!body.error.message.includes(privateStoryText), 'cross-owner project error should not leak private story text');
+}
+
+async function testProjectSaveAllowsMissingOptionalMetadata() {
+  const handler = createTestHandler(owner);
+  const project = createProject() as Partial<SavedStoryProject>;
+  project.id = 'project-account-no-optional-metadata';
+  delete project.synopsis;
+  delete project.createdAt;
+  delete project.updatedAt;
+
+  const saveResponse = new FakeResponse();
+  await handler(createRequest('POST', 'projects', { project }), saveResponse);
+  assert(saveResponse.statusCode === 200, 'project save without optional metadata should return 200');
+
+  const loadResponse = new FakeResponse();
+  await handler(createRequest('GET', 'project', undefined, 'project-account-no-optional-metadata'), loadResponse);
+  assert(loadResponse.statusCode === 200, 'project without optional metadata should remain loadable');
+  const loadBody = loadResponse.body as any;
+  assert(loadBody.data.project.createdAt === now, 'project save should fill missing createdAt through store normalization');
+  assert(loadBody.data.project.updatedAt === now, 'project save should fill missing updatedAt through store normalization');
+  assert(loadBody.data.project.synopsis === 'A private oath in a haunted chapel.', 'project save should derive missing synopsis from summary');
 }
 
 async function testMissingStorageConfigFailsClosed() {
@@ -400,6 +456,19 @@ async function testInvalidProjectBodyFailsClosedBeforeStoreAccess() {
   assert(
     (arrayShapeResponse.body as any).error.code === 'INVALID_REQUEST',
     'project save with array-shaped internals should use invalid request code'
+  );
+
+  const malformedOptionalStringResponse = new FakeResponse();
+  await handler(createRequest('POST', 'projects', {
+    project: {
+      ...createProject(),
+      synopsis: 42
+    }
+  }), malformedOptionalStringResponse);
+  assert(malformedOptionalStringResponse.statusCode === 400, 'project save with malformed synopsis should return 400');
+  assert(
+    (malformedOptionalStringResponse.body as any).error.code === 'INVALID_REQUEST',
+    'malformed project synopsis should use invalid request code'
   );
 
   const malformedWrapperResponse = new FakeResponse();

--- a/tests/story-lab-account-routes.test.ts
+++ b/tests/story-lab-account-routes.test.ts
@@ -197,12 +197,14 @@ async function testProfileCrossOwnerSaveIsForbidden() {
 
 async function testProfileSaveAllowsMissingOptionalTimestamps() {
   const handler = createTestHandler(owner);
-  const profile = createDefaultStoryLabUserProfile(owner, {
+  const {
+    createdAt: _createdAt,
+    updatedAt: _updatedAt,
+    ...profile
+  } = createDefaultStoryLabUserProfile(owner, {
     displayName: 'Avery',
     now
-  }) as Partial<ReturnType<typeof createDefaultStoryLabUserProfile>>;
-  delete profile.createdAt;
-  delete profile.updatedAt;
+  });
 
   const response = new FakeResponse();
   await handler(createRequest('PUT', 'profile', { profile }), response);
@@ -334,14 +336,19 @@ async function testProjectCrossOwnerReadIsForbidden() {
 
 async function testProjectSaveAllowsMissingOptionalMetadata() {
   const handler = createTestHandler(owner);
-  const project = createProject() as Partial<SavedStoryProject>;
-  project.id = 'project-account-no-optional-metadata';
-  delete project.synopsis;
-  delete project.createdAt;
-  delete project.updatedAt;
+  const {
+    synopsis: _synopsis,
+    createdAt: _createdAt,
+    updatedAt: _updatedAt,
+    ...project
+  } = createProject();
+  const projectWithoutOptionalMetadata = {
+    ...project,
+    id: 'project-account-no-optional-metadata'
+  };
 
   const saveResponse = new FakeResponse();
-  await handler(createRequest('POST', 'projects', { project }), saveResponse);
+  await handler(createRequest('POST', 'projects', { project: projectWithoutOptionalMetadata }), saveResponse);
   assert(saveResponse.statusCode === 200, 'project save without optional metadata should return 200');
 
   const loadResponse = new FakeResponse();

--- a/tests/story-lab-account-routes.test.ts
+++ b/tests/story-lab-account-routes.test.ts
@@ -217,6 +217,10 @@ async function testMalformedProfileBodyFailsClosed() {
     preferences: {}
   }), malformedWrapperResponse);
   assert(malformedWrapperResponse.statusCode === 400, 'malformed profile wrapper should not fall back to outer fields');
+  assert(
+    (malformedWrapperResponse.body as any).error.code === 'INVALID_REQUEST',
+    'malformed profile wrapper should use invalid request code'
+  );
 }
 
 async function testProjectSaveListLoadDeleteUsesAuthenticatedOwner() {
@@ -404,6 +408,10 @@ async function testInvalidProjectBodyFailsClosedBeforeStoreAccess() {
     ...createProject()
   }), malformedWrapperResponse);
   assert(malformedWrapperResponse.statusCode === 400, 'malformed project wrapper should not fall back to outer fields');
+  assert(
+    (malformedWrapperResponse.body as any).error.code === 'INVALID_REQUEST',
+    'malformed project wrapper should use invalid request code'
+  );
 }
 
 async function testInjectedStoreErrorMessageIsSanitized() {


### PR DESCRIPTION
## Scope

- Refactors the Story Lab cloud schema SQL splitter into smaller scanner helpers to clear PR #118 Sonar complexity/readability debt without changing schema execution behavior.
- Replaces account route path/body parsing casts with explicit record helpers and `RegExp.exec()` to clear PR #119 Sonar debt.
- Adds regression coverage for malformed `profile`/`project` wrapper bodies so invalid wrappers do not fall back to outer request fields.
- Records the cleanup and #145 false-positive Neon API audit in `PR70_RECOVERY_CHANGELOG.md`.

## Validation

- `npm run test:story-lab-cloud-schema-migration`
- `npm run test:story-lab-account-routes`
- `npm run test:story-lab-cloud-storage-config`
- `npm run test:story-lab-neon-executor`
- `git diff --check`
- `scripts/recovery/preflight.sh --quick --skip-status`

## Non-claims

- Does not add a production auth provider dependency.
- Does not provision, migrate, or write to a real database.
- Does not claim live cloud sync, durable profiles, or durable jobs.
- Function count remains `11/12`.

Addresses #133.