### PR TITLE
Fix Story Lab memory follow-ups

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -3014,3 +3014,24 @@ Validation:
 - `npm run recovery:preflight -- story-memory-cards`: passed and wrote `tmp/recovery/story-memory-cards-evidence.md`; latest initial browser bundle was 484.83 kB and Proving Grounds remained a lazy chunk.
 - `npm run recovery:preflight -- css-lazy-loading --quick`: passed and wrote `tmp/recovery/css-lazy-loading-evidence.md`.
 - Function count stayed `11/12`.
+
+## 2026-06-21 14:22 EDT - Memory Card Review Follow-Ups
+
+Actions:
+
+- Addressed issue #140 by saving the active browser-local project, including accepted and pinned memory-card state, before creating a continuation job.
+- Addressed issue #141 by rendering malformed browser-local accepted-memory metadata as a zero-card count instead of reading `.length` from non-array metadata.
+- Added Angular regressions for pre-continuation memory-card persistence, completed continuation recovery after reload, and malformed local library metadata rendering.
+
+Self-review:
+
+- Good: The fix stayed inside the existing Angular save/recovery path and did not add routes, cloud-sync claims, or durable-job claims.
+- Problem found: The previous memory-card review pass normalized malformed metadata during hydration, but the saved-project list could still render raw stale metadata before hydration; the display layer now guards the count too.
+- Problem found: Continuation jobs already stored a reload marker, but they did not first flush the current accepted/pinned card state into the saved project that reload recovery depends on.
+
+Validation:
+
+- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`: passed.
+- `git diff --check`: passed.
+- `npm run recovery:preflight -- story-memory-cards`: passed and wrote `tmp/recovery/story-memory-cards-evidence.md`; latest initial browser bundle was 485.03 kB and Proving Grounds remained a lazy chunk.
+- `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"` in `story-generator`: passed with `TOTAL: 81 SUCCESS` after one initial ChromeHeadless capture retry.

--- a/story-generator/src/app/app.html
+++ b/story-generator/src/app/app.html
@@ -647,7 +647,7 @@
               <span class="saved-meta" data-testid="local-project-meta">
                 {{ project.chapters.length }} chapter{{ project.chapters.length === 1 ? '' : 's' }} · {{ project.updatedAt | date:'MMM d, h:mm a' }}
                 <ng-container *ngIf="project.acceptedMemoryCards !== undefined">
-                  · {{ project.acceptedMemoryCards.length }} memory card{{ project.acceptedMemoryCards.length === 1 ? '' : 's' }}
+                  · {{ acceptedMemoryCardCount(project) }} memory card{{ acceptedMemoryCardCount(project) === 1 ? '' : 's' }}
                 </ng-container>
               </span>
             </button>

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -791,6 +791,21 @@ describe('App', () => {
     expect(localMeta?.textContent).toContain('0 memory cards');
   });
 
+  it('renders malformed browser-local accepted memory metadata as zero count', () => {
+    seedWorkbenchForContinuation();
+    component.saveActiveProject();
+
+    const savedProjects = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]') as Array<Record<string, unknown>>;
+    savedProjects[0]['acceptedMemoryCards'] = null;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(savedProjects));
+
+    const recoveredFixture = TestBed.createComponent(App);
+
+    expect(() => recoveredFixture.detectChanges()).not.toThrow();
+    const localMeta = recoveredFixture.nativeElement.querySelector('[data-testid="local-project-meta"]') as HTMLElement | null;
+    expect(localMeta?.textContent).toContain('0 memory cards');
+  });
+
   it('saves the active workbench project to cloud without disabling local save', () => {
     const payload = seedWorkbenchForContinuation();
     const receipt: CloudStoryProjectSaveReceipt = {
@@ -2017,6 +2032,49 @@ describe('App', () => {
       storyId: 'story-123'
     }));
     expect(marker.batchId).toMatch(/^batch-/);
+  });
+
+  it('persists accepted and pinned memory cards before continuation job recovery', () => {
+    const genesisPayload = seedMaraMemoryCardWorkbench();
+    const events$ = new Subject<StoryLabJobEvent<ContinuationJobResult>>();
+    storyService.createStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(undefined, {
+        status: 'running',
+        currentStep: 'continuing_story',
+        progressPercent: 28
+      })
+    }));
+    storyService.streamStoryLabJobEvents.and.returnValue(events$.asObservable());
+
+    clickFirstMemoryCardDraftAction('accept-memory-card-draft');
+    component.pinMemoryCardDraft('memory-card-thread-oath');
+    component.continueSaga('Make the betrayal more dangerous.');
+
+    const savedProjects = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]') as Array<Record<string, unknown>>;
+    const acceptedCards = savedProjects[0]['acceptedMemoryCards'] as unknown[];
+    const pinnedDraftIds = savedProjects[0]['pinnedMemoryCardDraftIds'] as string[];
+    expect(acceptedCards).toEqual([
+      jasmine.objectContaining({
+        id: 'memory-card-character-mara',
+        title: 'Mara',
+        detail: 'Keep the moonlit bargain from consuming her archive.'
+      })
+    ]);
+    expect(pinnedDraftIds).toContain('memory-card-thread-oath');
+
+    const continuationPayload = createContinuationPayload(genesisPayload);
+    storyService.getStoryLabJob.calls.reset();
+    storyService.getStoryLabJob.and.returnValue(of({
+      success: true,
+      data: createContinuationJobResponse(continuationPayload)
+    }));
+
+    const recovered = TestBed.createComponent(App).componentInstance;
+
+    expect(recovered.workbench().chapterHistory.length).toBe(2);
+    expect(recovered.acceptedMemoryCards()[0]?.title).toBe('Mara');
+    expect(recovered.pinnedMemoryCardDraftIds().has('memory-card-thread-oath')).toBeTrue();
   });
 
   it('recovers a running continuation job from browser storage and resumes events', () => {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -1039,12 +1039,23 @@ export class App implements OnDestroy {
       return;
     }
 
-    const session = this.workbench();
+    let session = this.workbench();
     if (!session.story || !session.state) {
       const message = 'Generate a story before requesting continuations.';
       this.statusMessage.set(message);
       this.notificationService.warning('No active story', message);
       return;
+    }
+    const story = session.story;
+    const storyState = session.state;
+
+    const savedProjectId = this.persistSession(session);
+    if (savedProjectId) {
+      session = {
+        ...session,
+        savedProjectId
+      };
+      this.workbench.set(session);
     }
 
     this.isGenerating.set(true);
@@ -1056,12 +1067,12 @@ export class App implements OnDestroy {
     const continuationBrief = this.withStoryMemoryCardBriefs(brief);
 
     const request = {
-      storyId: session.story.storyId,
+      storyId: story.storyId,
       chapterBatchSize: this.blueprint().chapterBatchSize,
-      storyState: session.state,
+      storyState,
       previouslyGeneratedChapters: session.chapterHistory,
       continuationBrief,
-      existingSummary: session.story,
+      existingSummary: story,
       heatContract: this.activeHeatContract()
     } as const;
 
@@ -2652,6 +2663,10 @@ ${chapters}
 
   trackCloudProject(_index: number, project: CloudStoryProjectListItem): string {
     return project.projectId;
+  }
+
+  acceptedMemoryCardCount(project: SavedStoryProject): number {
+    return Array.isArray(project.acceptedMemoryCards) ? project.acceptedMemoryCards.length : 0;
   }
 
   formatBatchStatus(status: BatchProgressState['status']): string {


### PR DESCRIPTION
## Summary
- Save accepted and pinned memory-card state before creating continuation jobs so reload recovery has the current browser-local project.
- Render malformed browser-local accepted-memory metadata as a zero-card count instead of reading `.length` from stale non-array values.
- Add focused Angular regressions and recovery changelog evidence for issues #140 and #141.

Closes #140
Closes #141

## Validation
- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`
- `git diff --check`
- `npm run recovery:preflight -- story-memory-cards` passed and wrote `tmp/recovery/story-memory-cards-evidence.md`
- `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"` in `story-generator`: `TOTAL: 81 SUCCESS` after one initial ChromeHeadless capture retry

## Non-Claims
- No live cloud sync, database provisioning, or signed-in account flow is claimed here.
- No durable job/process-loss guarantee is claimed; this only preserves the browser-local project state used by current continuation reload recovery.

## Next Slice
- Continue issue-backed review follow-ups after this PR merges.
