### PR TITLE
Harden Story Lab quality guidance follow-ups

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -3035,3 +3035,27 @@ Validation:
 - `git diff --check`: passed.
 - `npm run recovery:preflight -- story-memory-cards`: passed and wrote `tmp/recovery/story-memory-cards-evidence.md`; latest initial browser bundle was 485.03 kB and Proving Grounds remained a lazy chunk.
 - `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"` in `story-generator`: passed with `TOTAL: 81 SUCCESS` after one initial ChromeHeadless capture retry.
+
+## 2026-06-21 14:35 EDT - Story Quality Guidance Review Follow-Ups
+
+Actions:
+
+- Addressed issue #142 by adding an `860` character budget for assembled hidden continuation guidance, with per-section caps that preserve the Continuity Courtroom, Chapter Ending Stress Test, and Cliche Alarm anchors.
+- Addressed issue #143 by replacing repeated full rendered-body word recounts in no-key mock generation with incremental paragraph word tracking, and by rejecting oversized classic streaming word-count inputs before SSE starts.
+- Addressed issue #144 by hardening activation helpers against stale/partial continuity state: missing thread descriptions/devices, missing relationship arrays or notes, and nullish activation candidates now fail closed.
+- Added regression coverage for rich hidden-guidance states, stale partial continuity shapes, and oversized no-key streaming requests.
+
+Self-review:
+
+- Good: The slice stayed inside the PR #136 story-quality/mock-generation boundary and did not change auth, storage, routes beyond the existing classic stream validation, or UI behavior.
+- Problem found: The first hidden-guidance cap was too tight and trimmed an existing "leave one sharper" instruction; the final cap keeps prior guidance intent while bounding rich states.
+- Problem found: The stream route accepted any positive word count even though the story-service contract already limits allowed budgets; route validation now matches the service boundary.
+
+Validation:
+
+- `npm run test:story-lab-real-engine`: passed after the cap adjustment.
+- `npm run test:story`: passed with `15` tests, including the oversized no-key streaming regression.
+- `find api -name '*.ts' ! -name '*.spec.ts' ! -name '*.test.ts' -print0 | xargs -0 npx -p node@20 node ./node_modules/typescript/bin/tsc --noEmit --target es2020 --lib es2020,dom --module commonjs --moduleResolution node --esModuleInterop --skipLibCheck --types node`: passed.
+- `git diff --check`: passed.
+- `npm run recovery:preflight -- story-quality-guidance`: passed and wrote `tmp/recovery/story-quality-guidance-evidence.md`; function count stayed `11/12`.
+- Oversized `/api/story/stream` GET smoke with `wordCount=5000`: passed with `400 INVALID_INPUT` before SSE opened.

--- a/api/_lib/services/storyService.ts
+++ b/api/_lib/services/storyService.ts
@@ -548,6 +548,11 @@ export class StoryService {
       generationSpeed: number;
     }) => void
   ): Promise<void> {
+    const validationError = this.validateStoryInput(input);
+    if (validationError) {
+      throw new Error(validationError.message);
+    }
+
     const tropeSelection = this.selectTropeSubversions(input);
 
     if (!this.xaiClient.hasApiKey()) {
@@ -1625,11 +1630,7 @@ Write 400-600 words for this chapter. Use HTML: <h3> for chapter title, <p> for 
     ];
 
     const renderBody = () => paragraphs.map(paragraph => `<p>${paragraph}</p>`).join('\n\n');
-    let beatIndex = 0;
-    while (this.countWords(renderBody()) < targetBodyWords) {
-      paragraphs.push(expansionBeats[beatIndex % expansionBeats.length]);
-      beatIndex += 1;
-    }
+    this.expandMockParagraphsToWordTarget(paragraphs, expansionBeats, targetBodyWords);
 
     return `<h3>The ${creatureName}'s Forbidden Passion</h3>
 
@@ -1658,11 +1659,7 @@ ${renderBody()}
     ];
 
     const renderBody = () => paragraphs.map(paragraph => `<p>${paragraph}</p>`).join('\n\n');
-    let beatIndex = 0;
-    while (this.countWords(renderBody()) < targetBodyWords) {
-      paragraphs.push(expansionBeats[beatIndex % expansionBeats.length]);
-      beatIndex += 1;
-    }
+    this.expandMockParagraphsToWordTarget(paragraphs, expansionBeats, targetBodyWords);
 
     return `<h3>Chapter ${chapterNumber}: ${baseTitle}</h3>
 
@@ -1694,15 +1691,33 @@ ${renderBody()}`;
       ...paragraphs.map(paragraph => `<p>${paragraph}</p>`),
       '<p><em>This is a mock chapter generated without AI.</em></p>'
     ].join('\n\n');
-    let beatIndex = 0;
-    while (this.countWords(renderBody()) < MOCK_CONTINUATION_TARGET_BODY_WORDS) {
-      paragraphs.push(expansionBeats[beatIndex % expansionBeats.length]);
-      beatIndex += 1;
-    }
+    this.expandMockParagraphsToWordTarget(
+      paragraphs,
+      expansionBeats,
+      MOCK_CONTINUATION_TARGET_BODY_WORDS,
+      this.countWords(renderBody())
+    );
 
     return `<h3>Chapter ${nextNumber}: The Deeper Shadows</h3>
 
 ${renderBody()}`;
+  }
+
+  private expandMockParagraphsToWordTarget(
+    paragraphs: string[],
+    expansionBeats: string[],
+    targetBodyWords: number,
+    initialWordCount = this.countWords(paragraphs.join(' '))
+  ): void {
+    let bodyWordCount = initialWordCount;
+    let beatIndex = 0;
+
+    while (bodyWordCount < targetBodyWords && expansionBeats.length > 0) {
+      const nextBeat = expansionBeats[beatIndex % expansionBeats.length];
+      paragraphs.push(nextBeat);
+      bodyWordCount += this.countWords(nextBeat);
+      beatIndex += 1;
+    }
   }
 
   private getCreatureDisplayName(creature: string): string {

--- a/api/_lib/story-lab/storyLabEngine.ts
+++ b/api/_lib/story-lab/storyLabEngine.ts
@@ -62,6 +62,11 @@ const CONTINUITY_COURTROOM_MAX_THREADS = 3;
 const CONTINUITY_COURTROOM_MAX_ARTIFACTS = 2;
 const CONTINUITY_COURTROOM_MAX_WARNINGS = 2;
 const CONTINUITY_COURTROOM_MAX_DETAIL_LENGTH = 180;
+// Hidden anchors share one compact provider budget so guidance cannot crowd prior-chapter context.
+const CONTINUATION_HIDDEN_GUIDANCE_MAX_LENGTH = 860;
+const CONTINUITY_COURTROOM_MAX_SECTION_LENGTH = 420;
+const CHAPTER_ENDING_STRESS_TEST_MAX_SECTION_LENGTH = 320;
+const CLICHE_ALARM_MAX_SECTION_LENGTH = 300;
 const WORLD_ARTIFACT_MAX_NAME_WORDS = 4;
 type ChapterEndingPressureId = 'emotional_reveal' | 'danger_escalation' | 'secret_exposed';
 type ScenePressureLabel = 'Emotional' | 'Secret' | 'Deadline' | 'Social' | 'Setting';
@@ -382,11 +387,15 @@ export function buildStoryLabPayloadFromGeneratedStory(
 
 function withContinuationStrategyBrief(continuationBrief: string | undefined, storyState: StoryStateSnapshot): string | undefined {
   const trimmedBrief = continuationBrief?.trim();
-  return [
-    trimmedBrief,
+  const hiddenGuidance = joinGuidanceSectionsWithinBudget([
     buildContinuityCourtroomBrief(storyState, trimmedBrief),
     buildChapterEndingStressTestBrief(storyState, trimmedBrief),
     buildClicheAlarmBrief(storyState, trimmedBrief)
+  ], CONTINUATION_HIDDEN_GUIDANCE_MAX_LENGTH);
+
+  return [
+    trimmedBrief,
+    hiddenGuidance
   ]
     .filter((line): line is string => Boolean(line))
     .join('\n\n') || undefined;
@@ -406,6 +415,79 @@ function extractAnchorHeadings(hiddenGuidance: string): string[] {
     .map(line => line.trim())
     .filter(line => /^[A-Za-z][A-Za-z ]+:$/.test(line))
     .map(line => line.slice(0, -1));
+}
+
+function joinGuidanceSectionsWithinBudget(sections: Array<string | undefined>, maxLength: number): string | undefined {
+  const acceptedSections: string[] = [];
+  let usedLength = 0;
+
+  for (const section of sections) {
+    if (!section) {
+      continue;
+    }
+
+    const separatorLength = acceptedSections.length > 0 ? 2 : 0;
+    const remainingLength = maxLength - usedLength - separatorLength;
+    const trimmedSection = limitGuidanceSection(section.split('\n'), remainingLength);
+    if (!trimmedSection) {
+      continue;
+    }
+
+    acceptedSections.push(trimmedSection);
+    usedLength += separatorLength + trimmedSection.length;
+  }
+
+  return acceptedSections.join('\n\n') || undefined;
+}
+
+function limitGuidanceSection(lines: string[], maxLength: number): string | undefined {
+  const heading = lines[0]?.trim();
+  if (!heading || maxLength <= heading.length + 2) {
+    return undefined;
+  }
+
+  const selectedLines = [heading];
+  let usedLength = heading.length;
+
+  for (const line of lines.slice(1)) {
+    const trimmedLine = line.trim();
+    if (!trimmedLine) {
+      continue;
+    }
+
+    const remainingLength = maxLength - usedLength - 1;
+    if (remainingLength <= 0) {
+      break;
+    }
+
+    const nextLine = trimmedLine.length <= remainingLength
+      ? trimmedLine
+      : compactPromptLineToLength(trimmedLine, remainingLength);
+    if (!nextLine) {
+      break;
+    }
+
+    selectedLines.push(nextLine);
+    usedLength += 1 + nextLine.length;
+    if (nextLine !== trimmedLine) {
+      break;
+    }
+  }
+
+  return selectedLines.length > 1 ? selectedLines.join('\n') : undefined;
+}
+
+function compactPromptLineToLength(value: string, maxLength: number): string {
+  const compacted = collapseWhitespace(value).trim();
+  if (compacted.length <= maxLength) {
+    return compacted;
+  }
+
+  if (maxLength < 12) {
+    return '';
+  }
+
+  return `${compacted.slice(0, maxLength - 3).trim()}...`;
 }
 
 function buildContinuityCourtroomBrief(storyState: StoryStateSnapshot, continuationBrief: string | undefined): string | undefined {
@@ -432,10 +514,10 @@ function buildContinuityCourtroomBrief(storyState: StoryStateSnapshot, continuat
     return undefined;
   }
 
-  return [
+  return limitGuidanceSection([
     'Continuity Courtroom:',
     ...lines
-  ].join('\n');
+  ], CONTINUITY_COURTROOM_MAX_SECTION_LENGTH);
 }
 
 function buildContinuationContextSourceMap(
@@ -519,8 +601,8 @@ function selectScoredCourtroomThreads(storyState: StoryStateSnapshot, continuati
   index: number;
   activationScore: number;
 }> {
-  const source = normalizeActivationText(continuationBrief ?? '');
-  return storyState.threads
+  const source = normalizeActivationText(continuationBrief);
+  return getStateThreads(storyState)
     .filter(isUnresolvedThread)
     .map((thread, index) => ({
       thread,
@@ -540,8 +622,8 @@ function selectScoredCourtroomArtifacts(storyState: StoryStateSnapshot, continua
   index: number;
   activationScore: number;
 }> {
-  const source = normalizeActivationText(continuationBrief ?? '');
-  return storyState.artifacts
+  const source = normalizeActivationText(continuationBrief);
+  return getStateArtifacts(storyState)
     .filter(artifact => !artifact.resolvedInChapter)
     .map((artifact, index) => ({
       artifact,
@@ -558,9 +640,9 @@ function scoreThreadActivation(thread: PlotThread, source: string): number {
 
 function getThreadActivationCandidates(thread: PlotThread): string[] {
   return [
-    thread.label,
-    thread.description,
-    ...thread.foreshadowedDevices
+    safeString(thread.label),
+    safeString(thread.description),
+    ...getThreadForeshadowedDevices(thread)
   ];
 }
 
@@ -570,8 +652,8 @@ function scoreArtifactActivation(artifact: LoreArtifact, source: string): number
 
 function getArtifactActivationCandidates(artifact: LoreArtifact): string[] {
   return [
-    artifact.name,
-    artifact.significance
+    safeString(artifact.name),
+    safeString(artifact.significance)
   ];
 }
 
@@ -584,8 +666,8 @@ function selectScoredCourtroomWarnings(storyState: StoryStateSnapshot, continuat
   index: number;
   activationScore: number;
 }> {
-  const source = normalizeActivationText(continuationBrief ?? '');
-  return storyState.continuityWarnings
+  const source = normalizeActivationText(continuationBrief);
+  return getStateContinuityWarnings(storyState)
     .map((warning, index) => ({
       warning,
       index,
@@ -603,8 +685,8 @@ function getWarningActivationCandidates(warning: string): string[] {
   return [warning];
 }
 
-function normalizeActivationText(value: string): string {
-  return collapseWhitespace(value)
+function normalizeActivationText(value: unknown): string {
+  return collapseWhitespace(safeString(value))
     .toLowerCase()
     .replace(/[^a-z0-9 ]+/g, ' ')
     .replace(/\s+/g, ' ')
@@ -613,6 +695,54 @@ function normalizeActivationText(value: string): string {
 
 function isUnresolvedThread(thread: PlotThread): boolean {
   return thread.status !== 'resolved';
+}
+
+function getStateThreads(storyState: StoryStateSnapshot): PlotThread[] {
+  return Array.isArray((storyState as Partial<StoryStateSnapshot>).threads)
+    ? (storyState as Partial<StoryStateSnapshot>).threads as PlotThread[]
+    : [];
+}
+
+function getStateArtifacts(storyState: StoryStateSnapshot): LoreArtifact[] {
+  return Array.isArray((storyState as Partial<StoryStateSnapshot>).artifacts)
+    ? (storyState as Partial<StoryStateSnapshot>).artifacts as LoreArtifact[]
+    : [];
+}
+
+function getStateCharacters(storyState: StoryStateSnapshot): CharacterProfile[] {
+  return Array.isArray((storyState as Partial<StoryStateSnapshot>).characters)
+    ? (storyState as Partial<StoryStateSnapshot>).characters as CharacterProfile[]
+    : [];
+}
+
+function getStateContinuityWarnings(storyState: StoryStateSnapshot): string[] {
+  const warnings = (storyState as Partial<StoryStateSnapshot>).continuityWarnings;
+  return Array.isArray(warnings)
+    ? warnings.filter((warning): warning is string => typeof warning === 'string' && warning.trim().length > 0)
+    : [];
+}
+
+function getThreadForeshadowedDevices(thread: PlotThread): string[] {
+  const devices = (thread as Partial<PlotThread>).foreshadowedDevices;
+  return Array.isArray(devices)
+    ? devices.filter((device): device is string => typeof device === 'string' && device.trim().length > 0)
+    : [];
+}
+
+function getCharacterRelationships(character: CharacterProfile): CharacterProfile['relationships'] {
+  const relationships = (character as Partial<CharacterProfile>).relationships;
+  return Array.isArray(relationships)
+    ? relationships.filter((relationship): relationship is CharacterProfile['relationships'][number] =>
+        Boolean(relationship)
+        && typeof relationship === 'object'
+        && typeof relationship.characterId === 'string'
+        && typeof relationship.relationship === 'string'
+      )
+    : [];
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
 }
 
 function formatThreadDebtLabel(thread: PlotThread): string {
@@ -637,12 +767,13 @@ function selectRelationshipPressure(
   storyState: StoryStateSnapshot,
   continuationBrief: string | undefined
 ): RelationshipPressureSelection | undefined {
-  const source = normalizeActivationText(continuationBrief ?? '');
+  const source = normalizeActivationText(continuationBrief);
   const candidates: RelationshipPressureSelection[] = [];
+  const characters = getStateCharacters(storyState);
 
-  for (const sourceCharacter of storyState.characters) {
-    for (const relationship of sourceCharacter.relationships) {
-      const targetCharacter = storyState.characters.find(candidate => candidate.id === relationship.characterId);
+  for (const sourceCharacter of characters) {
+    for (const relationship of getCharacterRelationships(sourceCharacter)) {
+      const targetCharacter = characters.find(candidate => candidate.id === relationship.characterId);
       if (targetCharacter) {
         candidates.push({
           sourceCharacter,
@@ -680,14 +811,14 @@ function getRelationshipActivationCandidates(
   relationship: CharacterProfile['relationships'][number]
 ): string[] {
   return [
-    sourceCharacter.displayName,
-    targetCharacter.displayName,
-    relationship.relationship,
-    relationship.notes
+    safeString(sourceCharacter.displayName),
+    safeString(targetCharacter.displayName),
+    safeString(relationship.relationship),
+    safeString(relationship.notes)
   ];
 }
 
-function scoreActivationCandidates(candidates: string[], source: string): number {
+function scoreActivationCandidates(candidates: unknown[], source: string): number {
   if (!source) {
     return 0;
   }
@@ -731,13 +862,13 @@ function extractAcceptedMemoryCardSection(continuationBrief = ''): string {
   return pinnedStart === -1 ? acceptedText : acceptedText.slice(0, pinnedStart);
 }
 
-function formatCourtroomDetail(value: string): string {
+function formatCourtroomDetail(value: unknown): string {
   const detail = compactPromptLine(value);
   return detail ? ` - ${detail}` : '';
 }
 
-function compactPromptLine(value: string): string {
-  const compacted = collapseWhitespace(value).trim();
+function compactPromptLine(value: unknown): string {
+  const compacted = collapseWhitespace(safeString(value)).trim();
   if (compacted.length <= CONTINUITY_COURTROOM_MAX_DETAIL_LENGTH) {
     return compacted;
   }
@@ -747,18 +878,18 @@ function compactPromptLine(value: string): string {
 
 function buildChapterEndingStressTestBrief(storyState: StoryStateSnapshot, continuationBrief: string | undefined): string {
   const selectedPressure = chooseChapterEndingPressure(storyState, continuationBrief);
-  return [
+  return limitGuidanceSection([
     'Chapter Ending Stress Test:',
     `- Endings: ${CHAPTER_ENDING_PRESSURES.map(pressure => pressure.candidateLabel).join(', ')}.`,
     `- Chosen: ${selectedPressure.label} - ${selectedPressure.instruction}`,
     `- Scene pressure mix: ${chooseScenePressureMix(storyState, continuationBrief, selectedPressure)}.`,
     '- Answer one question; leave one sharper.'
-  ].join('\n');
+  ], CHAPTER_ENDING_STRESS_TEST_MAX_SECTION_LENGTH) ?? '';
 }
 
 function chooseChapterEndingPressure(storyState: StoryStateSnapshot, continuationBrief: string | undefined): ChapterEndingPressure {
-  const unresolvedThreads = storyState.threads.filter(isUnresolvedThread);
-  const unresolvedArtifacts = storyState.artifacts.filter(artifact => !artifact.resolvedInChapter);
+  const unresolvedThreads = getStateThreads(storyState).filter(isUnresolvedThread);
+  const unresolvedArtifacts = getStateArtifacts(storyState).filter(artifact => !artifact.resolvedInChapter);
   const pressureSource = buildContinuationPressureSource(storyState, continuationBrief);
   const scores: Record<ChapterEndingPressureId, number> = {
     emotional_reveal: 1,
@@ -782,7 +913,7 @@ function chooseChapterEndingPressure(storyState: StoryStateSnapshot, continuatio
     scores.secret_exposed += 3;
   }
 
-  if (unresolvedArtifacts.length > 0 || storyState.continuityWarnings.length > 0) {
+  if (unresolvedArtifacts.length > 0 || getStateContinuityWarnings(storyState).length > 0) {
     scores.secret_exposed += 2;
   }
 
@@ -804,12 +935,12 @@ function chooseScenePressureMix(
     secondaryCandidates.push('Deadline');
   }
 
-  if (storyState.artifacts.some(artifact => !artifact.resolvedInChapter)
+  if (getStateArtifacts(storyState).some(artifact => !artifact.resolvedInChapter)
     || containsAny(pressureSource, ['court', 'room', 'place', 'reef', 'shell', 'song', 'door', 'hall'])) {
     secondaryCandidates.push('Setting');
   }
 
-  if (storyState.characters.length > 1
+  if (getStateCharacters(storyState).length > 1
     || containsAny(pressureSource, ['family', 'crowd', 'witness', 'lord', 'queen', 'council'])) {
     secondaryCandidates.push('Social');
   }
@@ -861,23 +992,27 @@ function containsAny(value: string, needles: readonly string[]): boolean {
 }
 
 function buildContinuationPressureSource(storyState: StoryStateSnapshot, continuationBrief: string | undefined): string {
-  const unresolvedThreads = storyState.threads.filter(isUnresolvedThread);
-  const unresolvedArtifacts = storyState.artifacts.filter(artifact => !artifact.resolvedInChapter);
+  const unresolvedThreads = getStateThreads(storyState).filter(isUnresolvedThread);
+  const unresolvedArtifacts = getStateArtifacts(storyState).filter(artifact => !artifact.resolvedInChapter);
   return [
     continuationBrief ?? '',
-    ...unresolvedThreads.flatMap(thread => [thread.label, thread.description, ...thread.foreshadowedDevices]),
-    ...unresolvedArtifacts.map(artifact => `${artifact.name} ${artifact.significance}`),
-    ...storyState.continuityWarnings
+    ...unresolvedThreads.flatMap(thread => [
+      safeString(thread.label),
+      safeString(thread.description),
+      ...getThreadForeshadowedDevices(thread)
+    ]),
+    ...unresolvedArtifacts.map(artifact => `${safeString(artifact.name)} ${safeString(artifact.significance)}`),
+    ...getStateContinuityWarnings(storyState)
   ].join(' ').toLowerCase();
 }
 
 function buildClicheAlarmBrief(storyState: StoryStateSnapshot, continuationBrief: string | undefined): string {
-  return [
+  return limitGuidanceSection([
     'Cliche Alarm:',
     `- Avoid: ${chooseClicheAlarmPath(storyState, continuationBrief)}`,
     `- Freshness: turn ${chooseFreshnessTarget(storyState)} with visible cost.`,
     `- Subtext receipt: prove ${chooseSubtextReceiptTarget(storyState, continuationBrief)} by behavior before explanation.`
-  ].join('\n');
+  ], CLICHE_ALARM_MAX_SECTION_LENGTH) ?? '';
 }
 
 function chooseClicheAlarmPath(storyState: StoryStateSnapshot, continuationBrief: string | undefined): string {
@@ -898,14 +1033,15 @@ function chooseClicheAlarmPath(storyState: StoryStateSnapshot, continuationBrief
 }
 
 function chooseFreshnessTarget(storyState: StoryStateSnapshot): string {
-  const thread = storyState.threads.find(candidate => candidate.status === 'escalating')
-    ?? storyState.threads.find(candidate => candidate.status === 'active')
-    ?? storyState.threads.find(isUnresolvedThread);
+  const threads = getStateThreads(storyState);
+  const thread = threads.find(candidate => candidate.status === 'escalating')
+    ?? threads.find(candidate => candidate.status === 'active')
+    ?? threads.find(isUnresolvedThread);
   if (thread) {
     return compactPromptLine(thread.label);
   }
 
-  const artifact = storyState.artifacts.find(candidate => !candidate.resolvedInChapter);
+  const artifact = getStateArtifacts(storyState).find(candidate => !candidate.resolvedInChapter);
   if (artifact) {
     return compactPromptLine(artifact.name);
   }

--- a/api/story/stream.ts
+++ b/api/story/stream.ts
@@ -9,11 +9,12 @@
 import { StoryService } from '../_lib/services/storyService';
 import { randomUUID } from 'node:crypto';
 import { applyCorsPolicy } from '../_lib/http/corsPolicy';
-import { StoryGenerationSeam, StreamingStoryGenerationSeam } from '../_lib/types/contracts';
+import { StoryGenerationSeam, StreamingStoryGenerationSeam, VALIDATION_RULES } from '../_lib/types/contracts';
 import { logInfo, logError, logWarn } from '../_lib/utils/logger';
 
 const storyService = new StoryService();
 const VALID_REQUESTED_CHAPTER_COUNTS = new Set([1, 2, 3]);
+const VALID_STREAMING_WORD_COUNTS = new Set<number>(VALIDATION_RULES.wordCount.allowedValues);
 
 /**
  * GET/POST /api/story/stream
@@ -72,14 +73,14 @@ export default async function handler(req: any, res: any) {
       input.spicyLevel < 1 ||
       input.spicyLevel > 5 ||
       !Number.isInteger(input.wordCount) ||
-      input.wordCount < 1
+      !VALID_STREAMING_WORD_COUNTS.has(input.wordCount)
     ) {
       logWarn('Invalid streaming input', { requestId, endpoint: '/api/story/stream' }, { receivedFields: input ? Object.keys(input) : [] });
       return res.status(400).json({
         success: false,
         error: { 
           code: 'INVALID_INPUT', 
-          message: 'Invalid or missing fields: creature, themes, spicyLevel, wordCount'
+          message: `Invalid or missing fields: creature, themes, spicyLevel, wordCount. wordCount must be one of ${VALIDATION_RULES.wordCount.allowedValues.join(', ')}.`
         }
       });
     }

--- a/tests/story-lab-real-engine.test.ts
+++ b/tests/story-lab-real-engine.test.ts
@@ -9,7 +9,10 @@ import {
   toClassicGenerationInput
 } from '../api/_lib/story-lab/storyLabEngine';
 import { getAuthorStylesForCreature } from '../api/_lib/config/authorStyles';
-import type { StoryGenerationSeam as LabGenerationSeam } from '../api/_lib/story-lab/contracts';
+import type {
+  StoryGenerationSeam as LabGenerationSeam,
+  StoryStateSnapshot
+} from '../api/_lib/story-lab/contracts';
 import type {
   ChapterContinuationSeam as ClassicContinuationSeam,
   CreatureType,
@@ -516,6 +519,180 @@ withEnv({ XAI_API_KEY: 'test-key', STORY_LAB_FORCE_MOCK: 'true' }, () => {
       'subtext receipt should reach the real continuation seam as behavior-first guidance'
     );
     assert((capturedInput?.userInput?.length ?? 0) <= 900, 'hidden continuation anchors should stay under the compactness budget');
+  });
+
+  await withEnvAsync({ XAI_API_KEY: 'test-key', STORY_LAB_FORCE_MOCK: undefined, NODE_ENV: undefined, VERCEL_ENV: undefined }, async () => {
+    let capturedInput: ClassicContinuationSeam['input'] | undefined;
+    const longText = 'Ninth mirror debt '.repeat(60).trim();
+    const richState: StoryStateSnapshot = {
+      ...payload.state,
+      threads: Array.from({ length: 6 }, (_item, index) => ({
+        id: `story-test-long-thread-${index}`,
+        label: index === 0 ? 'Ninth Mirror Debt' : `Long Court Debt ${index}`,
+        status: index % 2 === 0 ? 'escalating' as const : 'active' as const,
+        description: `${longText} thread ${index} must not overflow the hidden guidance budget.`,
+        foreshadowedDevices: [`Mirror shard ${index}`, `${longText} device ${index}`],
+        lifetime: 'series' as const
+      })),
+      artifacts: Array.from({ length: 4 }, (_item, index) => ({
+        id: `story-test-long-artifact-${index}`,
+        name: `Ninth Mirror ${index}`,
+        significance: `${longText} artifact ${index} keeps repeating expensive court context.`,
+        introducedInChapter: 1
+      })),
+      continuityWarnings: Array.from({ length: 5 }, (_item, index) =>
+        `${longText} warning ${index} should be selected deterministically without overrunning the budget.`
+      )
+    };
+
+    const response = await continueStoryLab({
+      storyId: payload.summary.storyId,
+      chapterBatchSize: 1,
+      storyState: richState,
+      previouslyGeneratedChapters: payload.batch.chapters,
+      continuationBrief: 'Focus on the ninth mirror debt.',
+      existingSummary: payload.summary
+    }, {
+      serviceFactory: () => ({
+        generateStory: async () => {
+          throw new Error('generateStory should not be called by hidden-guidance budget test');
+        },
+        continueChapter: async input => {
+          capturedInput = input;
+          return {
+            success: true,
+            data: {
+              chapterId: 'chapter-2',
+              chapterNumber: 2,
+              title: 'Budgeted Mirror',
+              content: '<h3>Chapter 2: Budgeted Mirror</h3><p>The mirror debt narrowed.</p>',
+              rawContent: '<p>[Mira]: "Name the mirror."</p>',
+              wordCount: 8,
+              cliffhangerEnding: true,
+              themesContinued: ['forbidden_love'],
+              spicyLevelMaintained: 3,
+              appendedToStory: '<h3>Chapter 2: Budgeted Mirror</h3><p>The mirror debt narrowed.</p>',
+              tropeMetadata: payload.summary.tropeMetadata,
+              chapters: [{
+                chapterId: 'chapter-2',
+                chapterNumber: 2,
+                title: 'Budgeted Mirror',
+                content: '<h3>Chapter 2: Budgeted Mirror</h3><p>The mirror debt narrowed.</p>',
+                rawContent: '<p>[Mira]: "Name the mirror."</p>',
+                wordCount: 8,
+                generatedAt: new Date(),
+                hasAudio: false,
+                cliffhangerEnding: true
+              }],
+              totalWordCount: 8
+            }
+          };
+        }
+      })
+    });
+
+    const providerBrief = capturedInput?.userInput ?? '';
+    const hiddenGuidance = providerBrief.replace('Focus on the ninth mirror debt.', '').trim();
+    assert(response.success, 'continuation with rich hidden guidance should succeed');
+    assert(providerBrief.includes('Continuity Courtroom:'), 'budgeted guidance should retain the courtroom heading');
+    assert(providerBrief.includes('Pressure rising: Ninth Mirror Debt'), 'activated long thread should remain selected first');
+    assert(providerBrief.includes('Chapter Ending Stress Test:'), 'budgeted guidance should retain ending strategy');
+    assert(providerBrief.includes('Cliche Alarm:'), 'budgeted guidance should retain freshness guidance');
+    assert(hiddenGuidance.length <= 860, 'assembled hidden guidance should stay inside its documented budget');
+  });
+
+  await withEnvAsync({ XAI_API_KEY: 'test-key', STORY_LAB_FORCE_MOCK: undefined, NODE_ENV: undefined, VERCEL_ENV: undefined }, async () => {
+    let capturedInput: ClassicContinuationSeam['input'] | undefined;
+    const partialState = {
+      ...payload.state,
+      threads: [{
+        id: 'story-test-partial-thread',
+        label: 'Partial Oath',
+        status: 'active' as const
+      }],
+      characters: [
+        {
+          id: 'mira',
+          displayName: 'Mira',
+          archetype: 'protagonist',
+          summary: 'A diplomat with stale partial continuity.',
+          currentGoal: 'Protect the oath.',
+          internalConflict: '',
+          externalConflict: '',
+          secrets: [],
+          relationships: [{
+            characterId: 'lord-brine',
+            relationship: 'rival'
+          }],
+          spiceCompatibilities: [3]
+        },
+        {
+          id: 'lord-brine',
+          displayName: 'Lord Brine',
+          archetype: 'antagonist',
+          summary: 'A rival in a partial relationship edge.',
+          currentGoal: 'Collect the debt.',
+          internalConflict: '',
+          externalConflict: '',
+          secrets: [],
+          spiceCompatibilities: [3]
+        }
+      ],
+      continuityWarnings: [undefined, 'Carry the partial oath forward.']
+    } as unknown as StoryStateSnapshot;
+
+    const response = await continueStoryLab({
+      storyId: payload.summary.storyId,
+      chapterBatchSize: 1,
+      storyState: partialState,
+      previouslyGeneratedChapters: payload.batch.chapters,
+      continuationBrief: undefined,
+      existingSummary: payload.summary
+    }, {
+      serviceFactory: () => ({
+        generateStory: async () => {
+          throw new Error('generateStory should not be called by partial continuity test');
+        },
+        continueChapter: async input => {
+          capturedInput = input;
+          return {
+            success: true,
+            data: {
+              chapterId: 'chapter-2',
+              chapterNumber: 2,
+              title: 'Partial Oath',
+              content: '<h3>Chapter 2: Partial Oath</h3><p>Mira protected the oath.</p>',
+              rawContent: '<p>[Mira]: "The oath remains."</p>',
+              wordCount: 8,
+              cliffhangerEnding: true,
+              themesContinued: ['forbidden_love'],
+              spicyLevelMaintained: 3,
+              appendedToStory: '<h3>Chapter 2: Partial Oath</h3><p>Mira protected the oath.</p>',
+              tropeMetadata: payload.summary.tropeMetadata,
+              chapters: [{
+                chapterId: 'chapter-2',
+                chapterNumber: 2,
+                title: 'Partial Oath',
+                content: '<h3>Chapter 2: Partial Oath</h3><p>Mira protected the oath.</p>',
+                rawContent: '<p>[Mira]: "The oath remains."</p>',
+                wordCount: 8,
+                generatedAt: new Date(),
+                hasAudio: false,
+                cliffhangerEnding: true
+              }],
+              totalWordCount: 8
+            }
+          };
+        }
+      })
+    });
+
+    const providerBrief = capturedInput?.userInput ?? '';
+    assert(response.success, 'partial continuity state should not break continuation guidance');
+    assert(providerBrief.includes('Partial Oath'), 'thread label should survive when description/devices are missing');
+    assert(providerBrief.includes('Mira and Lord Brine'), 'relationship pressure should tolerate missing optional notes');
+    assert(providerBrief.includes('Carry the partial oath forward.'), 'valid continuity warning should survive stale warning entries');
+    assert(!providerBrief.includes('undefined'), 'partial continuity state should not inject undefined into hidden guidance');
   });
 
   console.log('Story Lab real-engine mapping tests passed');

--- a/tests/story-service-improved.test.ts
+++ b/tests/story-service-improved.test.ts
@@ -444,8 +444,34 @@ const testSuite = {
       console.log(`   ✓ Appended story word count: ${continuation.totalWordCount}`);
     });
   }),
+
+  // Test 10: Streaming mock mode rejects oversized word counts before emitting chunks
+  testStreamingRejectsOversizedMockWordCount: test('Streaming Mock Mode Rejects Oversized Word Count', async () => {
+    await withMockGrok(async () => {
+      const service = new StoryService();
+      let chunkCount = 0;
+      const input: StoryGenerationSeam['input'] = {
+        creature: 'vampire',
+        themes: ['forbidden_love'],
+        userInput: 'A streaming request that should be rejected before mock generation.',
+        spicyLevel: 3,
+        wordCount: 5000 as any
+      };
+
+      try {
+        await service.generateStoryStreaming(input, () => {
+          chunkCount++;
+        });
+        throw new Error('oversized streaming mock request should have been rejected');
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toContain('Invalid word count');
+        expect(chunkCount).toBe(0);
+      }
+    });
+  }),
   
-  // Test 10: Performance test
+  // Test 11: Performance test
   testPerformance: test('Performance Benchmarking', async () => {
     const service = new StoryService();
     const iterations = 3;


### PR DESCRIPTION
## Summary
- Cap assembled hidden continuation guidance at 860 characters with per-section budgets while preserving Continuity Courtroom, Chapter Ending Stress Test, and Cliche Alarm anchors.
- Harden continuation activation helpers against stale or partial continuity state so missing descriptions/devices/relationships/warnings fail closed instead of leaking `undefined`.
- Bound no-key mock generation work with incremental word tracking and reject oversized classic stream word counts before SSE opens.

Closes #142.
Closes #143.
Closes #144.

## Validation
- `npm run recovery:preflight -- story-quality-guidance` passed and wrote `tmp/recovery/story-quality-guidance-evidence.md`.
- `scripts/recovery/check-vercel-function-count.sh` passed at `11/12` inside preflight.
- `npm run test:story-lab-real-engine` passed inside preflight.
- `npm run test:story-quality` passed inside preflight.
- `npm run test:story` passed inside preflight with `15` tests.
- API TypeScript check passed inside preflight with the Node 20 wrapper.
- Oversized `/api/story/stream` GET smoke with `wordCount=5000` returned `400 INVALID_INPUT` before opening the stream.

## Non-Claims
- No auth/provider/storage/account/cloud sync changes.
- No durable job or Workflow behavior changes.
- No Angular UI changes.
- No live provider generation proof; this is deterministic guidance and mock-boundary hardening.

## Next Slice
- Review-tooling/comment-policy cleanup for #146.
