### PR TITLE
Tune CodeRabbit docstring coverage policy

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+inheritance: true
+
+reviews:
+  pre_merge_checks:
+    # Fairytales documents public contracts and non-obvious behavior selectively.
+    # A blanket TypeScript/Angular docstring coverage threshold creates noisy
+    # recovery warnings and encourages low-value comments on tests/callbacks.
+    docstrings:
+      mode: "off"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md - Fairytales with Spice
 
-Last updated: 2026-06-21 06:43 EDT
+Last updated: 2026-06-21 14:41 EDT
 
 This file is read automatically by AI coding agents. It is the repo-level operating guide for current Story Lab platform work, recovery work, and autonomous sessions.
 
@@ -47,6 +47,12 @@ Default loop for unpublished Story Lab work:
 6. Stop after the PR is opened or merged; do not begin the next feature on the same branch.
 
 If a branch contains more than one planned slice, stop and split before adding more code. If a branch's upstream is gone, first check whether it was merged into `origin/main`; do not keep working on stale branch tips.
+
+## Review Tooling Policy
+
+CodeRabbit configuration lives in `.coderabbit.yaml`. The repository intentionally disables the blanket docstring-coverage pre-merge check. Do not mass-add JSDoc/docstrings to satisfy a generic percentage threshold.
+
+Add focused documentation when it clarifies public contracts, exported ports/adapters, security/privacy invariants, cross-process storage behavior, or non-obvious story-generation constraints. If a bot asks for broad docstring coverage, treat that as review-tooling drift: tune the tool or open a follow-up issue instead of adding low-value comments.
 
 ## Current Operating Direction
 

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -3059,3 +3059,27 @@ Validation:
 - `git diff --check`: passed.
 - `npm run recovery:preflight -- story-quality-guidance`: passed and wrote `tmp/recovery/story-quality-guidance-evidence.md`; function count stayed `11/12`.
 - Oversized `/api/story/stream` GET smoke with `wordCount=5000`: passed with `400 INVALID_INPUT` before SSE opened.
+
+## 2026-06-21 14:41 EDT - CodeRabbit Docstring Coverage Policy
+
+Actions:
+
+- Addressed issue #146 by inspecting the current repo for CodeRabbit configuration and finding no existing `.coderabbit.yaml`; PR comments showed CodeRabbit was using organization UI configuration.
+- Checked CodeRabbit's current configuration reference: docstring coverage is a pre-merge check with `warning` default mode and `80` default threshold, while repository-root `.coderabbit.yaml` is detected from the branch under review.
+- Added `.coderabbit.yaml` with `reviews.pre_merge_checks.docstrings.mode: "off"` so recovery PRs do not receive generic docstring-coverage warnings.
+- Addressed PR #150 Codex review by adding root `inheritance: true`, preserving organization-level CodeRabbit settings while overriding only the docstring coverage check.
+- Added an `AGENTS.md` review-tooling policy: document public contracts, exported ports/adapters, security/privacy invariants, cross-process storage behavior, and non-obvious story-generation constraints selectively; do not mass-add comments to satisfy a generic percentage.
+- PR #150 CodeRabbit noted that OSS repositories apply only base-branch configuration while reviewing config-file changes, so this PR cannot prove the new config against itself; once merged to `main`, future PRs should use the repo config.
+
+Self-review:
+
+- Good: The decision fixes the noisy warning at the tool boundary instead of degrading TypeScript/Angular code with mechanical docstrings.
+- Problem found: The repo relied on organization UI defaults, so future agents could not see why CodeRabbit was warning about docstrings from local files alone.
+- Problem found: The first PR body implied branch config would apply immediately; CodeRabbit's OSS security rule means config PRs must be evaluated by YAML validity, review comments, and future-PR behavior after merge.
+- Problem found: The first `.coderabbit.yaml` would have disabled docstring coverage but could have dropped inherited organization settings; root inheritance keeps the override narrow.
+- Process correction: review-tool policy belongs in versioned repo config and `AGENTS.md`, not only in chat or bot UI state.
+
+Validation:
+
+- CodeRabbit docs checked: `https://docs.coderabbit.ai/reference/configuration` and `https://docs.coderabbit.ai/getting-started/yaml-configuration`.
+- CodeRabbit inheritance docs checked: `https://docs.coderabbit.ai/configuration/configuration-inheritance`.


### PR DESCRIPTION
## Summary
- Add repo-level `.coderabbit.yaml` to disable CodeRabbit's blanket docstring coverage pre-merge check for future PRs while preserving organization settings with `inheritance: true`.
- Record the Fairytales documentation policy in `AGENTS.md`: document public contracts, exported ports/adapters, security/privacy invariants, cross-process storage behavior, and non-obvious story-generation constraints selectively.
- Record the decision, source docs, CodeRabbit OSS base-branch config nuance, and inheritance follow-up in the PR70 recovery changelog.

Closes #146.

## Decision
FairytaleswithSpice should not enforce a generic TypeScript/Angular docstring coverage threshold right now. The warning was coming from CodeRabbit organization UI defaults, not a visible repo policy. Mass-adding docstrings to callbacks/tests would add noise, so the repo now disables that pre-merge check and keeps selective documentation guidance in versioned files.

## CodeRabbit Config Nuance
CodeRabbit's docs say repo-root `.coderabbit.yaml` is detected for reviews, but CodeRabbit commented on this PR that OSS repositories apply only base-branch configuration when reviewing config-file changes. This PR therefore cannot prove the new config against itself; once merged to `main`, future PRs should use the repo config instead of the organization UI docstring default.

`inheritance: true` is set so the local file only overrides docstring coverage and does not discard existing organization-level review profile, auto-review, path instructions, or tool settings.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".coderabbit.yaml"); puts "coderabbit yaml ok"'` passed.
- `git diff --check` passed.
- `scripts/recovery/check-vercel-function-count.sh` passed at `11/12` before the changelog-only amend; no route files changed.
- Confirmed CodeRabbit docs: `.coderabbit.yaml` at repo root is the repository config file; `reviews.pre_merge_checks.docstrings.mode` supports `off`, `warning`, and `error`, with `warning`/`80` as defaults; configuration inheritance must be explicitly enabled with `inheritance: true` when preserving parent settings.

## Non-Claims
- Does not disable substantive CodeRabbit review comments.
- Does not add broad docstrings or change TypeScript/Angular runtime behavior.
- Does not change Vercel routes, auth, storage, jobs, Story Lab UI, or story generation.
