### PR TITLE
Guard mock story expansion beats

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -3083,3 +3083,23 @@ Validation:
 
 - CodeRabbit docs checked: `https://docs.coderabbit.ai/reference/configuration` and `https://docs.coderabbit.ai/getting-started/yaml-configuration`.
 - CodeRabbit inheritance docs checked: `https://docs.coderabbit.ai/configuration/configuration-inheritance`.
+
+## 2026-06-21 14:55 EDT - Mock Expansion Guard Review Follow-Up
+
+Actions:
+
+- Addressed the post-merge PR #149 Gemini review comment on `expandMockParagraphsToWordTarget`.
+- Filtered expansion beats to positive-word entries before the mock expansion loop so future empty/zero-word mock beats cannot keep the loop from making progress.
+
+Self-review:
+
+- Good: Filtering by counted words removes the infinite-loop class without adding an arbitrary iteration cap.
+- Problem found: The PR #149 comment arrived after the API merge, so the first review audit missed it; the follow-up sweep caught it before final handoff.
+- Process correction: after API-merging a PR, rerun the review-thread query once more because late bot comments can land seconds after merge.
+
+Validation:
+
+- `npm run test:story`: passed with `15` tests.
+- API TypeScript check with the Node 20 wrapper: passed.
+- `git diff --check`: passed.
+- `npm run recovery:preflight -- story-quality-guidance`: passed and rewrote `tmp/recovery/story-quality-guidance-evidence.md`; function count stayed `11/12`.

--- a/api/_lib/services/storyService.ts
+++ b/api/_lib/services/storyService.ts
@@ -1709,13 +1709,19 @@ ${renderBody()}`;
     targetBodyWords: number,
     initialWordCount = this.countWords(paragraphs.join(' '))
   ): void {
+    const countedExpansionBeats = expansionBeats
+      .map(beat => ({
+        beat,
+        wordCount: this.countWords(beat)
+      }))
+      .filter(({ wordCount }) => wordCount > 0);
     let bodyWordCount = initialWordCount;
     let beatIndex = 0;
 
-    while (bodyWordCount < targetBodyWords && expansionBeats.length > 0) {
-      const nextBeat = expansionBeats[beatIndex % expansionBeats.length];
-      paragraphs.push(nextBeat);
-      bodyWordCount += this.countWords(nextBeat);
+    while (bodyWordCount < targetBodyWords && countedExpansionBeats.length > 0) {
+      const nextBeat = countedExpansionBeats[beatIndex % countedExpansionBeats.length];
+      paragraphs.push(nextBeat.beat);
+      bodyWordCount += nextBeat.wordCount;
       beatIndex += 1;
     }
   }


### PR DESCRIPTION
## Summary
- Address the late Gemini review thread from PR #149 on `expandMockParagraphsToWordTarget`.
- Filter mock expansion beats to positive-word entries before the expansion loop, so empty/zero-word beats cannot prevent progress.
- Record the late-comment miss and process correction in the PR70 recovery changelog.

Review thread addressed:
- https://github.com/Phazzie/FairytaleswithSpice/pull/149#discussion_r3448885795

## Validation
- `npm run test:story` passed with `15` tests.
- API TypeScript check with the Node 20 wrapper passed.
- `git diff --check` passed.
- `npm run recovery:preflight -- story-quality-guidance` passed and rewrote `tmp/recovery/story-quality-guidance-evidence.md`; function count stayed `11/12`.

## Non-Claims
- No auth, account, storage, cloud sync, durable job, route, provider, or UI changes.
- No live provider proof; this is deterministic mock-generation hardening.
