### PR TITLE
Fix Story Lab UI review thread follow-ups

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -3133,3 +3133,28 @@ Validation:
 - `git diff --check`: passed.
 - `npm run recovery:status`: passed with expected tracked/untracked files for this slice; function count stayed `11/12`.
 - `scripts/recovery/check-vercel-function-count.sh`: passed at `11/12`.
+
+## 2026-06-21 15:38 EDT - Review Comment Triage UI Cleanup
+
+Actions:
+
+- Began the post-PR #154 unresolved review-thread cleanup from issue #152.
+- Resolved PR #116, #115, #114, and #113 review threads after verifying the fixes or linked issues were present on `main`.
+- Addressed the remaining PR #112 stale villain-pressure fallback by removing unused `selectedVillainPressure` computed state that still depended on option index fallback.
+- Addressed PR #111 Director Room review comments by keeping the Continuity Keeper label/detail from the same continuity item and clearing the custom continuation brief after dispatching accepted Director Room notes.
+- Addressed PR #155 review feedback by making the continuity-item selection an explicit `if`/`else` block instead of a nested ternary.
+- Left the PR #111/#112 code-fix threads unresolved until this cleanup PR lands.
+
+Self-review:
+
+- Good: Resolved threads only after checking current code, linked issues, or reachable refs instead of relying on old chat memory.
+- Problem found: The old PR #112 thread had been answered, but a later narrative-dials refactor left a stale unused fallback computed in place.
+- Problem found: The local ChromeHeadless app-spec run remained flaky and disconnected after capture; this needs to be reported as a runner failure, not claimed as passing.
+
+Validation:
+
+- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`: passed.
+- `git diff --check`: passed.
+- `npm run recovery:preflight -- cloud-library-ui --quick`: passed and wrote `tmp/recovery/cloud-library-ui-evidence.md`; function count stayed `11/12`.
+- `npm run build`: passed; Angular reported the existing Node 23 odd-version warning and stale `baseline-browser-mapping` warning.
+- `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"`: did not pass because ChromeHeadless failed to capture twice, then disconnected after the second retry connected; no Jasmine assertion failure was reported.

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -1108,8 +1108,16 @@ describe('App', () => {
             id: 'oath',
             label: 'Moonlit oath',
             status: 'escalating',
-            description: 'The bargain demands a public sacrifice.',
+            description: '',
             foreshadowedDevices: []
+          }
+        ],
+        artifacts: [
+          {
+            id: 'witness-shell',
+            name: 'Witness Shell',
+            significance: 'The shell repeats any vow spoken near the reef court.',
+            introducedInChapter: 1
           }
         ]
       })
@@ -1123,6 +1131,8 @@ describe('App', () => {
     expect(directorText).toContain('Chapter Ending');
     expect(directorText).toContain('Mara');
     expect(directorText).toContain('Moonlit oath');
+    expect(directorText).toContain('Summary of chapter one.');
+    expect(directorText).not.toContain('The shell repeats any vow spoken near the reef court.');
   });
 
   it('renders a read-only Continuity Preview from current story state', () => {
@@ -1645,6 +1655,7 @@ describe('App', () => {
     acceptButtons?.[0]?.click();
     acceptButtons?.[1]?.click();
     fixture.detectChanges();
+    component.customContinuationBrief.set('Bring the oath back before the next kiss.');
 
     const continueButton = renderedDirectorRoomPanel()?.querySelector('[data-testid="continue-with-director-notes"]') as HTMLButtonElement | null;
     continueButton?.click();
@@ -1656,8 +1667,10 @@ describe('App', () => {
     };
     expect(jobRequest.kind).toBe('continuation');
     expect(jobRequest.continuation.continuationBrief).toContain('Director Room notes');
+    expect(jobRequest.continuation.continuationBrief).toContain('Bring the oath back before the next kiss.');
     expect(jobRequest.continuation.continuationBrief).toContain('Desire Ledger');
     expect(jobRequest.continuation.continuationBrief).toContain('Continuity Keeper');
+    expect(component.customContinuationBrief()).toBe('');
   });
 
   it('renders a villain pressure dial after a story exists', () => {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -424,13 +424,6 @@ export class App implements OnDestroy {
       };
     });
   });
-  readonly selectedVillainPressureId = computed(() =>
-    this.selectedNarrativeDialOptionIds()['villain-pressure'] as VillainPressureId
-  );
-  readonly selectedVillainPressure = computed(() =>
-    this.villainPressureOptions.find(option => option.id === this.selectedVillainPressureId()) ?? this.villainPressureOptions[0]
-  );
-
   readonly timeline = computed<ChapterTimelineEntry[]>(() => {
     const session = this.workbench();
     return session.chapterHistory.map(chapter => ({
@@ -772,8 +765,15 @@ export class App implements OnDestroy {
     const primaryArtifact = continuity.unresolvedArtifacts[0];
     const protagonist = primaryCharacter?.displayName || blueprint.protagonistName?.trim() || 'the lead';
     const currentGoal = primaryCharacter?.currentGoal || `make the ${blueprint.creature} desire more costly`;
-    const continuityLabel = primaryThread?.label || primaryArtifact?.name || 'the current story thread';
-    const continuityDetail = primaryThread?.description || primaryArtifact?.significance || chapter.summary;
+    let continuityLabel = 'the current story thread';
+    let continuityDetail = chapter.summary;
+    if (primaryThread) {
+      continuityLabel = primaryThread.label;
+      continuityDetail = primaryThread.description || chapter.summary;
+    } else if (primaryArtifact) {
+      continuityLabel = primaryArtifact.name;
+      continuityDetail = primaryArtifact.significance || chapter.summary;
+    }
     const endingSuggestion = chapter.hasCliffhanger
       ? 'Pay off the current cliffhanger, then open a harder question before the chapter closes.'
       : 'End the next chapter on an impossible choice instead of a quiet fade-out.';
@@ -1302,6 +1302,7 @@ export class App implements OnDestroy {
     }
 
     this.continueSaga(this.withNarrativeDialBriefs(this.buildDirectorRoomContinuationBrief(acceptedNotes)));
+    this.customContinuationBrief.set('');
   }
 
   getSafeHtml(html: string): string {


### PR DESCRIPTION
## Summary
- remove stale unused villain-pressure computed state that still relied on index fallback
- keep Director Room Continuity Keeper label/detail from the same continuity item
- clear the custom continuation brief after dispatching accepted Director Room notes
- document the #152 review-thread cleanup progress in the recovery changelog

## Review Threads Addressed
- PR #112 stale villain-pressure fallback thread
- PR #111 Continuity Keeper mixed thread/artifact detail thread
- PR #111 custom continuation brief clearing thread

## Validation
- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`
- `git diff --check`
- `npm run recovery:preflight -- cloud-library-ui --quick`
- `npm run build`
- `npm run recovery:status`
- `npm run review:unresolved -- --prs 111,112`

## Known Local Runner Failure
- `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"` did not pass locally because ChromeHeadless failed to capture twice, then disconnected after the second retry connected. No Jasmine assertion failure was reported.
