### PR TITLE
Fix Story Lab batch status review follow-up

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -3158,3 +3158,22 @@ Validation:
 - `npm run recovery:preflight -- cloud-library-ui --quick`: passed and wrote `tmp/recovery/cloud-library-ui-evidence.md`; function count stayed `11/12`.
 - `npm run build`: passed; Angular reported the existing Node 23 odd-version warning and stale `baseline-browser-mapping` warning.
 - `npx -p node@20 -c "node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts"`: did not pass because ChromeHeadless failed to capture twice, then disconnected after the second retry connected; no Jasmine assertion failure was reported.
+
+## 2026-06-21 15:48 EDT - Batch Queue Review Comment Follow-Up
+
+Actions:
+
+- Continued #152 review-thread cleanup after PR #155.
+- Addressed PR #110 by replacing the batch-status `switch` with an exhaustive `Record<BatchProgressState['status'], string>` map.
+- Addressed PR #156 review feedback by adding a defensive fallback for unknown runtime batch statuses and focused spec coverage.
+
+Self-review:
+
+- Good: This is a small still-valid maintainability fix with compile-time exhaustiveness if batch statuses change.
+- Non-claim: This slice does not address the remaining job-route or PR #87 backlog threads.
+
+Validation:
+
+- `npm run recovery:preflight -- cloud-library-ui --quick`: passed and wrote `tmp/recovery/cloud-library-ui-evidence.md`; function count stayed `11/12`.
+- `git diff --check`: passed.
+- `npm run review:unresolved -- --prs 110`: still reports the one PR #110 thread that this slice fixes after merge.

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -1048,6 +1048,12 @@ describe('App', () => {
     expect(queueText).toContain('0 of 1 chapter');
   });
 
+  it('formats unknown batch statuses defensively', () => {
+    expect(component.formatBatchStatus('in_progress')).toBe('In Progress');
+    expect(component.formatBatchStatus('paused' as any)).toBe('paused');
+    expect(component.formatBatchStatus(undefined)).toBe('Unknown');
+  });
+
   it('clears finished batches from the visible batch queue', () => {
     const payload: StoryIterationPayload = {
       summary: createSummary(),

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -180,6 +180,17 @@ type GenerationProgressState = {
   elapsedSeconds: number;
 };
 
+const BATCH_STATUS_LABELS: Record<BatchProgressState['status'], string> = {
+  queued: 'Queued',
+  in_progress: 'In Progress',
+  completed: 'Completed',
+  failed: 'Failed'
+};
+
+function isBatchProgressStatus(status: unknown): status is BatchProgressState['status'] {
+  return typeof status === 'string' && Object.prototype.hasOwnProperty.call(BATCH_STATUS_LABELS, status);
+}
+
 type ActiveStoryLabJobState = {
   jobId: string;
   kind: 'genesis' | 'continuation';
@@ -2670,17 +2681,11 @@ ${chapters}
     return Array.isArray(project.acceptedMemoryCards) ? project.acceptedMemoryCards.length : 0;
   }
 
-  formatBatchStatus(status: BatchProgressState['status']): string {
-    switch (status) {
-      case 'queued':
-        return 'Queued';
-      case 'in_progress':
-        return 'In Progress';
-      case 'completed':
-        return 'Completed';
-      case 'failed':
-        return 'Failed';
+  formatBatchStatus(status: BatchProgressState['status'] | string | null | undefined): string {
+    if (isBatchProgressStatus(status)) {
+      return BATCH_STATUS_LABELS[status];
     }
+    return typeof status === 'string' && status.trim() ? status : 'Unknown';
   }
 
   formatBatchChapterProgress(batch: BatchProgressState): string {


### PR DESCRIPTION
## Summary
- replace `formatBatchStatus` switch with an exhaustive `Record<BatchProgressState['status'], string>` map
- document the #152 PR #110 review-thread follow-up in the recovery changelog

## Review Thread Addressed
- PR #110 batch status formatter maintainability thread

## Validation
- `npm run recovery:preflight -- cloud-library-ui --quick`
- `git diff --check`
- `npm run review:unresolved -- --prs 110`
