### PR TITLE
Harden Story Lab job resume recovery

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -3177,3 +3177,26 @@ Validation:
 - `npm run recovery:preflight -- cloud-library-ui --quick`: passed and wrote `tmp/recovery/cloud-library-ui-evidence.md`; function count stayed `11/12`.
 - `git diff --check`: passed.
 - `npm run review:unresolved -- --prs 110`: still reports the one PR #110 thread that this slice fixes after merge.
+
+## 2026-06-21 16:12 EDT - Resume Review Comment Follow-Up
+
+Actions:
+
+- Continued #152 review-thread cleanup after PR #156.
+- Verified PR #108 and PR #107 are clean after their fixes landed on `main`.
+- Addressed four PR #106 resume-hardening threads by tracking recovered job snapshot subscriptions, clearing them on completion/error, guarding active-job storage through a safe accessor, and rejecting JSON `null` active-job markers without throwing.
+- Turned the remaining PR #106 long-running POST resume-marker contract gap into issue #157 because it requires changing the job creation route contract rather than a bounded UI cleanup.
+
+Self-review:
+
+- Good: The fix keeps the existing non-durable resume behavior honest and only hardens the current client-side recovery path.
+- Problem found: Browser-side resume cannot recover a reload during the initial long POST until job creation returns an early resumable marker; issue #157 tracks that contract change.
+- Non-claim: This slice does not implement durable queueing or early job-create responses.
+
+Validation:
+
+- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`: passed.
+- `npm run recovery:preflight -- cloud-library-ui --quick`: passed and wrote `tmp/recovery/cloud-library-ui-evidence.md`; function count stayed `11/12`.
+- `git diff --check`: passed.
+- `npm run build`: passed; Angular reported the existing Node 23 odd-version warning and stale `baseline-browser-mapping` warning.
+- `npx -p node@20 node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts`: did not execute assertions because ChromeHeadless failed to capture twice and Karma gave up.

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -1917,6 +1917,18 @@ describe('App', () => {
     expect(creation$.observed).toBeFalse();
   });
 
+  it('cancels an in-flight recovered genesis job snapshot on destroy', () => {
+    const restore$ = new Subject<ApiResponse<StoryLabJobCreationResponse<StoryIterationPayload>>>();
+    storeActiveJobMarker();
+    storyService.getStoryLabJob.and.returnValue(restore$.asObservable());
+
+    const recovered = TestBed.createComponent(App).componentInstance;
+
+    expect(restore$.observed).toBeTrue();
+    recovered.ngOnDestroy();
+    expect(restore$.observed).toBeFalse();
+  });
+
   it('stores an active genesis job marker while job snapshots are running', () => {
     const events$ = new Subject<StoryLabJobEvent<StoryIterationPayload>>();
 
@@ -2113,6 +2125,21 @@ describe('App', () => {
     expect(recovered.activeBatchQueue().at(-1)?.label).toBe('Continuation');
   });
 
+  it('cancels an in-flight recovered continuation job snapshot on destroy', () => {
+    const genesisPayload = seedWorkbenchForContinuation();
+    const restore$ = new Subject<ApiResponse<StoryLabJobCreationResponse<ContinuationJobResult>>>();
+    component.saveActiveProject();
+    storeContinuationRecoveryMarker(genesisPayload.summary.storyId);
+    storyService.getStoryLabJob.calls.reset();
+    storyService.getStoryLabJob.and.returnValue(restore$.asObservable());
+
+    const recovered = TestBed.createComponent(App).componentInstance;
+
+    expect(restore$.observed).toBeTrue();
+    recovered.ngOnDestroy();
+    expect(restore$.observed).toBeFalse();
+  });
+
   it('clears an unavailable recovered continuation job with recovery-specific status copy', () => {
     const genesisPayload = seedWorkbenchForContinuation();
     component.saveActiveProject();
@@ -2233,6 +2260,14 @@ describe('App', () => {
 
   it('clears malformed active job storage without crashing startup', () => {
     sessionStorage.setItem(ACTIVE_JOB_STORAGE_KEY, '{not-json');
+
+    expect(() => TestBed.createComponent(App).componentInstance).not.toThrow();
+    expect(sessionStorage.getItem(ACTIVE_JOB_STORAGE_KEY)).toBeNull();
+    expect(storyService.getStoryLabJob).not.toHaveBeenCalled();
+  });
+
+  it('clears null active job storage without crashing startup', () => {
+    sessionStorage.setItem(ACTIVE_JOB_STORAGE_KEY, 'null');
 
     expect(() => TestBed.createComponent(App).componentInstance).not.toThrow();
     expect(sessionStorage.getItem(ACTIVE_JOB_STORAGE_KEY)).toBeNull();

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -1940,7 +1940,7 @@ ${chapters}
       return;
     }
 
-    this.storyService.getStoryLabJob<StoryIterationPayload>(activeJob.jobId).subscribe({
+    const jobCreationSubscription = this.storyService.getStoryLabJob<StoryIterationPayload>(activeJob.jobId).subscribe({
       next: response => {
         if (!response.success || !response.data) {
           const message = this.formatRecoveredRestoreFailureMessage(
@@ -1963,14 +1963,19 @@ ${chapters}
         }
       },
       error: error => {
+        this.jobCreationSubscription = null;
         this.errorLogging.logError(error, 'App.restoreActiveStoryLabJob');
         const message = this.formatRecoveredRestoreFailureMessage(
           activeJob.kind,
           this.formatHttpError(error, '')
         );
         this.failRecoveredStoryLabJob(activeJob.kind, activeJob.batchId, message);
+      },
+      complete: () => {
+        this.jobCreationSubscription = null;
       }
     });
+    this.jobCreationSubscription = jobCreationSubscription.closed ? null : jobCreationSubscription;
   }
 
   private restoreActiveContinuationJob(activeJob: ActiveStoryLabJobState) {
@@ -1994,7 +1999,7 @@ ${chapters}
       return;
     }
 
-    this.storyService.getStoryLabJob<ContinuationJobResult>(activeJob.jobId).subscribe({
+    const jobCreationSubscription = this.storyService.getStoryLabJob<ContinuationJobResult>(activeJob.jobId).subscribe({
       next: response => {
         if (!response.success || !response.data) {
           const message = this.formatRecoveredRestoreFailureMessage(
@@ -2017,14 +2022,19 @@ ${chapters}
         }
       },
       error: error => {
+        this.jobCreationSubscription = null;
         this.errorLogging.logError(error, 'App.restoreActiveContinuationJob');
         const message = this.formatRecoveredRestoreFailureMessage(
           activeJob.kind,
           this.formatHttpError(error, '')
         );
         this.failRecoveredStoryLabJob(activeJob.kind, activeJob.batchId, message);
+      },
+      complete: () => {
+        this.jobCreationSubscription = null;
       }
     });
+    this.jobCreationSubscription = jobCreationSubscription.closed ? null : jobCreationSubscription;
   }
 
   private ensureRecoveredBatch(activeJob: ActiveStoryLabJobState) {
@@ -2047,47 +2057,55 @@ ${chapters}
   }
 
   private storeActiveStoryLabJob(activeJob: ActiveStoryLabJobState) {
-    if (typeof sessionStorage === 'undefined') {
+    const storage = this.getActiveJobStorage();
+    if (!storage) {
       return;
     }
 
     try {
-      sessionStorage.setItem(this.activeJobStorageKey, JSON.stringify(activeJob));
+      storage.setItem(this.activeJobStorageKey, JSON.stringify(activeJob));
     } catch {
       this.workspaceSaveStatus.set('Story job progress will last until this tab closes.');
     }
   }
 
   private readActiveStoryLabJob(): ActiveStoryLabJobState | null {
-    if (typeof sessionStorage === 'undefined') {
+    const storage = this.getActiveJobStorage();
+    if (!storage) {
       return null;
     }
 
     let rawJob: string | null = null;
     try {
-      rawJob = sessionStorage.getItem(this.activeJobStorageKey);
+      rawJob = storage.getItem(this.activeJobStorageKey);
       if (!rawJob) {
         return null;
       }
 
-      const parsed = JSON.parse(rawJob) as Partial<ActiveStoryLabJobState>;
+      const parsed = JSON.parse(rawJob) as unknown;
+      if (!parsed || typeof parsed !== 'object') {
+        this.clearActiveStoryLabJob();
+        return null;
+      }
+
+      const activeJob = parsed as Partial<ActiveStoryLabJobState>;
       if (
-        typeof parsed.jobId === 'string'
-        && (parsed.kind === 'genesis' || parsed.kind === 'continuation')
-        && typeof parsed.batchId === 'string'
-        && this.isChapterBatchSize(parsed.batchSize)
-        && typeof parsed.statusPath === 'string'
-        && typeof parsed.startedAt === 'string'
-        && (parsed.kind === 'genesis' || typeof parsed.storyId === 'string')
+        typeof activeJob.jobId === 'string'
+        && (activeJob.kind === 'genesis' || activeJob.kind === 'continuation')
+        && typeof activeJob.batchId === 'string'
+        && this.isChapterBatchSize(activeJob.batchSize)
+        && typeof activeJob.statusPath === 'string'
+        && typeof activeJob.startedAt === 'string'
+        && (activeJob.kind === 'genesis' || typeof activeJob.storyId === 'string')
       ) {
         return {
-          jobId: parsed.jobId,
-          kind: parsed.kind,
-          batchId: parsed.batchId,
-          batchSize: parsed.batchSize,
-          statusPath: parsed.statusPath,
-          startedAt: parsed.startedAt,
-          storyId: parsed.kind === 'continuation' ? parsed.storyId : undefined
+          jobId: activeJob.jobId,
+          kind: activeJob.kind,
+          batchId: activeJob.batchId,
+          batchSize: activeJob.batchSize,
+          statusPath: activeJob.statusPath,
+          startedAt: activeJob.startedAt,
+          storyId: activeJob.kind === 'continuation' ? activeJob.storyId : undefined
         };
       }
     } catch {
@@ -2100,14 +2118,23 @@ ${chapters}
   }
 
   private clearActiveStoryLabJob() {
-    if (typeof sessionStorage === 'undefined') {
+    const storage = this.getActiveJobStorage();
+    if (!storage) {
       return;
     }
 
     try {
-      sessionStorage.removeItem(this.activeJobStorageKey);
+      storage.removeItem(this.activeJobStorageKey);
     } catch {
       // Ignore storage cleanup failures; the job state is only a reload hint.
+    }
+  }
+
+  private getActiveJobStorage(): Storage | null {
+    try {
+      return globalThis.sessionStorage ?? null;
+    } catch {
+      return null;
     }
   }
 


### PR DESCRIPTION
## Summary
- Track recovered genesis and continuation job snapshot subscriptions so `ngOnDestroy()` cancels in-flight restore requests.
- Guard active job storage through a safe `sessionStorage` accessor and reject JSON `null` active-job markers without throwing.
- Add focused regression specs and changelog evidence for PR #106 review-thread cleanup.
- Track the remaining long-running POST resume-marker contract gap as #157 instead of hiding it in a resolved thread.

## Validation
- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`
- `npm run recovery:preflight -- cloud-library-ui --quick`
- `git diff --check`
- `npm run build`
- `npx -p node@20 node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts` did not execute assertions because ChromeHeadless failed to capture twice and Karma gave up.

## Non-Claims
- Does not implement early resumable job-create responses or durable queueing; #157 tracks that route-contract work.