### PR TITLE
Close genesis job subscription on failure

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -3200,3 +3200,24 @@ Validation:
 - `git diff --check`: passed.
 - `npm run build`: passed; Angular reported the existing Node 23 odd-version warning and stale `baseline-browser-mapping` warning.
 - `npx -p node@20 node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/app.spec.ts`: did not execute assertions because ChromeHeadless failed to capture twice and Karma gave up.
+
+## 2026-06-21 16:18 EDT - Genesis Subscription Review Comment Follow-Up
+
+Actions:
+
+- Continued #152 review-thread cleanup after PR #158.
+- Addressed the remaining PR #105 genesis subscription cleanup by making failed job paths close all tracked job subscriptions, not only the event stream.
+- Addressed PR #159 review feedback by applying the same cleanup to continuation and recovered-job failures.
+- Added regression specs for genesis creation, continuation creation, recovered genesis, and recovered continuation failures that do not complete, proving their subscriptions are immediately unsubscribed.
+
+Self-review:
+
+- Good: The fix uses the existing generalized `jobCreationSubscription` and `closeJobSubscriptions()` path instead of adding duplicate job-type-specific subscription helpers.
+- Non-claim: This slice does not change the job route contract or durable queue behavior.
+
+Validation:
+
+- `git diff --check`: passed.
+- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`: passed.
+- `npm run recovery:preflight -- cloud-library-ui --quick`: passed and wrote `tmp/recovery/cloud-library-ui-evidence.md`; function count stayed `11/12`.
+- `npm run build`: passed; Angular reported the existing Node 23 odd-version warning and stale `baseline-browser-mapping` warning.

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -1917,6 +1917,27 @@ describe('App', () => {
     expect(creation$.observed).toBeFalse();
   });
 
+  it('cancels an in-flight genesis job creation subscription when creation fails', () => {
+    const creation$ = new Subject<ApiResponse<StoryLabJobCreationResponse<StoryIterationPayload>>>();
+    storyService.createStoryLabJob.and.returnValue(creation$.asObservable());
+    configureValidBlueprint('A witch queen bargains with a haunted mirror.');
+
+    component.startGenesis();
+
+    expect(creation$.observed).toBeTrue();
+
+    creation$.next({
+      success: false,
+      error: {
+        code: 'STORY_LAB_JOB_FAILED',
+        message: 'Story generation failed.'
+      }
+    });
+
+    expect(creation$.observed).toBeFalse();
+    expect(component.activeBatchQueue().at(-1)?.status).toBe('failed');
+  });
+
   it('cancels an in-flight recovered genesis job snapshot on destroy', () => {
     const restore$ = new Subject<ApiResponse<StoryLabJobCreationResponse<StoryIterationPayload>>>();
     storeActiveJobMarker();
@@ -1927,6 +1948,28 @@ describe('App', () => {
     expect(restore$.observed).toBeTrue();
     recovered.ngOnDestroy();
     expect(restore$.observed).toBeFalse();
+  });
+
+  it('cancels an in-flight recovered genesis job snapshot when recovery fails', () => {
+    const restore$ = new Subject<ApiResponse<StoryLabJobCreationResponse<StoryIterationPayload>>>();
+    storeActiveJobMarker();
+    storyService.getStoryLabJob.and.returnValue(restore$.asObservable());
+
+    const recovered = TestBed.createComponent(App).componentInstance;
+
+    expect(restore$.observed).toBeTrue();
+
+    restore$.next({
+      success: false,
+      error: {
+        code: 'JOB_STORE_UNAVAILABLE',
+        message: 'Story Lab job storage is not configured.'
+      }
+    });
+
+    expect(restore$.observed).toBeFalse();
+    expect(recovered.generationProgress().active).toBeFalse();
+    expect(recovered.statusMessage()).toBe('Story Lab job storage is not configured.');
   });
 
   it('stores an active genesis job marker while job snapshots are running', () => {
@@ -2065,6 +2108,27 @@ describe('App', () => {
     expect(marker.batchId).toMatch(/^batch-/);
   });
 
+  it('cancels an in-flight continuation job creation subscription when creation fails', () => {
+    const creation$ = new Subject<ApiResponse<StoryLabJobCreationResponse<ContinuationJobResult>>>();
+    seedWorkbenchForContinuation();
+    storyService.createStoryLabJob.and.returnValue(creation$.asObservable());
+
+    component.continueSaga('Make the betrayal more dangerous.');
+
+    expect(creation$.observed).toBeTrue();
+
+    creation$.next({
+      success: false,
+      error: {
+        code: 'STORY_LAB_JOB_FAILED',
+        message: 'Continuation failed.'
+      }
+    });
+
+    expect(creation$.observed).toBeFalse();
+    expect(component.activeBatchQueue().at(-1)?.status).toBe('failed');
+  });
+
   it('persists accepted and pinned memory cards before continuation job recovery', () => {
     const genesisPayload = seedMaraMemoryCardWorkbench();
     const events$ = new Subject<StoryLabJobEvent<ContinuationJobResult>>();
@@ -2138,6 +2202,31 @@ describe('App', () => {
     expect(restore$.observed).toBeTrue();
     recovered.ngOnDestroy();
     expect(restore$.observed).toBeFalse();
+  });
+
+  it('cancels an in-flight recovered continuation job snapshot when recovery fails', () => {
+    const genesisPayload = seedWorkbenchForContinuation();
+    const restore$ = new Subject<ApiResponse<StoryLabJobCreationResponse<ContinuationJobResult>>>();
+    component.saveActiveProject();
+    storeContinuationRecoveryMarker(genesisPayload.summary.storyId);
+    storyService.getStoryLabJob.calls.reset();
+    storyService.getStoryLabJob.and.returnValue(restore$.asObservable());
+
+    const recovered = TestBed.createComponent(App).componentInstance;
+
+    expect(restore$.observed).toBeTrue();
+
+    restore$.next({
+      success: false,
+      error: {
+        code: 'JOB_STORE_UNAVAILABLE',
+        message: 'Story Lab job storage is not configured.'
+      }
+    });
+
+    expect(restore$.observed).toBeFalse();
+    expect(recovered.generationProgress().active).toBeFalse();
+    expect(recovered.statusMessage()).toBe('Story Lab job storage is not configured.');
   });
 
   it('clears an unavailable recovered continuation job with recovery-specific status copy', () => {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -1846,7 +1846,7 @@ ${chapters}
   private failGenesisJob(batchId: string, message: string) {
     this.clearActiveStoryLabJob();
     this.clearJobStatusPanel();
-    this.closeJobEventSubscription();
+    this.closeJobSubscriptions();
     this.statusMessage.set(message);
     this.markBatchFailed(batchId, message);
     this.notificationService.error('Generation failed', message);
@@ -1861,7 +1861,7 @@ ${chapters}
   private failContinuationJob(batchId: string, message: string) {
     this.clearActiveStoryLabJob();
     this.clearJobStatusPanel();
-    this.closeJobEventSubscription();
+    this.closeJobSubscriptions();
     this.statusMessage.set(message);
     this.markBatchFailed(batchId, message);
     this.notificationService.error('Continuation failed', message);
@@ -1872,7 +1872,7 @@ ${chapters}
   private failRecoveredStoryLabJob(kind: ActiveStoryLabJobState['kind'], batchId: string, message: string) {
     this.clearActiveStoryLabJob();
     this.clearJobStatusPanel();
-    this.closeJobEventSubscription();
+    this.closeJobSubscriptions();
     this.statusMessage.set(message);
     this.markBatchFailed(batchId, message);
     this.notificationService.warning(


### PR DESCRIPTION
## Summary
- Close all tracked job subscriptions from `failGenesisJob()` so failed genesis creation cannot leave the creation subscription active.
- Add a regression spec for a failed genesis job creation response that does not complete.
- Record the PR #105 review-thread follow-up in the recovery changelog.

## Validation
- `git diff --check`
- `npx -p node@20 node ./node_modules/typescript/bin/tsc -p story-generator/tsconfig.spec.json --noEmit`
- `npm run recovery:preflight -- cloud-library-ui --quick`
- `npm run build`

## Non-Claims
- Does not change the Story Lab job route contract or durable queue behavior.