### PR TITLE
Fix exact last-40 PR audit guidance

### DIFF
--- a/STORY_LAB_FINAL_MERGE_AUDIT_EXEC_PLAN.md
+++ b/STORY_LAB_FINAL_MERGE_AUDIT_EXEC_PLAN.md
@@ -397,16 +397,15 @@ Steps:
 mkdir -p tmp/recovery
 ```
 
-2. Generate the exact last-40 PR list by PR number, not by `gh pr list`'s default ordering:
+2. Generate the exact last-40 PR list by PR number, not by `gh pr list`'s default ordering. Do not use a contiguous numeric range: GitHub PR numbers share the issue number space, so some numbers are issues rather than PRs.
 
 ```bash
-latest_pr=$(env -u GH_PAGER GH_NO_UPDATE_NOTIFIER=1 gh api 'repos/Phazzie/FairytaleswithSpice/pulls?state=all&sort=created&direction=desc&per_page=1' --jq '.[0].number')
-first_pr=$((latest_pr - 39))
-seq "$first_pr" "$latest_pr" > tmp/recovery/last-40-pr-numbers.txt
+env -u GH_PAGER GH_NO_UPDATE_NOTIFIER=1 gh api 'repos/Phazzie/FairytaleswithSpice/pulls?state=all&sort=created&direction=desc&per_page=40' \
+  --jq '.[].number' > tmp/recovery/last-40-pr-numbers.txt
+test "$(wc -l < tmp/recovery/last-40-pr-numbers.txt | tr -d ' ')" = "40"
 pr_list=$(paste -sd, tmp/recovery/last-40-pr-numbers.txt)
-for pr in $(cat tmp/recovery/last-40-pr-numbers.txt); do
-  env -u GH_PAGER GH_NO_UPDATE_NOTIFIER=1 gh pr view "$pr" --repo Phazzie/FairytaleswithSpice --json number,title,state,mergedAt,closedAt,updatedAt,url
-done | jq -s '.' > tmp/recovery/last-40-prs.json
+env -u GH_PAGER GH_NO_UPDATE_NOTIFIER=1 gh api 'repos/Phazzie/FairytaleswithSpice/pulls?state=all&sort=created&direction=desc&per_page=40' \
+  --jq '[.[] | {number, title, state, mergedAt: .merged_at, closedAt: .closed_at, updatedAt: .updated_at, url: .html_url}]' > tmp/recovery/last-40-prs.json
 ```
 
 3. Audit active non-outdated review threads for those PRs using the remote script:

--- a/STORY_LAB_FINAL_MERGE_AUDIT_EXEC_PLAN.md
+++ b/STORY_LAB_FINAL_MERGE_AUDIT_EXEC_PLAN.md
@@ -401,11 +401,11 @@ mkdir -p tmp/recovery
 
 ```bash
 env -u GH_PAGER GH_NO_UPDATE_NOTIFIER=1 gh api 'repos/Phazzie/FairytaleswithSpice/pulls?state=all&sort=created&direction=desc&per_page=40' \
-  --jq '.[].number' > tmp/recovery/last-40-pr-numbers.txt
+  > tmp/recovery/last-40-prs-raw.json
+jq -r '.[].number' tmp/recovery/last-40-prs-raw.json > tmp/recovery/last-40-pr-numbers.txt
 test "$(wc -l < tmp/recovery/last-40-pr-numbers.txt | tr -d ' ')" = "40"
 pr_list=$(paste -sd, tmp/recovery/last-40-pr-numbers.txt)
-env -u GH_PAGER GH_NO_UPDATE_NOTIFIER=1 gh api 'repos/Phazzie/FairytaleswithSpice/pulls?state=all&sort=created&direction=desc&per_page=40' \
-  --jq '[.[] | {number, title, state, mergedAt: .merged_at, closedAt: .closed_at, updatedAt: .updated_at, url: .html_url}]' > tmp/recovery/last-40-prs.json
+jq '[.[] | {number, title, state, mergedAt: .merged_at, closedAt: .closed_at, updatedAt: .updated_at, url: .html_url}]' tmp/recovery/last-40-prs-raw.json > tmp/recovery/last-40-prs.json
 ```
 
 3. Audit active non-outdated review threads for those PRs using the remote script:

--- a/scripts/recovery/list-unresolved-review-threads.mjs
+++ b/scripts/recovery/list-unresolved-review-threads.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { execFileSync } from 'node:child_process';
 import { accessSync, constants } from 'node:fs';
+import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const DEFAULT_LIMIT = 200;
@@ -396,7 +397,15 @@ function main() {
   printMarkdown(rows);
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+export function isEntrypoint(moduleUrl, argvPath = process.argv[1]) {
+  if (!argvPath) {
+    return false;
+  }
+
+  return fileURLToPath(moduleUrl) === resolve(argvPath);
+}
+
+if (isEntrypoint(import.meta.url)) {
   try {
     main();
   } catch (error) {

--- a/tests/review-thread-audit-options.test.ts
+++ b/tests/review-thread-audit-options.test.ts
@@ -1,6 +1,9 @@
+// Created: 2026-07-03 08:38 EDT
 import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-process.argv = ['node', 'scripts/recovery/list-unresolved-review-threads.mjs', '--help'];
+process.argv = ['node', 'tests/review-thread-audit-options.test.ts'];
 
 void main();
 
@@ -26,6 +29,7 @@ async function main() {
     format: string;
     threadMode: string;
   };
+  const isEntrypoint = reviewAudit.isEntrypoint as (moduleUrl: string, argvPath?: string) => boolean;
   const selectUnresolvedThreads = reviewAudit.selectUnresolvedThreads as (
     threads: Array<{
       id: string;
@@ -96,6 +100,12 @@ async function main() {
     () => parseArgs(['--include-outdated', '--outdated-only']),
     /Choose only one outdated thread mode/,
   );
+
+  const scriptPath = 'scripts/recovery/list-unresolved-review-threads.mjs';
+  const scriptUrl = pathToFileURL(resolve(scriptPath)).href;
+  assert.equal(isEntrypoint(scriptUrl, scriptPath), true);
+  assert.equal(isEntrypoint(scriptUrl, resolve(scriptPath)), true);
+  assert.equal(isEntrypoint(scriptUrl, 'scripts/recovery/other-script.mjs'), false);
 
   assert.deepEqual(
     selectUnresolvedThreads(threads, 'active').map((thread) => thread.id),


### PR DESCRIPTION
## Summary
- Correct the final audit plan so the last-40 PR list comes from the Pulls API records instead of a contiguous numeric range that can include issue numbers.
- Make the review-thread audit script entrypoint guard robust for relative script paths.
- Add the missing timestamp header to the audit-options test and cover relative/absolute entrypoint detection.

## Validation
- `npm run test:review-thread-audit-options`
- `npm run test:all`
- `node --check scripts/recovery/list-unresolved-review-threads.mjs`
- `git diff --check -- STORY_LAB_FINAL_MERGE_AUDIT_EXEC_PLAN.md scripts/recovery/list-unresolved-review-threads.mjs tests/review-thread-audit-options.test.ts`
- `npm run recovery:status`
- Validated the corrected Pulls API command writes 40 actual PR numbers and audits the resulting explicit PR list.

## Non-claims
- Does not complete the last-40 review cleanup gate. Current exact audit still has active and outdated unresolved threads.
- Does not implement the 90% coverage gate.

## Summary by Sourcery

Correct the last-40 PR audit plan to use explicit Pulls API results and harden the review-thread audit entrypoint detection, with accompanying tests.

Bug Fixes:
- Ensure the last-40 PR list is derived from the latest 40 pull requests returned by the GitHub Pulls API instead of a contiguous numeric range that may include issue numbers.
- Fix the review-thread audit script entrypoint guard so it correctly handles relative and absolute script paths and missing argv values.

Enhancements:
- Streamline generation and serialization of the last-40 PR metadata by using a single Pulls API call for both the ID list and detailed JSON output.

Documentation:
- Update the final merge audit execution plan to describe the corrected approach for listing the last 40 pull requests and to verify the list contains exactly 40 entries.

Tests:
- Extend review-thread audit options tests to include the required timestamp header and to cover relative vs absolute entrypoint detection for the recovery script.