### PR TITLE
Reject invalid review audit PR lists

### DIFF
--- a/scripts/recovery/list-unresolved-review-threads.mjs
+++ b/scripts/recovery/list-unresolved-review-threads.mjs
@@ -124,12 +124,31 @@ function validateOptions(options) {
 }
 
 function parsePrList(value) {
-  return value
+  const entries = value
     .split(',')
-    .map((entry) => entry.trim().replace(/^#/, ''))
-    .filter(Boolean)
-    .map(Number)
-    .filter((entry) => Number.isInteger(entry) && entry > 0);
+    .map((entry) => entry.trim());
+
+  if (entries.every((entry) => entry === '')) {
+    throw new Error('--prs requires at least one pull request number');
+  }
+
+  return entries.map((entry) => {
+    if (!entry) {
+      throw new Error('Invalid --prs value: empty entry');
+    }
+
+    const numberText = entry.replace(/^#/, '');
+    if (!/^\d+$/.test(numberText)) {
+      throw new Error(`Invalid --prs value: ${entry}`);
+    }
+
+    const number = Number(numberText);
+    if (number <= 0) {
+      throw new Error(`Invalid --prs value: ${entry}`);
+    }
+
+    return number;
+  });
 }
 
 function printHelp() {

--- a/tests/review-thread-audit-options.test.ts
+++ b/tests/review-thread-audit-options.test.ts
@@ -27,6 +27,7 @@ async function main() {
   };
   const parseArgs = reviewAudit.parseArgs as (argv: string[]) => {
     format: string;
+    prs: number[];
     threadMode: string;
   };
   const isEntrypoint = reviewAudit.isEntrypoint as (moduleUrl: string, argvPath?: string) => boolean;
@@ -96,6 +97,27 @@ async function main() {
   assert.equal(parseArgs(['--json']).threadMode, 'active');
   assert.equal(parseArgs(['--include-outdated', '--json']).threadMode, 'include-outdated');
   assert.equal(parseArgs(['--outdated-only', '--json']).threadMode, 'outdated-only');
+  assert.deepEqual(parseArgs(['--prs', '#154,166']).prs, [154, 166]);
+  assert.throws(
+    () => parseArgs(['--prs', '154,abc']),
+    /Invalid --prs value: abc/,
+  );
+  assert.throws(
+    () => parseArgs(['--prs', '154,0']),
+    /Invalid --prs value: 0/,
+  );
+  assert.throws(
+    () => parseArgs(['--prs', '154,,166']),
+    /Invalid --prs value: empty entry/,
+  );
+  assert.throws(
+    () => parseArgs(['--prs', '154,']),
+    /Invalid --prs value: empty entry/,
+  );
+  assert.throws(
+    () => parseArgs(['--prs', ',,']),
+    /--prs requires at least one pull request number/,
+  );
   assert.throws(
     () => parseArgs(['--include-outdated', '--outdated-only']),
     /Choose only one outdated thread mode/,


### PR DESCRIPTION
## Summary
- reject malformed `--prs` entries instead of silently dropping them
- prevent all-empty `--prs` input from falling back to the default PR sweep
- add regression coverage for valid `#154,166`, malformed, non-positive, and empty PR lists

## Review-thread context
Addresses the still-valid PR #154 review thread about invalid PR list entries being silently ignored:
- `PRRT_kwDOPyrwIM6LHK5e`

## Validation
- `npm run test:review-thread-audit-options`
- `npm run --silent review:unresolved -- --repo Phazzie/FairytaleswithSpice --prs 154,abc --json` exits with `Invalid --prs value: abc`
- `node --check scripts/recovery/list-unresolved-review-threads.mjs`
- `npm run --silent review:unresolved -- --repo Phazzie/FairytaleswithSpice --prs 154 --outdated-only --json`
- `git diff --check`
- `npm run test:all`
- `scripts/recovery/check-vercel-function-count.sh` (`11/12`)

`npm run recovery:preflight -- review-audit-invalid-prs --dry-run` was attempted, but the slice name is not registered in `scripts/recovery/slice-preflight.sh`; this is a tooling-slice-only change.

## Summary by Sourcery

Enforce strict validation of the --prs option for review audit scripts and add regression tests for invalid PR lists.

Bug Fixes:
- Reject malformed, non-numeric, non-positive, and empty --prs lists instead of silently ignoring invalid entries.

Tests:
- Add regression tests covering valid, malformed, non-positive, and empty --prs argument combinations for the review audit CLI.