### PR TITLE
Resolve final review follow-ups

### DIFF
--- a/api/_lib/services/xaiTextClient.ts
+++ b/api/_lib/services/xaiTextClient.ts
@@ -84,10 +84,12 @@ export class XaiTextClient {
       const usesDifferentFastProfile = fastModel !== preferredModel || fastReasoningEffort !== preferredReasoningEffort;
 
       if (allowFallback && usesDifferentFastProfile && this.isRetryableProviderError(error)) {
-        logWarn('Primary xAI model attempt did not finish in the live request window; retrying with fast Grok model.', request.context, {
+        logWarn('Primary xAI profile attempt did not finish in the live request window; retrying with fast profile.', request.context, {
           operation: request.operation,
           primaryModel: preferredModel,
           fallbackModel: fastModel,
+          primaryReasoningEffort: preferredReasoningEffort,
+          fastReasoningEffort,
           status: error.response?.status,
           errorCode: error.code
         });

--- a/api/_lib/story-lab/continuityExtractor.ts
+++ b/api/_lib/story-lab/continuityExtractor.ts
@@ -11,6 +11,8 @@ import type {
 import { XaiTextClient } from '../services/xaiTextClient';
 import { getXaiFastTimeoutMs } from '../config/xaiConfig';
 
+const MIN_AI_CONTINUITY_TIMEOUT_MS = 1000;
+
 interface ContinuityExtractionInput {
   storyId: string;
   currentState: StoryStateSnapshot;
@@ -40,11 +42,11 @@ export async function extractContinuity(input: ContinuityExtractionInput): Promi
   const client = new XaiTextClient();
   const timeoutMs = input.timeoutMs ?? getXaiFastTimeoutMs();
 
-  if (!input.useAi || !client.hasApiKey() || timeoutMs <= 0) {
-    const warning = !client.hasApiKey()
-      ? 'Continuity is using local heuristic extraction because XAI_API_KEY is not configured.'
-      : !input.useAi
-        ? 'AI continuity extraction disabled for this run.'
+  if (!input.useAi || !client.hasApiKey() || timeoutMs < MIN_AI_CONTINUITY_TIMEOUT_MS) {
+    const warning = !input.useAi
+      ? 'AI continuity extraction disabled for this run.'
+      : !client.hasApiKey()
+        ? 'Continuity is using local heuristic extraction because XAI_API_KEY is not configured.'
         : 'AI continuity extraction skipped because the request budget was nearly exhausted.';
 
     return {

--- a/api/_lib/story-lab/routeStatus.ts
+++ b/api/_lib/story-lab/routeStatus.ts
@@ -19,7 +19,7 @@ export function getStoryLabResponseStatus(payload: ApiResponse<unknown> | unknow
 
   const response = payload as Partial<ApiResponse<unknown>>;
   if (response.success === true) {
-    return 200;
+    return response.data === undefined ? 500 : 200;
   }
 
   if (response.success !== false || !response.error || typeof response.error !== 'object') {

--- a/api/_lib/story-lab/storyLabEngine.ts
+++ b/api/_lib/story-lab/storyLabEngine.ts
@@ -68,7 +68,7 @@ const CONTINUITY_COURTROOM_MAX_SECTION_LENGTH = 420;
 const CHAPTER_ENDING_STRESS_TEST_MAX_SECTION_LENGTH = 320;
 const CLICHE_ALARM_MAX_SECTION_LENGTH = 300;
 const WORLD_ARTIFACT_MAX_NAME_WORDS = 4;
-const STORY_LAB_FUNCTION_BUDGET_MS = 60000;
+const DEFAULT_STORY_LAB_FUNCTION_BUDGET_MS = 60000;
 const STORY_LAB_CONTINUITY_FINALIZATION_RESERVE_MS = 5000;
 const STORY_LAB_MIN_AI_CONTINUITY_TIMEOUT_MS = 1000;
 type ChapterEndingPressureId = 'emotional_reveal' | 'danger_escalation' | 'secret_exposed';
@@ -136,13 +136,36 @@ export function shouldUseMockStoryLab(): boolean {
 
 export function getStoryLabContinuityTimeoutMs(requestStartedAtMs: number, nowMs = Date.now()): number {
   const elapsedMs = Math.max(0, nowMs - requestStartedAtMs);
-  const remainingMs = STORY_LAB_FUNCTION_BUDGET_MS - elapsedMs - STORY_LAB_CONTINUITY_FINALIZATION_RESERVE_MS;
+  const remainingMs = getStoryLabFunctionBudgetMs() - elapsedMs - STORY_LAB_CONTINUITY_FINALIZATION_RESERVE_MS;
 
   if (remainingMs < STORY_LAB_MIN_AI_CONTINUITY_TIMEOUT_MS) {
     return 0;
   }
 
   return Math.min(getXaiFastTimeoutMs(), remainingMs);
+}
+
+function getStoryLabFunctionBudgetMs(): number {
+  return getPositiveIntegerEnv(
+    ['STORY_LAB_FUNCTION_BUDGET_MS', 'FUNCTION_BUDGET_MS'],
+    DEFAULT_STORY_LAB_FUNCTION_BUDGET_MS
+  );
+}
+
+function getPositiveIntegerEnv(names: string[], fallback: number): number {
+  for (const name of names) {
+    const rawValue = process.env[name]?.trim();
+    if (!rawValue) {
+      continue;
+    }
+
+    const parsed = Number(rawValue);
+    if (Number.isInteger(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+
+  return fallback;
 }
 
 export function previewStoryLabContinuationGuidance(input: {

--- a/tests/story-lab-route-status.test.ts
+++ b/tests/story-lab-route-status.test.ts
@@ -143,6 +143,7 @@ function createContinuationBody() {
 async function main(): Promise<void> {
   assert(getStoryLabResponseStatus(null as never) === 500, 'null response payload should map to 500');
   assert(getStoryLabResponseStatus({} as never) === 500, 'malformed response payload should map to 500');
+  assert(getStoryLabResponseStatus({ success: true } as never) === 500, 'success response without data should map to 500');
   assert(
     getStoryLabResponseStatus({ success: false } as never) === 500,
     'missing error payload should map to 500'

--- a/tests/story-quality-evals.test.ts
+++ b/tests/story-quality-evals.test.ts
@@ -159,7 +159,7 @@ async function main(): Promise<void> {
     useAi: false
   });
   assert(continuity.receipt.source === 'heuristic', 'continuity extraction should label heuristic fallback.');
-  assert(continuity.receipt.warning?.includes('heuristic'), 'heuristic fallback should be visible.');
+  assert(continuity.receipt.warning?.includes('disabled'), 'disabled AI continuity fallback should be visible.');
 
   const guidancePreview = previewStoryLabContinuationGuidance({
     continuationBrief: 'Pay off the witness shell and make Lord Brine escalate.',

--- a/tests/xai-fast-path-review.test.ts
+++ b/tests/xai-fast-path-review.test.ts
@@ -34,6 +34,50 @@ function buildRequest(modelPreference: XaiTextRequest['modelPreference'], allowF
   };
 }
 
+function buildContinuityInput(useAi = true) {
+  return {
+    storyId: 'test-story',
+    currentState: {
+      storyId: 'test-story',
+      revision: 1,
+      characters: [],
+      threads: [],
+      artifacts: [],
+      continuityWarnings: [],
+      narrativeVoice: '',
+      lastUpdatedAt: ''
+    },
+    chapters: [],
+    summary: {
+      storyId: 'test-story',
+      title: 'Test Story',
+      synopsis: '',
+      tone: 'romance',
+      spicyLevel: 3,
+      createdAt: '',
+      updatedAt: ''
+    },
+    useAi
+  };
+}
+
+async function captureConsoleWarn<T>(fn: () => Promise<T>): Promise<{ result: T; calls: unknown[][] }> {
+  const originalWarn = console.warn;
+  const calls: unknown[][] = [];
+  console.warn = (...args: unknown[]) => {
+    calls.push(args);
+  };
+
+  try {
+    return {
+      result: await fn(),
+      calls
+    };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
 async function assertContinuityFastTimeoutUsesConfiguredBudget(): Promise<void> {
   const originalApiKey = process.env['XAI_API_KEY'];
   const originalFastTimeout = process.env['XAI_STORY_FAST_TIMEOUT_MS'];
@@ -48,39 +92,27 @@ async function assertContinuityFastTimeoutUsesConfiguredBudget(): Promise<void> 
       return { text: '{}', model: 'grok-4.3', latencyMs: 0 };
     };
 
-    const continuityInput = {
-      storyId: 'test-story',
-      currentState: {
-        storyId: 'test-story',
-        revision: 1,
-        characters: [],
-        threads: [],
-        artifacts: [],
-        continuityWarnings: [],
-        narrativeVoice: '',
-        lastUpdatedAt: ''
-      },
-      chapters: [],
-      summary: {
-        storyId: 'test-story',
-        title: 'Test Story',
-        synopsis: '',
-        tone: 'romance',
-        spicyLevel: 3,
-        createdAt: '',
-        updatedAt: ''
-      },
-      useAi: true
-    };
+    const continuityInput = buildContinuityInput(true);
 
     await extractContinuity(continuityInput);
     await extractContinuity({
       ...continuityInput,
       timeoutMs: 1234
     });
+    const lowBudgetResult = await extractContinuity({
+      ...continuityInput,
+      timeoutMs: 999
+    });
 
     assert.equal(capturedTimeouts[0], getXaiFastTimeoutMs(), 'continuity extraction should use the configured fast timeout by default');
     assert.equal(capturedTimeouts[1], 1234, 'continuity extraction should use the remaining request budget when provided');
+    assert.equal(capturedTimeouts.length, 2, 'subsecond remaining budget should skip the xAI continuity request');
+    assert.equal(lowBudgetResult.receipt.source, 'heuristic', 'subsecond remaining budget should fall back to heuristic continuity extraction');
+    assert.equal(
+      lowBudgetResult.receipt.warning,
+      'AI continuity extraction skipped because the request budget was nearly exhausted.',
+      'subsecond remaining budget should explain the budget skip'
+    );
   } finally {
     XaiTextClient.prototype.generateText = originalGenerateText;
 
@@ -94,6 +126,28 @@ async function assertContinuityFastTimeoutUsesConfiguredBudget(): Promise<void> 
       delete process.env['XAI_STORY_FAST_TIMEOUT_MS'];
     } else {
       process.env['XAI_STORY_FAST_TIMEOUT_MS'] = originalFastTimeout;
+    }
+  }
+}
+
+async function assertContinuityHeuristicWarningPriority(): Promise<void> {
+  const originalApiKey = process.env['XAI_API_KEY'];
+
+  try {
+    delete process.env['XAI_API_KEY'];
+    const result = await extractContinuity(buildContinuityInput(false));
+
+    assert.equal(result.receipt.source, 'heuristic', 'disabled AI continuity should use heuristic extraction');
+    assert.equal(
+      result.receipt.warning,
+      'AI continuity extraction disabled for this run.',
+      'explicitly disabled AI should take warning priority over a missing API key'
+    );
+  } finally {
+    if (originalApiKey === undefined) {
+      delete process.env['XAI_API_KEY'];
+    } else {
+      process.env['XAI_API_KEY'] = originalApiKey;
     }
   }
 }
@@ -198,13 +252,20 @@ async function assertXaiClientPayloads(): Promise<void> {
     }) as typeof axios.post;
 
     const sameModelFallbackClient = new XaiTextClient();
-    const sameModelFallbackResponse = await sameModelFallbackClient.generateText(buildRequest(undefined, true));
+    const sameModelFallback = await captureConsoleWarn(() =>
+      sameModelFallbackClient.generateText(buildRequest(undefined, true))
+    );
+    const sameModelFallbackResponse = sameModelFallback.result;
+    const sameModelFallbackWarnings = JSON.stringify(sameModelFallback.calls);
     assert.equal(capturedPosts.length, 2, 'same model fallback should retry when the fast reasoning profile differs');
     assert.equal((capturedPosts[0].payload['reasoning'] as { effort?: string }).effort, 'medium', 'same model primary attempt should use primary reasoning');
     assert.equal((capturedPosts[1].payload['reasoning'] as { effort?: string }).effort, 'none', 'same model retry should use fast no-reasoning profile');
     assert.equal(capturedPosts[1].config.timeout, 5678, 'same model retry should use fallback timeout budget');
     assert.equal(sameModelFallbackResponse.reasoningEffort, 'none', 'same model fallback metadata should report fast none reasoning');
     assert.equal(sameModelFallbackResponse.fallbackFromModel, 'grok-4.3', 'same model fallback metadata should record the primary model');
+    assert(sameModelFallbackWarnings.includes('fast profile'), 'same model fallback warning should describe a fast profile retry');
+    assert(sameModelFallbackWarnings.includes('primaryReasoningEffort'), 'same model fallback warning should include primary reasoning effort');
+    assert(sameModelFallbackWarnings.includes('fastReasoningEffort'), 'same model fallback warning should include fast reasoning effort');
 
     capturedPosts.length = 0;
     process.env['XAI_STORY_MODEL'] = 'grok-4.20-multi-agent';
@@ -308,24 +369,48 @@ async function assertStoryLabContinuityBudgetUsesRemainingRequestWindow(): Promi
     getStoryLabContinuityTimeoutMs?: (requestStartedAtMs: number, nowMs?: number) => number;
   };
   const originalFastTimeout = process.env['XAI_STORY_FAST_TIMEOUT_MS'];
+  const originalFunctionBudget = process.env['STORY_LAB_FUNCTION_BUDGET_MS'];
+  const originalFallbackFunctionBudget = process.env['FUNCTION_BUDGET_MS'];
 
   try {
     process.env['XAI_STORY_FAST_TIMEOUT_MS'] = '40000';
+    delete process.env['STORY_LAB_FUNCTION_BUDGET_MS'];
+    delete process.env['FUNCTION_BUDGET_MS'];
     assert.equal(typeof getStoryLabContinuityTimeoutMs, 'function', 'Story Lab engine should expose its continuity timeout budget calculation');
     assert.equal(getStoryLabContinuityTimeoutMs(0, 10000), 40000, 'early requests should keep the configured fast timeout');
     assert.equal(getStoryLabContinuityTimeoutMs(0, 30000), 25000, 'late requests should cap continuity extraction to remaining function budget');
     assert.equal(getStoryLabContinuityTimeoutMs(0, 59500), 0, 'nearly exhausted requests should skip AI continuity extraction');
+
+    process.env['STORY_LAB_FUNCTION_BUDGET_MS'] = '15000';
+    assert.equal(getStoryLabContinuityTimeoutMs(0, 9000), 1000, 'configured Story Lab budget should cap continuity extraction');
+
+    delete process.env['STORY_LAB_FUNCTION_BUDGET_MS'];
+    process.env['FUNCTION_BUDGET_MS'] = '20000';
+    assert.equal(getStoryLabContinuityTimeoutMs(0, 10000), 5000, 'generic function budget fallback should cap continuity extraction');
   } finally {
     if (originalFastTimeout === undefined) {
       delete process.env['XAI_STORY_FAST_TIMEOUT_MS'];
     } else {
       process.env['XAI_STORY_FAST_TIMEOUT_MS'] = originalFastTimeout;
     }
+
+    if (originalFunctionBudget === undefined) {
+      delete process.env['STORY_LAB_FUNCTION_BUDGET_MS'];
+    } else {
+      process.env['STORY_LAB_FUNCTION_BUDGET_MS'] = originalFunctionBudget;
+    }
+
+    if (originalFallbackFunctionBudget === undefined) {
+      delete process.env['FUNCTION_BUDGET_MS'];
+    } else {
+      process.env['FUNCTION_BUDGET_MS'] = originalFallbackFunctionBudget;
+    }
   }
 }
 
 async function main(): Promise<void> {
   await assertContinuityFastTimeoutUsesConfiguredBudget();
+  await assertContinuityHeuristicWarningPriority();
   assertReasoningConfig();
   await assertXaiClientPayloads();
   assertAiMetadataMerge();


### PR DESCRIPTION
## Summary
- reject malformed Story Lab success envelopes that omit `data`
- make Story Lab function budget configurable via `STORY_LAB_FUNCTION_BUDGET_MS` / `FUNCTION_BUDGET_MS`
- skip AI continuity extraction when the remaining timeout is below the 1000ms floor
- prioritize explicit AI-disabled continuity warnings over missing-key warnings
- update xAI fallback telemetry to describe fast profile retries and include primary/fast reasoning efforts

## Review threads addressed
Addresses new active review threads:
- PR #175: PRRT_kwDOPyrwIM6ONqDJ
- PR #176: PRRT_kwDOPyrwIM6ON0F8
- PR #176: PRRT_kwDOPyrwIM6ON0GE
- PR #176: PRRT_kwDOPyrwIM6ON0jl
- PR #176: PRRT_kwDOPyrwIM6ON0lJ

## TDD / validation
RED observed before production fixes:
- `npm run test:story-lab-route-status` failed because `{ success: true }` mapped to 200
- `npm run test:xai-fast-path-review` failed because 999ms continuity budget still called xAI

GREEN validation:
- `npm run test:story-lab-route-status`
- `npm run test:xai-fast-path-review`
- `npm run test:story-quality`
- `git diff --check`
- `scripts/recovery/check-vercel-function-count.sh` (11/12)
- `npm run build` (Node 23 and baseline-browser-mapping warnings only)
- `npm run test:all`

Note: local git hooks were bypassed because pre-commit/pre-push still point at missing `pocketfm-contest-forge`; equivalent repo gates above passed locally.

## Summary by Sourcery

Harden Story Lab continuity handling and xAI fallback behavior based on review feedback.

Bug Fixes:
- Treat Story Lab success responses without data as server errors instead of 200 responses.
- Skip xAI continuity requests when the remaining timeout budget is below a 1s minimum to avoid near-expired calls.
- Ensure disabled AI continuity uses heuristic extraction and surfaces the appropriate warning message.

Enhancements:
- Make the Story Lab function budget configurable via STORY_LAB_FUNCTION_BUDGET_MS with a FUNCTION_BUDGET_MS fallback, preserving a sensible default.
- Adjust Story Lab continuity timeout calculation to respect the configurable function budget and enforce a minimum AI continuity timeout.
- Prioritize explicit AI-disabled continuity warnings over missing API key warnings.
- Enrich xAI fast-path retry logging to describe fast profile retries and include primary and fast reasoning efforts.
- Expand and refine tests around xAI fast-path review, Story Lab continuity budgeting, and heuristic continuity warnings.