### PR TITLE
Correct Dependabot merge state in final audit docs

### DIFF
--- a/STORY_LAB_FINAL_MERGE_AUDIT_EXEC_PLAN.md
+++ b/STORY_LAB_FINAL_MERGE_AUDIT_EXEC_PLAN.md
@@ -78,7 +78,7 @@ This plan uses a stricter definition than the older recovery docs.
 - A late CodeRabbit pass can still add threads after a PR is merged. PR #178 was clean at merge time, then later received two active trivial maintainability comments. PR #179 fixed and resolved those late comments, and future completion claims still need a post-bot, post-merge audit window.
 - As of 2026-07-03 12:54 EDT, the last-40 PR audit commands report `0` active unresolved, `0` outdated unresolved, and `0` include-outdated unresolved threads.
 - As of 2026-07-03 12:54 EDT, a wider `--state all --limit 200` audit still finds older historical backlog outside the last-40 recovery window: 168 active unresolved threads across 35 PRs, 56 outdated unresolved threads across 14 PRs, and 224 combined unresolved threads across 45 PRs.
-- As of 2026-07-03 12:54 EDT, the only open PRs are Dependabot PR #120 and PR #121. Both are old, `UNKNOWN`/failing, and have failing Recovery CI/Vercel checks.
+- As of 2026-07-03 12:54 EDT, the only open PRs are Dependabot PR #120 and PR #121. Both are old, `UNSTABLE`, and have failing Recovery CI/Vercel checks.
 - Dependabot PR #120 and PR #121 are not quick merge candidates. Both contain Angular 22 major-upgrade work that conflicts with the repo's current Angular 20/TypeScript 5.9 setup; close/recreate as separate root dependency and Angular-major-upgrade work.
 - The parent checkout still has four parked untracked artifacts that are intentionally local-only: `SPARK_TRIAL_TASKS.md`, `STORY_LAB_REVIEW_MISTAKES_2026-06-09.md`, `STORY_QUALITY_EVALS_PLAN.md`, and `tests/grok-smoke.test.ts`. No tracked PR #179 work remains local-only after merge.
 


### PR DESCRIPTION
## Summary
- correct PR #120/#121 merge state wording from `UNKNOWN` to `UNSTABLE`
- addresses the late PR #180 review thread on `STORY_LAB_FINAL_MERGE_AUDIT_EXEC_PLAN.md`

## Validation
- `git diff --check`

## Summary by Sourcery

Documentation:
- Correct the documented merge state of Dependabot PR #120 and #121 in the final merge audit plan from UNKNOWN/failing to UNSTABLE with failing checks.