### PR TITLE
Add subagent operating guidance and log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,8 @@ Exact steps:
 Commands to run:
 Expected pass/fail meaning:
 Stop condition:
-Output format:
+Output contract:
+Artifact requirement:
 ```
 
 For coding subagents, use disjoint write ownership. Do not let two workers edit the same package file, lockfile, route, component, or changelog section in parallel. If the work needs shared files, either serialize those edits or keep the subagents read-only and integrate in the parent session.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md - Fairytales with Spice
 
-Last updated: 2026-07-03 08:30 EDT
+Last updated: 2026-07-03 18:39 EDT
 
 This file is read automatically by AI coding agents. It is the repo-level operating guide for current Story Lab platform work, recovery work, and autonomous sessions.
 
@@ -68,6 +68,59 @@ CodeRabbit configuration lives in `.coderabbit.yaml`. The repository intentional
 
 Add focused documentation when it clarifies public contracts, exported ports/adapters, security/privacy invariants, cross-process storage behavior, or non-obvious story-generation constraints. If a bot asks for broad docstring coverage, treat that as review-tooling drift: tune the tool or open a follow-up issue instead of adding low-value comments.
 
+## Subagent Operating Rules
+
+Use subagents as bounded execution help, not as a substitute for parent-agent judgment. The parent agent owns strategy, final integration, GitHub actions, and completion claims.
+
+Before dispatching subagents:
+
+1. Analyze the target locally first and write down the split.
+2. Confirm each subtask is independent, has a disjoint write scope, or is explicitly read-only.
+3. Keep at most six subagents active at once.
+4. Prefer Spark-style fast agents only for narrow tickets with complete context and easy-to-check outputs.
+5. Do not ask a subagent to "figure out the repo", "fix coverage", or "handle Dependabot" without a bounded target.
+
+Every subagent ticket must include:
+
+- **Parent analysis:** what is already known and what strategy has already been chosen.
+- **Role:** read-only explorer, bounded worker, reviewer, or drafting assistant.
+- **Owned files:** exact paths the agent may edit, or `Read-only`.
+- **Forbidden actions:** no PR merges, no branch deletion, no review-thread resolution, no broad refactors, and no reverting unrelated work.
+- **Commands:** exact checks to run, including whether failures are expected evidence.
+- **Stop condition:** when to stop instead of broadening scope.
+- **Output contract:** status, files changed, commands run, percent ready, blockers, concerns, and recommendation.
+- **Artifact requirement:** command log, patch summary, checklist, or draft text that the parent can inspect without rereading the whole workspace.
+
+Use this minimum ticket shape:
+
+```text
+Task name:
+Parent analysis:
+Goal:
+Role:
+Model / reason:
+Owned files:
+Read-only files:
+Forbidden actions:
+Exact steps:
+Commands to run:
+Expected pass/fail meaning:
+Stop condition:
+Output format:
+```
+
+For coding subagents, use disjoint write ownership. Do not let two workers edit the same package file, lockfile, route, component, or changelog section in parallel. If the work needs shared files, either serialize those edits or keep the subagents read-only and integrate in the parent session.
+
+Dependency PRs need extra care. Do not split one dependency PR into multiple package-lock writers unless each lockfile is in a different package root. Root `package-lock.json` and `story-generator/package-lock.json` can be separate workers; two workers must not both edit the same lockfile. Major framework upgrades should be separate from patch/minor tooling updates.
+
+After subagents return:
+
+1. Review every result before integrating it.
+2. Run the relevant local checks yourself.
+3. Push and merge only from the parent session.
+4. Record timeouts or stale-workspace failures as failures, not partial success.
+5. Update `SUBAGENT_LOG.md` and the active changelog or execution plan in the same PR when subagent work materially affects repo decisions.
+
 ## Current Operating Direction
 
 The unpublished `feature/story-lab-auth-profile-contracts` stack has been split and merged through PR #151. The current recovery task is completion hardening: address or track review comments, resolve dependency follow-ups, prove live auth/database behavior before cloud claims, and keep durable-job claims gated on process-loss proof.
@@ -127,6 +180,7 @@ The companion inventory is `PR_USEFUL_MATERIAL_INVENTORY.md`.
 Keep these files current during the recovery:
 
 - `PR70_RECOVERY_CHANGELOG.md` - chronological work log and decisions.
+- `SUBAGENT_LOG.md` - subagent batches, tickets, results, integration decisions, and follow-ups.
 - `PR70_RECOVERY_LEDGER.md` - one row/section per PR disposition.
 - `NOT_TAKEN_FEATURE_LEDGER.md` - useful material intentionally not taken, especially story-generation ideas.
 - `LESSONS_LEARNED.md` - durable lessons and corrections discovered during the recovery.

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -3280,3 +3280,23 @@ Validation:
 - `git diff --check`: passed.
 - `scripts/recovery/check-vercel-function-count.sh`: passed at `11/12`.
 - `npm run recovery:status`: passed; branch contains only `api/README.md` and changelog edits.
+
+## 2026-07-03 18:39 EDT - Subagent Guidance And PR #120 Split Trial
+
+Actions:
+
+- Added `AGENTS.md` guidance for bounded subagent tickets, disjoint write scopes, parent-owned strategy, and required result contracts.
+- Added `SUBAGENT_LOG.md` as the dedicated place to record subagent batches, outputs, parent verification, integration decisions, and follow-ups.
+- Ran a six-agent Spark trial for Dependabot PR #120 after parent analysis found it mixed root `tsx`/`esbuild` work with an Angular 20 to Angular 22 major upgrade.
+- Recorded the trial result: five agents returned, one timed out, and no dependency/config changes were integrated without parent revalidation.
+
+Self-review:
+
+- Good: The guidance makes subagent work auditable instead of relying on chat memory.
+- Correction: Previous subagent activity was documented in plans/memory, but not in a dedicated repo log.
+- Finding: Spark is useful for narrow package diffs, config drafts, validation matrices, and wording drafts, but tickets still need stronger workspace/source-of-truth constraints and deterministic artifacts.
+- Non-claim: Subagent output is not accepted until parent review and local validation finish.
+
+Validation:
+
+- `git diff --check`: passed.

--- a/SUBAGENT_LOG.md
+++ b/SUBAGENT_LOG.md
@@ -1,0 +1,57 @@
+# Subagent Log
+
+This file records subagent batches that materially affect repository work. It is not a transcript. It is a decision log for what was delegated, what came back, what was integrated, and what still needs parent-agent verification.
+
+Update this file in the same PR as the active changelog or execution plan when subagent work changes repo status, PR strategy, review cleanup, dependency handling, or test/coverage plans.
+
+## Entry Format
+
+```text
+## YYYY-MM-DD HH:MM TZ - Short Batch Name
+
+Parent branch / PR:
+Goal:
+Parent analysis before dispatch:
+
+| Agent | Model | Role | Scope | Status | Result | Integrated? |
+|---|---|---|---|---|---|---|
+
+Parent verification:
+Follow-ups:
+```
+
+## 2026-07-03 18:39 EDT - PR #120 Six-Agent Dependabot Split Trial
+
+Parent branch / PR: `recovery/subagent-guidance-log` / not opened yet
+
+Goal: test the user's proposed pattern: parent agent analyzes one Dependabot PR first, then splits the already-chosen implementation strategy into up to six narrow Spark subagent tickets.
+
+Parent analysis before dispatch:
+
+- PR #120 is not a good merge candidate as-is.
+- It mixes a root `tsx`/`esbuild` update with a `story-generator` Angular 20 to Angular 22 jump.
+- The root update can potentially be replaced by a root-only dependency slice.
+- The Angular 22 part needs a separate major-upgrade plan because it pulls TypeScript 6 and newer Node/toolchain constraints.
+- Spark agents were assigned narrow execution, validation, drafting, or review tickets; they were not asked to choose the strategy.
+
+| Agent | Model | Role | Scope | Status | Result | Integrated? |
+|---|---|---|---|---|---|---|
+| A / Planck | `gpt-5.3-codex-spark` | worker | Root `package.json` and `package-lock.json` only | Done with concerns | Produced root-only `tsx` `^4.20.6` to `^4.22.4` / `esbuild` `0.25.10` to `0.28.1` lockfile trial; `npm ci` passed, but requested focused scripts were missing in that workspace | Not integrated; parent must rerun from current `origin/main` |
+| B / Hilbert | `gpt-5.3-codex-spark` | worker | `story-generator/package.json` and lockfile only, if same-major Angular 20 update exists | Timed out / closed | No usable result after extended wait | Not integrated |
+| C / Faraday | `gpt-5.3-codex-spark` | worker | `.github/dependabot.yml` only | Done | Proposed split Dependabot config with separate root and `story-generator` npm scopes | Not integrated; needs parent decision because it changes Dependabot behavior |
+| D / Hooke | `gpt-5.3-codex-spark` | explorer | Read-only validation matrix | Done with concerns | Produced command matrix for root-only, Angular 20 same-major, and Angular 22 major-upgrade replacement slices | Partially useful; parent must trim over-broad smoke checks |
+| E / Peirce | `gpt-5.3-codex-spark` | explorer | Read-only close/recreate wording | Done with concerns | Drafted PR #120 close/supersede wording, issue update, and changelog bullet | Not posted; useful as draft only |
+| F / Fermat | `gpt-5.3-codex-spark` | explorer | Read-only prompt-quality review | Done with concerns | Rated the six-way split 78%; flagged Angular and validation overlap, ambiguous Dependabot config ownership, and weak deterministic artifacts | Integrated into `AGENTS.md` guidance |
+
+Parent verification:
+
+- The experiment was useful but not clean enough to let Spark implement a dependency PR unsupervised.
+- Main failure modes: one timeout, one stale-workspace validation issue, over-broad validation matrix, and ambiguous config ownership.
+- Parent decision: integrate the subagent-process guidance and log, but do not integrate PR #120 dependency/config changes in this docs PR.
+
+Follow-ups:
+
+- Re-run the root-only `tsx`/`esbuild` replacement from current `origin/main` before opening a replacement PR.
+- Decide whether to add a split `.github/dependabot.yml` in a separate dependency-process PR.
+- Decide whether to close/supersede PR #120 after replacement path is ready.
+- For the next six-agent trial, make the Angular ticket explicitly either same-major normalization or major-upgrade feasibility, not both.

--- a/SUBAGENT_LOG.md
+++ b/SUBAGENT_LOG.md
@@ -22,7 +22,7 @@ Follow-ups:
 
 ## 2026-07-03 18:39 EDT - PR #120 Six-Agent Dependabot Split Trial
 
-Parent branch / PR: `recovery/subagent-guidance-log` / not opened yet
+Parent branch / PR: `recovery/subagent-guidance-log` / PR #183
 
 Goal: test the user's proposed pattern: parent agent analyzes one Dependabot PR first, then splits the already-chosen implementation strategy into up to six narrow Spark subagent tickets.
 


### PR DESCRIPTION
## Summary
- add repo guidance for bounded subagent tickets, disjoint write scopes, parent-owned strategy, and required output contracts
- add `SUBAGENT_LOG.md` as the durable log for subagent batches and parent verification
- record the PR #120 six-agent Spark trial in the recovery changelog and subagent log

## Trial result
- Parent analysis identified PR #120 as too broad: root `tsx`/`esbuild` plus Angular 20 -> 22 in one Dependabot PR.
- Six Spark agents were dispatched with narrow tickets.
- Five returned; one timed out and was closed.
- No dependency or Dependabot config changes were integrated in this docs PR.
- Main lesson: Spark is useful for narrow diffs/drafts/reviews, but tickets need source-of-truth constraints, deterministic artifacts, and tighter dependency lockfile ownership.

## Validation
- `git diff --check`

## Summary by Sourcery

Document subagent operating rules and introduce a durable subagent activity log informed by a recent multi-agent dependency upgrade trial.

Enhancements:
- Add repo-level subagent operating guidance, including ticket structure, role definitions, disjoint write ownership, and parent-agent responsibilities in AGENTS.md.
- Introduce SUBAGENT_LOG.md as a structured decision log for subagent batches, including parent analysis, agent roles, results, verification, and follow-ups.
- Record the 2026-07-03 six-agent Spark trial for Dependabot PR #120 in both the recovery changelog and the new subagent log, capturing outcomes and lessons for future dependency work.

Documentation:
- Update recovery documentation to reference SUBAGENT_LOG.md alongside existing recovery logs and ledgers.