### PR TITLE
Add communication checklist discipline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file is read automatically by AI coding agents. It is the repo-level operat
 
 Prefer fewer, larger progress updates over many small command-by-command updates. Group related status into meaningful checkpoints: current truth, what changed, what is blocked, what is next, and what is already pushed or merged.
 
-When the user asks for a checklist, status report, or other concrete artifact, show the requested artifact or full checklist directly. Do not replace it with a short summary unless the user explicitly asks for a summary.
+When the user asks for a checklist, status report, or other concrete artifact, show the requested artifact or full checklist directly. Concrete artifacts include checklists, status tables, PR lists, subagent tickets, command-output summaries the user asked to see, named doc contents, and explicit done/not-done matrices. Do not replace them with a short summary unless the user explicitly asks for a summary.
 
 ## Required Start Order
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,14 @@
 # AGENTS.md - Fairytales with Spice
 
-Last updated: 2026-07-04 14:33 EDT
+Last updated: 2026-07-05 00:43 EDT
 
 This file is read automatically by AI coding agents. It is the repo-level operating guide for current Story Lab platform work, recovery work, and autonomous sessions.
+
+## User Communication Preference
+
+Prefer fewer, larger progress updates over many small command-by-command updates. Group related status into meaningful checkpoints: current truth, what changed, what is blocked, what is next, and what is already pushed or merged.
+
+When the user asks for a checklist, status report, or other concrete artifact, show the requested artifact or full checklist directly. Do not replace it with a short summary unless the user explicitly asks for a summary.
 
 ## Required Start Order
 

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -10,6 +10,7 @@ Actions:
 
 - Updated `AGENTS.md` with the user's communication preference: fewer, larger progress updates instead of many small command-by-command updates.
 - Added an explicit rule that when the user asks for a checklist, status report, or concrete artifact, agents should show the requested artifact directly instead of replacing it with a short summary.
+- Addressed PR review feedback by defining concrete artifacts as checklists, status tables, PR lists, subagent tickets, requested command-output summaries, named doc contents, and done/not-done matrices.
 
 Self-review:
 

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -4,6 +4,24 @@ Created: 2026-05-26 00:12 EDT
 
 This is the chronological work log for the PR #70 recovery. It should capture commands, decisions, self-review notes, validation results, and anything that changes the plan.
 
+## 2026-07-05 00:43 EDT - Communication And Checklist Discipline
+
+Actions:
+
+- Updated `AGENTS.md` with the user's communication preference: fewer, larger progress updates instead of many small command-by-command updates.
+- Added an explicit rule that when the user asks for a checklist, status report, or concrete artifact, agents should show the requested artifact directly instead of replacing it with a short summary.
+
+Self-review:
+
+- Correction: the prior response summarized the future-work checklist instead of showing the full checklist the user asked for.
+- Non-claim: this pass only changes operating guidance; it does not change Story Lab implementation status.
+
+Validation:
+
+- `git diff --check` passed.
+- `npm run test:recovery-finish-check` passed.
+- `scripts/recovery/check-vercel-function-count.sh` passed at `11/12`.
+
 ## 2026-07-04 14:33 EDT - Granular Future-Work Checklist And Archive Cleanup
 
 Actions:


### PR DESCRIPTION
## Summary
- add an `AGENTS.md` communication preference for fewer, larger progress updates
- add an explicit rule to show requested checklists/status artifacts directly instead of substituting summaries
- record the correction and validation in the recovery changelog

## Validation
- `git diff --check`
- `npm run test:recovery-finish-check`
- `scripts/recovery/check-vercel-function-count.sh` -> 11/12

## Non-claims
- docs/process only
- no Story Lab implementation status changed

## Summary by Sourcery

Clarify agent communication and checklist handling guidelines and record the change in the recovery changelog.

Documentation:
- Document the user’s preference for fewer, consolidated progress updates and structured status checkpoints in AGENTS.md.
- Specify that requested checklists or status artifacts must be shown in full rather than replaced by short summaries in AGENTS.md.
- Add a recovery changelog entry describing the communication preference update, checklist rule, and associated validation steps.