### PR TITLE
Add Story Lab exploration findings synthesis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md - Fairytales with Spice
 
-Last updated: 2026-07-05 01:54 EDT
+Last updated: 2026-07-05 02:25 EDT
 
 This file is read automatically by AI coding agents. It is the repo-level operating guide for current Story Lab platform work, recovery work, and autonomous sessions.
 
@@ -23,7 +23,7 @@ Prefer durable turnover in `SUBAGENT_LOG.md`, `PR70_RECOVERY_CHANGELOG.md`, PR b
 Before planning, editing, or claiming readiness:
 
 1. Run `git status --short --branch` and treat the live worktree as authoritative.
-2. Read `STORY_LAB_UNPUBLISHED_BRANCH_SPLIT_PLAN.md` when recovering the local Story Lab stack.
+2. Read the current active Story Lab control docs first: `STORY_LAB_COMPLETION_HARDENING_EXEC_PLAN.md`, `STORY_LAB_FINAL_MERGE_AUDIT_EXEC_PLAN.md`, `STORY_LAB_FUTURE_WORK_CHECKLIST.md`, and `STORY_LAB_EXPLORATION_FINDINGS.md` when it exists. Treat `STORY_LAB_UNPUBLISHED_BRANCH_SPLIT_PLAN.md` as historical publication evidence unless a task explicitly asks to recover that old stack.
 3. For long-running autonomous work, read `OVERNIGHT_MODE.md` before selecting the next task.
 4. Use `STORY_LAB_IDEA_BOARD.md` for research-mined ideas, story-quality experiments, and Weird Lab candidates.
 5. Read the execution plan that matches the files or behavior being changed.
@@ -103,6 +103,7 @@ Do not leave status only in chat. Update the narrowest durable document that mat
 | `STORY_LAB_FINAL_MERGE_AUDIT_EXEC_PLAN.md` | Final audit evidence changes: last-40 PR audit, wider PR debt, unresolved review comments, coverage proof, or "all work merged" claims. |
 | `STORY_LAB_FUTURE_WORK_CHECKLIST.md` | Granular future-work tickets, subagent-ready scopes, execution ordering, admin cleanup status, or next-work prioritization changes. |
 | `STORY_LAB_EXPLORATION_TICKETS.md` | Exploration ticket scope, standard exploration report fields, context-turnover packet shape, exploration wave planning, or explore-to-worker conversion strategy changes. |
+| `STORY_LAB_EXPLORATION_FINDINGS.md` | Exploration batches complete, findings need durable synthesis, first worker wave changes, context-turnover packets are produced, or exploratory tickets are converted to implementation batches. |
 | `STORY_LAB_AUTH_PROFILE_CLOUD_LIBRARY_EXEC_PLAN.md` | Auth, profile, cloud library APIs/UI, signed-in save/load/list/delete behavior, or provider-backed claims change. |
 | `STORY_LAB_STORAGE_PORT_EXEC_PLAN.md` | Storage ports, in-memory/Postgres adapters, schema, durability wording, owner-scoped behavior, or cloud-vs-local status changes. |
 | `STORY_LAB_JOB_ROUTES_EXEC_PLAN.md` | Job routes, job store, SSE events, progress/reload behavior, Workflow claims, or non-durable job wording changes. |
@@ -205,6 +206,8 @@ The whole-concept status checklist is `STORY_LAB_CONCEPT_CHECKLIST.md`. Use it f
 The granular future-work checklist is `STORY_LAB_FUTURE_WORK_CHECKLIST.md`. Use it before dispatching subagents for unfinished Story Lab work; each unfinished item is broken into owned scope, stop condition, output, and validation.
 
 The exploration-ticket packet is `STORY_LAB_EXPLORATION_TICKETS.md`. Use it before running the next exploration batch; it defines the standard exploration report, context-turnover packet, and the exploration tickets that should convert the future-work checklist into larger worker chunks.
+
+The latest completed exploration synthesis is `STORY_LAB_EXPLORATION_FINDINGS.md`. Use it before rerunning any EXP ticket. If the finding is still current, dispatch workers from that synthesis instead of repeating read-only exploration.
 
 ## Historical Recovery Context
 

--- a/OVERNIGHT_MODE.md
+++ b/OVERNIGHT_MODE.md
@@ -1,6 +1,6 @@
 # Overnight Mode
 
-Last updated: 2026-06-13
+Last updated: 2026-07-05
 
 ## Purpose
 
@@ -31,7 +31,10 @@ Run or inspect these before making changes:
 5. `npm run test:all` when the change risk justifies the time
 6. Read or skim:
    - `AGENTS.md`
-   - `STORY_LAB_UNPUBLISHED_BRANCH_SPLIT_PLAN.md`
+   - `STORY_LAB_COMPLETION_HARDENING_EXEC_PLAN.md`
+   - `STORY_LAB_FINAL_MERGE_AUDIT_EXEC_PLAN.md`
+   - `STORY_LAB_FUTURE_WORK_CHECKLIST.md`
+   - `STORY_LAB_EXPLORATION_FINDINGS.md` when present
    - `STORY_LAB_IDEA_BOARD.md`
    - the execution plan matching the files being changed
 
@@ -44,7 +47,7 @@ Use this order when the user has not given a newer explicit task:
 1. User's newest explicit request.
 2. Open PR review comments or failing CI.
 3. Failing local checks from the start-of-run checklist.
-4. The next unchecked publishing step in `STORY_LAB_UNPUBLISHED_BRANCH_SPLIT_PLAN.md`.
+4. The next unchecked gate in `STORY_LAB_COMPLETION_HARDENING_EXEC_PLAN.md`, `STORY_LAB_FINAL_MERGE_AUDIT_EXEC_PLAN.md`, or `STORY_LAB_FUTURE_WORK_CHECKLIST.md`.
 5. The next unchecked gate in the active execution plan.
 6. Source-backed research ideas from `STORY_LAB_IDEA_BOARD.md`.
 7. One bounded Weird Lab experiment from `STORY_LAB_IDEA_BOARD.md`.

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -4,6 +4,26 @@ Created: 2026-05-26 00:12 EDT
 
 This is the chronological work log for the PR #70 recovery. It should capture commands, decisions, self-review notes, validation results, and anything that changes the plan.
 
+## 2026-07-05 02:25 EDT - Exploration Findings Synthesis
+
+Actions:
+
+- Completed the EXP-01 through EXP-13 subagent exploration batch.
+- Added `STORY_LAB_EXPLORATION_FINDINGS.md` with the durable synthesis, first/second implementation waves, parent decisions, and a context-turnover packet.
+- Updated `STORY_LAB_FUTURE_WORK_CHECKLIST.md` so the next session uses the completed synthesis instead of rerunning the full exploration batch.
+- Updated `SUBAGENT_LOG.md` with each exploration agent, result, integration decision, and follow-up.
+- Updated `AGENTS.md` and `OVERNIGHT_MODE.md` so active Story Lab sessions start from the current completion/audit/future-work/finding docs instead of treating historical publication docs as current.
+
+Self-review:
+
+- Correction: one docs-source subagent reported stale open-PR wording. Parent verified live GitHub state and kept the current truth: there are zero open PRs at the time of synthesis.
+- Finding: tests/coverage, auth/cloud durability, durable jobs, streaming privacy, and UI polish are worker-ready enough for implementation waves; the process should not spend another turn broadly scouting these same areas.
+- Non-claim: this pass does not implement coverage tooling, signed-in cloud proof, durable job process-loss proof, streaming privacy migration, or UI polish. It only converts exploration into worker-ready execution guidance.
+
+Validation:
+
+- Pending for this branch: docs diff checks, recovery finish check, function-count check, commit, push, PR, and merge.
+
 ## 2026-07-05 01:54 EDT - Exploration Ticket Packet And Context Turnover
 
 Actions:

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -22,7 +22,12 @@ Self-review:
 
 Validation:
 
-- Pending for this branch: docs diff checks, recovery finish check, function-count check, commit, push, PR, and merge.
+- `git diff --check`: passed.
+- `npm run test:recovery-finish-check`: passed.
+- `scripts/recovery/check-vercel-function-count.sh`: passed at `11/12`.
+- Commit hook reran `npm run test:recovery-finish-check`: passed.
+- `git push -u origin recovery/story-lab-exploration-findings`: succeeded.
+- PR and merge are still pending for this branch.
 
 ## 2026-07-05 01:54 EDT - Exploration Ticket Packet And Context Turnover
 

--- a/STORY_LAB_EXPLORATION_FINDINGS.md
+++ b/STORY_LAB_EXPLORATION_FINDINGS.md
@@ -1,7 +1,7 @@
 # Story Lab Exploration Findings
 
 Created: 2026-07-05 02:25 EDT
-Last updated: 2026-07-05 02:25 EDT
+Last updated: 2026-07-05 02:27 EDT
 
 This is the durable synthesis of the EXP-01 through EXP-13 subagent exploration batch. It converts the read-only exploration pass into implementation-ready worker batches and a context turnover packet.
 
@@ -152,7 +152,7 @@ Current branch and commit: `recovery/story-lab-exploration-findings` from `95c10
 
 Upstream state: `main` was current with `origin/main` before this branch; no open PRs at synthesis time.
 
-Working tree state: docs-only synthesis changes in progress on this branch.
+Working tree state: docs-only synthesis committed on this branch; no tracked or untracked changes after commit/push verification.
 
 Open PRs and review-thread state: open PR list is empty. Review-thread audit was not rerun in this synthesis branch because no PR exists yet.
 
@@ -166,12 +166,12 @@ Decisions made: do not rerun the whole exploration batch by default; move to wor
 
 Subagent tickets dispatched and results: EXP-01 through EXP-13 all returned; statuses and findings are summarized above.
 
-Unmerged or local-only work: this branch contains docs-only synthesis until committed, pushed, and merged.
+Unmerged or local-only work: docs-only synthesis is pushed on `recovery/story-lab-exploration-findings`; it remains unmerged until the PR lands.
 
 Known unknowns: live credentialed auth/database proof, process-loss durable job proof, final coverage baselines, Proving Grounds exposure stance, old streaming GET compatibility stance.
 
 Parked topics not to revive: archived dependency investigation branches and the unsliced AI-review reference worktree are not active implementation lines.
 
-Next exact action: validate docs, commit, push, open PR, merge if checks and review-thread audit are clean.
+Next exact action: open PR, wait for required checks, audit unresolved review threads, and merge if clean.
 
 Recommended stop point: after this docs synthesis is merged to `main`, start the first implementation wave from this file.

--- a/STORY_LAB_EXPLORATION_FINDINGS.md
+++ b/STORY_LAB_EXPLORATION_FINDINGS.md
@@ -1,0 +1,177 @@
+# Story Lab Exploration Findings
+
+Created: 2026-07-05 02:25 EDT
+Last updated: 2026-07-05 02:25 EDT
+
+This is the durable synthesis of the EXP-01 through EXP-13 subagent exploration batch. It converts the read-only exploration pass into implementation-ready worker batches and a context turnover packet.
+
+Use this file before rerunning any EXP ticket. If these facts are still current, dispatch workers from this synthesis instead of spending another turn on broad scouting.
+
+## Live Repo Truth
+
+- Branch at synthesis time: `recovery/story-lab-exploration-findings`.
+- Base commit: `95c10d3 Add aggressive subagent exploration planning (#189)`.
+- Open PRs: none, verified with `gh pr list --state open --json number,title --limit 20`.
+- Main state before branch: `main...origin/main`, clean.
+- Remaining non-main worktree: `/Users/hbpheonix/fairytaleswithspice-ai-review-unsliced` on `ai-review/story-lab-unsliced-reference-do-not-merge`; treat as parked reference work, not the active line.
+
+## Exploration Status
+
+| Ticket | Status | Confidence | Main finding |
+|---|---:|---:|---|
+| EXP-01 Communication guardrails | Partial | 84% | Add WHY-vs-WHAT response discipline and artifact-first acceptance checks. |
+| EXP-02 Checklist aggression | Complete | 91% | Current checklist is still too conservative; many Explorer items should become Worker work. |
+| EXP-03 Files-touched mapping | Complete | 95% | Shared-file conflicts are clear; root `package.json`, Angular app files, job route files, and changelog edits must be serialized. |
+| EXP-04 PR/merge speed | Complete | 92% | Fast PR lane is viable: core CI plus unresolved-thread audit should drive merge timing, not advisory bot noise. |
+| EXP-05 Context turnover | Complete | 95% | Turnover packets should be written after subagent batches, PR events, risky branch switches, and crowded threads. |
+| EXP-06 Test/coverage readiness | Partial | 92% | No root/API coverage gate exists; Angular coverage exists at 85%; several runnable tests are outside `test:all`. |
+| EXP-07 Auth/cloud durability | Partial | 88% | Auth/storage are scaffolded and fail closed, but signed-in Clerk plus Postgres save/load/list/delete is not live-proven. |
+| EXP-08 Durable jobs | Partial | 88% | Interfaces, schema, Postgres store, and route wiring exist; default behavior is still process-local memory and process-loss proof is missing. |
+| EXP-09 Streaming privacy | Complete | 95% | Private blueprint/user-input fields still travel through streaming URLs; backend and UI transport must change. |
+| EXP-10 UI worker opportunity | Complete | 92% | Main app and Proving Grounds have direct worker-ready UI/test slices; Proving Grounds visibility remains parent-owned. |
+| EXP-11 Docs source-of-truth | Complete | 95% | Historical control docs were still over-prominent; parent verified live PR truth before applying any wording. |
+| EXP-12 Parallelization boundary | Complete | 86% | First implementation waves should be grouped by write scope, not theme. |
+| EXP-13 Process red-team | Complete | 90% | The exploration plan itself was too process-heavy; future passes should consolidate or skip low-unlock scouts. |
+
+## Plain-Language Findings
+
+### Tests And Coverage
+
+Estimated readiness: 45%.
+
+Tests exist, but the gate is not honest enough yet. Root/API tests do not emit coverage, and some important privacy/security/job tests are runnable but not part of `test:all`. Angular has real coverage tooling, but the threshold is 85% and the coverage command is not explicit enough for a repo-wide claim.
+
+Worker-ready next steps:
+
+- Add a focused privacy/security/job-contract test command.
+- Decide whether that command joins `test:all`.
+- Add root/API coverage with a real coverage tool.
+- Add explicit Angular coverage invocation before any 90% threshold decision.
+
+### Auth, Account, And Cloud Durability
+
+Estimated readiness: 65% scaffolded, 0% live-proven.
+
+The code has auth ports, owner-scoped storage ports, Postgres storage code, readiness checks, schema helpers, and fail-closed behavior. What is missing is the signed-in proof: real auth token, durable database, save/list/load/delete, and owner-isolation evidence.
+
+Worker-ready next steps:
+
+- Make DB/schema readiness scripts first-class commands.
+- Document a credential-safe runbook.
+- Add a signed-in account smoke script that skips cleanly when credentials are missing.
+- Run real provider proof only when credentials and database are available.
+
+### Durable Jobs
+
+Estimated readiness: 60% scaffolded, 0% process-loss-proven.
+
+The job architecture is coherent: contracts, store interface, in-memory store, Postgres store, schema, route wiring, and path safety exist. The default path remains `non_durable_memory`, and no proof shows job snapshots/events survive process loss.
+
+Worker-ready next steps:
+
+- Lock schema/readiness evidence.
+- Harden Postgres job store/config tests.
+- Wire durable mode through routes with owner enforcement.
+- Add process-loss proof, either true restart in staging or local simulated loss backed by durable store.
+
+### Streaming Privacy
+
+Estimated readiness: 55%.
+
+The current flow works, but private Story Lab blueprint fields and classic story user input can still appear in query strings. That is the highest privacy risk found in the batch.
+
+Worker-ready next steps:
+
+- Change backend streaming contracts so private payloads are accepted through body/job state, not URLs.
+- Change UI streaming code so EventSource or job-event URLs use opaque ids only.
+- Update stale streaming tests/docs that still describe query-string story payloads.
+
+### UI Polish
+
+Estimated readiness: 80%.
+
+Core UI actions are mostly guarded. The weaker spots are visible disabled/action-state proof, Proving Grounds interaction coverage, and the product decision about whether Proving Grounds stays behind `debug=1`.
+
+Worker-ready next steps:
+
+- Add main app action-state polish and DOM assertions.
+- Add Proving Grounds interaction/button-state coverage.
+- Keep Proving Grounds discoverability as a parent decision before changing nav exposure.
+
+### Docs And Process
+
+Estimated readiness: 85%.
+
+The docs are much better than before, but there was still stale routing toward historical docs. The bigger process lesson is that future scout work should be consolidated and should stop as soon as worker tickets are clear.
+
+Worker-ready next steps:
+
+- Keep `STORY_LAB_EXPLORATION_FINDINGS.md` as the latest synthesis.
+- Use `STORY_LAB_FUTURE_WORK_CHECKLIST.md` for dispatch, but follow the post-exploration wave plan instead of rerunning completed scouts.
+- Treat `STORY_LAB_UNPUBLISHED_BRANCH_SPLIT_PLAN.md` as historical unless explicitly needed.
+
+## First Implementation Wave
+
+These six workers can run together if they keep write scopes disjoint:
+
+| Worker | Goal | Write scope | Validation |
+|---|---|---|---|
+| W1 Test-surface truth pass | Add missing privacy/security/job-contract test command and document command map. | `package.json`, `tests/README.md`, optional `tests/run-all.mjs` | `npm run test:story-lab-privacy-contracts`; `npm run test:all` if included |
+| W2 Angular coverage command | Add explicit Angular coverage script without raising thresholds yet. | `story-generator/package.json`, `story-generator/karma.conf.js`, `story-generator/angular.json` | `cd story-generator && npm run test:coverage -- --watch=false --browsers=ChromeHeadless` |
+| W3 Cloud durability runbook | Document schema/readiness/live-proof steps without claiming proof. | `STORY_LAB_AUTH_PROFILE_CLOUD_LIBRARY_EXEC_PLAN.md`, `STORY_LAB_STORAGE_PORT_EXEC_PLAN.md` | `git diff --check`; secret-name-only review |
+| W4 Durable-job schema/readiness | Lock job-related schema/readiness proof before route work. | `api/_lib/story-lab/storage/storyLabCloudSchema.sql`, readiness tests/docs only | `npx tsx tests/story-lab-cloud-schema-migration.test.ts`; `npx tsx tests/story-lab-cloud-db-readiness.test.ts` |
+| W5 Main app action-state polish | Add visible action-state/DOM assertions for story and cloud controls. | `story-generator/src/app/app.html`, `story-generator/src/app/app.css`, `story-generator/src/app/app.spec.ts` | focused `app.spec.ts` run |
+| W6 Proving Grounds interaction coverage | Add button/action/history state tests and focused polish. | `story-generator/src/app/proving-grounds/*` | focused `proving-grounds.spec.ts` run |
+
+Parent should integrate and push each worker result from one controlling session. `package.json` must not be edited by two workers at once.
+
+## Second Implementation Wave
+
+Run after the first wave lands or after the parent confirms the shared files are free:
+
+- Root/API coverage bootstrap: `package.json`, `package-lock.json`, `scripts/recovery/run-root-self-tests.mjs`.
+- Account signed-in smoke: `scripts/recovery/story-lab-account-smoke.ts`, `package.json`.
+- Durable job store/config hardening: `api/_lib/story-lab/jobs/*Store*`, `api/_lib/story-lab/jobs/storyLabJobStoreConfig.ts`, focused job tests.
+- Streaming privacy backend patch: `api/story-lab/stream/genesis.ts`, `api/story/stream.ts`, parser/job route tests.
+- Streaming privacy UI migration: `story-generator/src/app/story.service.ts`, streaming specs.
+- Source-of-truth cleanup/final audit: active Story Lab docs only.
+
+## Parent Decisions Needed
+
+- Whether Proving Grounds stays behind `debug=1` or becomes visible in standard navigation.
+- Whether old streaming GET query compatibility must remain for any external client.
+- Whether job route query fallback for job ids should be removed now or treated as low-risk follow-up.
+- Which coverage threshold should be enforced after real root/API and Angular coverage artifacts exist.
+- When credentials/database access are available for live signed-in proof.
+
+## Context Turnover Packet
+
+Objective: complete the EXP-01 through EXP-13 exploration batch, synthesize findings, and leave a clean restart point.
+
+Current branch and commit: `recovery/story-lab-exploration-findings` from `95c10d3 Add aggressive subagent exploration planning (#189)`.
+
+Upstream state: `main` was current with `origin/main` before this branch; no open PRs at synthesis time.
+
+Working tree state: docs-only synthesis changes in progress on this branch.
+
+Open PRs and review-thread state: open PR list is empty. Review-thread audit was not rerun in this synthesis branch because no PR exists yet.
+
+What changed this run: all exploration reports were collected; stale open-PR wording was rejected after live GitHub verification; this findings doc, the subagent log, the future-work checklist, and operating docs were updated.
+
+Docs updated: `STORY_LAB_EXPLORATION_FINDINGS.md`, `STORY_LAB_FUTURE_WORK_CHECKLIST.md`, `SUBAGENT_LOG.md`, `PR70_RECOVERY_CHANGELOG.md`, `AGENTS.md`, `OVERNIGHT_MODE.md`.
+
+Commands run and results: `git status --short --branch` showed clean/current main before branching; `gh pr list --state open --json number,title --limit 20` returned `[]`; `git worktree list` showed the parked unsliced reference worktree.
+
+Decisions made: do not rerun the whole exploration batch by default; move to worker dispatch by write scope; keep parent control over PR actions, shared-file integration, source-of-truth docs, and product decisions.
+
+Subagent tickets dispatched and results: EXP-01 through EXP-13 all returned; statuses and findings are summarized above.
+
+Unmerged or local-only work: this branch contains docs-only synthesis until committed, pushed, and merged.
+
+Known unknowns: live credentialed auth/database proof, process-loss durable job proof, final coverage baselines, Proving Grounds exposure stance, old streaming GET compatibility stance.
+
+Parked topics not to revive: archived dependency investigation branches and the unsliced AI-review reference worktree are not active implementation lines.
+
+Next exact action: validate docs, commit, push, open PR, merge if checks and review-thread audit are clean.
+
+Recommended stop point: after this docs synthesis is merged to `main`, start the first implementation wave from this file.

--- a/STORY_LAB_FUTURE_WORK_CHECKLIST.md
+++ b/STORY_LAB_FUTURE_WORK_CHECKLIST.md
@@ -1,16 +1,18 @@
 # Story Lab Future Work Checklist
 
 Created: 2026-07-04 14:33 EDT
-Last updated: 2026-07-04 14:33 EDT
+Last updated: 2026-07-05 02:25 EDT
 
 This checklist breaks the unfinished Story Lab work into small tickets that a subagent can execute or audit. It is not a promise that all tickets should run at once. The parent agent must choose the next workstream, keep write scopes disjoint, verify results, open/merge PRs, and keep docs current.
 
 Before running a broad exploration batch, use `STORY_LAB_EXPLORATION_TICKETS.md`. That file defines the standard exploration report, context-turnover packet, and the explore-to-worker tickets needed to revise this checklist into larger worker chunks with `Files touched` fields.
 
+The 2026-07-05 exploration batch has already run. Use `STORY_LAB_EXPLORATION_FINDINGS.md` before rerunning any Explorer ticket; most scout work is now worker-ready and should not be repeated unless live repo state has changed.
+
 ## Current Snapshot
 
 - [x] **Repo hygiene:** `main` is current with `origin/main`.
-- [x] **Open PRs:** zero open PRs after PR #186 merged.
+- [x] **Open PRs:** zero open PRs, verified with `gh pr list --state open --json number,title --limit 20` on 2026-07-05 02:25 EDT.
 - [x] **Old dependency investigation:** archived at `origin/archive/angular22-dependency-investigation-2026-07-04`; it is evidence only, not an active workstream or PR.
 - [x] **Whole-concept status:** `STORY_LAB_CONCEPT_CHECKLIST.md` is merged.
 - [x] **Public Story Lab loop:** create, continue, local save, copy, download, and progress UI exist.
@@ -18,6 +20,37 @@ Before running a broad exploration batch, use `STORY_LAB_EXPLORATION_TICKETS.md`
 - [ ] **Coverage proof:** root/API coverage tooling and repo-wide coverage evidence do not exist.
 - [ ] **Durable jobs:** job state is still explicitly `non_durable_memory`.
 - [ ] **Final completion report:** not ready until durability, coverage, and final audits are proven.
+- [x] **Exploration batch:** EXP-01 through EXP-13 completed and synthesized in `STORY_LAB_EXPLORATION_FINDINGS.md`.
+
+## Post-Exploration Execution Batches
+
+Do not rerun the full EXP batch by default. The next productive move is worker dispatch from the synthesis.
+
+### First Implementation Wave
+
+These six tasks can run in parallel if each worker keeps the listed write scope:
+
+| Worker | Why now | Write scope |
+|---|---|---|
+| Test-surface truth pass | Several runnable privacy/security/job tests are outside `test:all`; fix the command map before coverage. | `package.json`, `tests/README.md`, optional `tests/run-all.mjs` |
+| Angular coverage command | Angular already has `karma-coverage`; make invocation explicit without raising thresholds yet. | `story-generator/package.json`, `story-generator/karma.conf.js`, `story-generator/angular.json` |
+| Auth/cloud proof runbook | Signed-in durability is scaffolded but not live-proven; document the exact safe proof path. | `STORY_LAB_AUTH_PROFILE_CLOUD_LIBRARY_EXEC_PLAN.md`, `STORY_LAB_STORAGE_PORT_EXEC_PLAN.md` |
+| Durable-job schema/readiness proof | Job schema and readiness checks exist; lock that boundary before route/process-loss work. | `api/_lib/story-lab/storage/storyLabCloudSchema.sql`, readiness tests/docs only |
+| Main app action-state polish | Existing UI guards work, but visible disabled/action-state tests are thin. | `story-generator/src/app/app.html`, `story-generator/src/app/app.css`, `story-generator/src/app/app.spec.ts` |
+| Proving Grounds interaction coverage | The route exists; interaction/button-state coverage is minimal and isolated. | `story-generator/src/app/proving-grounds/*` |
+
+### Second Implementation Wave
+
+Run after root `package.json` is free and the first wave has evidence:
+
+| Worker | Why second | Write scope |
+|---|---|---|
+| Root/API coverage bootstrap | Needs root dependency/script edits and should not collide with the test-surface pass. | `package.json`, `package-lock.json`, `scripts/recovery/run-root-self-tests.mjs` |
+| Account signed-in smoke | Needs package/script edits and possibly credential-safe skip behavior. | `scripts/recovery/story-lab-account-smoke.ts`, `package.json` |
+| Durable job store/config hardening | Deeper job persistence work after schema/readiness is locked. | `api/_lib/story-lab/jobs/*Store*`, `api/_lib/story-lab/jobs/storyLabJobStoreConfig.ts`, focused tests |
+| Streaming privacy backend patch | Private payloads are in URLs; backend transport needs body/job-based replacement. | `api/story-lab/stream/genesis.ts`, `api/story/stream.ts`, parser/job route tests |
+| Streaming privacy UI migration | Must follow or pair with backend transport; removes private payloads from browser-visible URLs. | `story-generator/src/app/story.service.ts`, streaming specs |
+| Final source-of-truth cleanup | Keep only live docs as current and route historical docs as historical. | `AGENTS.md`, `OVERNIGHT_MODE.md`, active Story Lab plan docs |
 
 ## How To Use This Checklist
 

--- a/SUBAGENT_LOG.md
+++ b/SUBAGENT_LOG.md
@@ -20,6 +20,47 @@ Parent verification:
 Follow-ups:
 ```
 
+## 2026-07-05 02:25 EDT - Story Lab Exploration Findings Batch
+
+Parent branch / PR: `recovery/story-lab-exploration-findings` / pending
+
+Goal: complete the EXP-01 through EXP-13 exploration tickets, convert the results into worker-ready implementation batches, and leave a compact context turnover packet.
+
+Parent analysis before dispatch:
+
+- The user wanted all exploration completed before another implementation run.
+- The maximum useful concurrency was six agents at once.
+- The parent kept strategy, live GitHub truth, stale-doc correction, final synthesis, and publication actions in the parent session.
+- Exploration output was accepted only when it named worker tickets, files touched, shared-file conflicts, and validation commands.
+
+| Agent | Model | Role | Scope | Status | Result | Integrated? |
+|---|---|---|---|---|---|---|
+| Darwin | `gpt-5.3-codex-spark` | explorer | EXP-01 communication guardrails | Partial | Found artifact substitution, WHY/WHAT inversion, and parked-topic revival as main failure modes | Integrated into synthesis; follow-up guidance still needed |
+| Socrates | `gpt-5.3-codex-spark` | explorer | EXP-02 checklist aggression | Done | Reclassified many future-work items from Explorer to Worker and proposed aggressive waves | Integrated into first/second wave synthesis |
+| Bacon | `gpt-5.3-codex-spark` | explorer | EXP-03 files-touched mapping | Done | Named shared-file conflicts and package/UI/job-route bottlenecks | Integrated into wave conflict rules |
+| Copernicus | `gpt-5.3-codex-spark` | explorer | EXP-04 PR/merge speed | Done | Proposed fast PR lane based on core CI and unresolved-thread checks | Integrated as process guidance |
+| Franklin | `gpt-5.3-codex-spark` | explorer | EXP-05 context turnover | Done | Confirmed turnover packet fields and triggers | Integrated into this findings handoff |
+| Harvey | `gpt-5.3-codex-spark` | explorer | EXP-06 tests/coverage | Partial | Found no root/API coverage gate, Angular 85% threshold, and omitted runnable tests | Integrated into test/coverage worker plan |
+| Singer | `gpt-5.3-codex-spark` | explorer | EXP-07 auth/cloud durability | Partial | Found scaffolded fail-closed auth/storage but no live signed-in proof | Integrated into auth/cloud worker plan |
+| Pasteur | `gpt-5.3-codex-spark` | explorer | EXP-08 durable jobs | Partial | Found coherent durable-job scaffold but no process-loss proof | Integrated into durable-job worker plan |
+| Erdos | `gpt-5.3-codex-spark` | explorer | EXP-09 streaming privacy | Done | Found private payloads still travel through streaming URLs | Integrated into streaming privacy worker plan |
+| Jason | `gpt-5.3-codex-spark` | explorer | EXP-10 UI opportunities | Done | Found main app and Proving Grounds worker-ready UI/test slices | Integrated into UI worker plan |
+| Noether | `gpt-5.3-codex-spark` | explorer | EXP-11 docs source-of-truth | Done | Found stale doc routing, but included a stale open-PR claim that parent rejected after live verification | Partially integrated with correction |
+| Arendt | `gpt-5.3-codex-spark` | explorer | EXP-12 parallelization boundaries | Done | Proposed disjoint implementation waves and shared-file limits | Integrated into first/second wave synthesis |
+| Bernoulli | `gpt-5.3-codex-spark` | explorer | EXP-13 process red-team | Done | Critiqued the batch as too process-heavy and recommended consolidation before future scouting | Integrated into do-not-rerun guidance |
+
+Parent verification:
+
+- Parent verified live open PR state with `gh pr list --state open --json number,title --limit 20`; result was `[]`.
+- Parent rejected the stale EXP-11 wording that treated old dependency PRs as open.
+- Parent verified current branch base and parked worktree state before writing the synthesis.
+
+Follow-ups:
+
+- Commit, push, open, and merge this docs-only synthesis branch.
+- Start the next implementation run from `STORY_LAB_EXPLORATION_FINDINGS.md`.
+- Do not rerun EXP-01 through EXP-13 unless live repo state changes enough to invalidate the synthesis.
+
 ## 2026-07-04 07:16 EDT - Whole Story Lab Concept Checklist Audit
 
 Parent branch / PR: `recovery/story-lab-concept-checklist` / pending


### PR DESCRIPTION
## Summary
- add STORY_LAB_EXPLORATION_FINDINGS.md with EXP-01 through EXP-13 findings, readiness percentages, worker-ready batches, parent decisions, and context turnover packet
- update future-work checklist so the next session starts from worker dispatch instead of rerunning completed exploration
- update AGENTS.md, OVERNIGHT_MODE.md, SUBAGENT_LOG.md, and PR70_RECOVERY_CHANGELOG.md with current source-of-truth routing and subagent-batch evidence

## Validation
- git diff --check
- npm run test:recovery-finish-check
- scripts/recovery/check-vercel-function-count.sh (11/12)

## Non-claims
- does not implement coverage tooling, signed-in cloud proof, durable job process-loss proof, streaming privacy migration, or UI polish
- does not revive archived dependency investigation work
