### PR TITLE
Address Story Lab exploration review comments

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -4,6 +4,27 @@ Created: 2026-05-26 00:12 EDT
 
 This is the chronological work log for the PR #70 recovery. It should capture commands, decisions, self-review notes, validation results, and anything that changes the plan.
 
+## 2026-07-05 02:33 EDT - Exploration Findings Review Follow-Up
+
+Actions:
+
+- Addressed post-merge review feedback from PR #190 by removing a machine-specific absolute path from `STORY_LAB_EXPLORATION_FINDINGS.md`.
+- Clarified that proposed second-wave scripts are new files to be created, not existing files.
+- Standardized the proposed account smoke script name to `scripts/recovery/story-lab-account-smoke.mjs`.
+- Clarified that `npm run test:story-lab-privacy-contracts` is a command W1 must create before it can be run.
+
+Self-review:
+
+- Correction: docs should not leak local absolute paths or imply future script files already exist.
+- Non-claim: this pass is docs-only and does not create the proposed smoke or coverage scripts.
+
+Validation:
+
+- `git diff --check`: passed.
+- `npm run test:recovery-finish-check`: passed.
+- Reference scan found no `/Users/hbpheonix` path and no `story-lab-account-smoke.ts` reference.
+- PR, merge, and thread resolution are still pending for this follow-up branch.
+
 ## 2026-07-05 02:25 EDT - Exploration Findings Synthesis
 
 Actions:

--- a/STORY_LAB_EXPLORATION_FINDINGS.md
+++ b/STORY_LAB_EXPLORATION_FINDINGS.md
@@ -1,7 +1,7 @@
 # Story Lab Exploration Findings
 
 Created: 2026-07-05 02:25 EDT
-Last updated: 2026-07-05 02:27 EDT
+Last updated: 2026-07-05 02:33 EDT
 
 This is the durable synthesis of the EXP-01 through EXP-13 subagent exploration batch. It converts the read-only exploration pass into implementation-ready worker batches and a context turnover packet.
 
@@ -13,7 +13,7 @@ Use this file before rerunning any EXP ticket. If these facts are still current,
 - Base commit: `95c10d3 Add aggressive subagent exploration planning (#189)`.
 - Open PRs: none, verified with `gh pr list --state open --json number,title --limit 20`.
 - Main state before branch: `main...origin/main`, clean.
-- Remaining non-main worktree: `/Users/hbpheonix/fairytaleswithspice-ai-review-unsliced` on `ai-review/story-lab-unsliced-reference-do-not-merge`; treat as parked reference work, not the active line.
+- Remaining non-main worktree: a local parked reference worktree on `ai-review/story-lab-unsliced-reference-do-not-merge`; treat it as evidence only, not the active line.
 
 ## Exploration Status
 
@@ -116,7 +116,7 @@ These six workers can run together if they keep write scopes disjoint:
 
 | Worker | Goal | Write scope | Validation |
 |---|---|---|---|
-| W1 Test-surface truth pass | Add missing privacy/security/job-contract test command and document command map. | `package.json`, `tests/README.md`, optional `tests/run-all.mjs` | `npm run test:story-lab-privacy-contracts`; `npm run test:all` if included |
+| W1 Test-surface truth pass | Add missing privacy/security/job-contract test command and document command map. | `package.json`, `tests/README.md`, optional `tests/run-all.mjs` | After W1 creates it: `npm run test:story-lab-privacy-contracts`; `npm run test:all` if included |
 | W2 Angular coverage command | Add explicit Angular coverage script without raising thresholds yet. | `story-generator/package.json`, `story-generator/karma.conf.js`, `story-generator/angular.json` | `cd story-generator && npm run test:coverage -- --watch=false --browsers=ChromeHeadless` |
 | W3 Cloud durability runbook | Document schema/readiness/live-proof steps without claiming proof. | `STORY_LAB_AUTH_PROFILE_CLOUD_LIBRARY_EXEC_PLAN.md`, `STORY_LAB_STORAGE_PORT_EXEC_PLAN.md` | `git diff --check`; secret-name-only review |
 | W4 Durable-job schema/readiness | Lock job-related schema/readiness proof before route work. | `api/_lib/story-lab/storage/storyLabCloudSchema.sql`, readiness tests/docs only | `npx tsx tests/story-lab-cloud-schema-migration.test.ts`; `npx tsx tests/story-lab-cloud-db-readiness.test.ts` |
@@ -129,8 +129,8 @@ Parent should integrate and push each worker result from one controlling session
 
 Run after the first wave lands or after the parent confirms the shared files are free:
 
-- Root/API coverage bootstrap: `package.json`, `package-lock.json`, `scripts/recovery/run-root-self-tests.mjs`.
-- Account signed-in smoke: `scripts/recovery/story-lab-account-smoke.ts`, `package.json`.
+- Root/API coverage bootstrap: `package.json`, `package-lock.json`, new `scripts/recovery/run-root-self-tests.mjs`.
+- Account signed-in smoke: new `scripts/recovery/story-lab-account-smoke.mjs`, `package.json`.
 - Durable job store/config hardening: `api/_lib/story-lab/jobs/*Store*`, `api/_lib/story-lab/jobs/storyLabJobStoreConfig.ts`, focused job tests.
 - Streaming privacy backend patch: `api/story-lab/stream/genesis.ts`, `api/story/stream.ts`, parser/job route tests.
 - Streaming privacy UI migration: `story-generator/src/app/story.service.ts`, streaming specs.

--- a/STORY_LAB_FUTURE_WORK_CHECKLIST.md
+++ b/STORY_LAB_FUTURE_WORK_CHECKLIST.md
@@ -1,7 +1,7 @@
 # Story Lab Future Work Checklist
 
 Created: 2026-07-04 14:33 EDT
-Last updated: 2026-07-05 02:25 EDT
+Last updated: 2026-07-05 02:33 EDT
 
 This checklist breaks the unfinished Story Lab work into small tickets that a subagent can execute or audit. It is not a promise that all tickets should run at once. The parent agent must choose the next workstream, keep write scopes disjoint, verify results, open/merge PRs, and keep docs current.
 
@@ -45,8 +45,8 @@ Run after root `package.json` is free and the first wave has evidence:
 
 | Worker | Why second | Write scope |
 |---|---|---|
-| Root/API coverage bootstrap | Needs root dependency/script edits and should not collide with the test-surface pass. | `package.json`, `package-lock.json`, `scripts/recovery/run-root-self-tests.mjs` |
-| Account signed-in smoke | Needs package/script edits and possibly credential-safe skip behavior. | `scripts/recovery/story-lab-account-smoke.ts`, `package.json` |
+| Root/API coverage bootstrap | Needs root dependency/script edits and should not collide with the test-surface pass. | `package.json`, `package-lock.json`, new `scripts/recovery/run-root-self-tests.mjs` |
+| Account signed-in smoke | Needs package/script edits and possibly credential-safe skip behavior. | new `scripts/recovery/story-lab-account-smoke.mjs`, `package.json` |
 | Durable job store/config hardening | Deeper job persistence work after schema/readiness is locked. | `api/_lib/story-lab/jobs/*Store*`, `api/_lib/story-lab/jobs/storyLabJobStoreConfig.ts`, focused tests |
 | Streaming privacy backend patch | Private payloads are in URLs; backend transport needs body/job-based replacement. | `api/story-lab/stream/genesis.ts`, `api/story/stream.ts`, parser/job route tests |
 | Streaming privacy UI migration | Must follow or pair with backend transport; removes private payloads from browser-visible URLs. | `story-generator/src/app/story.service.ts`, streaming specs |
@@ -108,7 +108,7 @@ Do not dispatch two workers that write the same file. Do not dispatch implementa
   - Goal: add a repeatable script such as `test:story-lab-privacy-contracts` and decide whether it belongs in `test:all`.
   - Stop condition: if any listed test is not self-running under `tsx`, report the exact failure and stop.
   - Output: package-script diff plus command evidence.
-  - Validation: `npm run test:story-lab-privacy-contracts`; if added to the full gate, `npm run test:all`.
+  - Validation: after the worker creates the script, `npm run test:story-lab-privacy-contracts`; if added to the full gate, `npm run test:all`.
 
 - [ ] **1.3 Root/API coverage tool decision**
   - Role: Explorer.


### PR DESCRIPTION
## Summary
- remove machine-specific local path from the exploration findings doc
- clarify proposed scripts are new files to be created by later workers
- standardize the proposed account smoke script to .mjs
- clarify the proposed privacy-contract test command is only runnable after W1 creates it

## Validation
- git diff --check
- npm run test:recovery-finish-check
- reference scan for the removed absolute path and .ts account-smoke reference

## Follow-up to
- PR #190 post-merge review threads
