### PR TITLE
Scope exploration review validation wording

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -22,7 +22,7 @@ Validation:
 
 - `git diff --check`: passed.
 - `npm run test:recovery-finish-check`: passed.
-- Reference scan found no `/Users/hbpheonix` path and no `story-lab-account-smoke.ts` reference.
+- Reference scan over the touched docs found no machine-specific worktree path and no `story-lab-account-smoke.ts` reference.
 - PR, merge, and thread resolution are still pending for this follow-up branch.
 
 ## 2026-07-05 02:25 EDT - Exploration Findings Synthesis


### PR DESCRIPTION
## Summary
- clarify the PR #191 changelog validation line so it refers to the touched docs scan, not a whole-repo path scan

## Validation
- git diff --check
- npm run test:recovery-finish-check

## Follow-up to
- PR #191 review thread on PR70_RECOVERY_CHANGELOG.md

## Summary by Sourcery

Documentation:
- Update recovery changelog wording to better describe the scope of the reference scan over touched docs.