### PR TITLE
Fix three defects in quality scoring, trope selection, and PDF export

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -4,6 +4,30 @@ Created: 2026-05-26 00:12 EDT
 
 This is the chronological work log for the PR #70 recovery. It should capture commands, decisions, self-review notes, validation results, and anything that changes the plan.
 
+## 2026-08-24 20:05 UTC - HTML-Blind Quality Heuristics, Undercounted Trope Pools, And Fabricated PDF Xref Offsets
+
+Actions:
+
+- Split story content into text blocks before scoring it in `storyQualityHeuristics`. The evaluation route is called with the story exactly as the generator renders it — `<p>` elements on one line, `[Speaker]:` tags inside those elements, no blank lines anywhere — but the scan split paragraphs on blank lines and looked for speaker tags at the start of a line. Against that markup every paragraph-shaped and dialogue-shaped signal reported the opposite of what the story holds: the whole story counted as one paragraph, so `cliffhanger_quality` scanned the entire text as if it were the ending and `audio_readiness` marked every story as one overlong block; no `[Speaker]:` tag ever started a line, so no story was credited with dialogue or speaker variety; and `<p>Hello</p>` counted as a single word. Block-level tags and `<br>` now become block boundaries, inline tags are dropped, and basic entities are decoded, so each dimension reads the prose the reader sees. Plain-text callers are unaffected: their blank-line boundaries are honoured exactly as before.
+- Counted distinct tropes, not pool entries, when deciding whether a preferred-intensity pool can satisfy `selectTropesForSubversion`. The pool is weighted by repetition — every common trope is pushed three times — so one trope at the requested intensity looked like three candidates. A caller asking for two `subtle` werewolf tropes got one: the loop drains every copy of the only id it holds and never falls back to the wider pool that could supply the second.
+- Built the mock PDF's cross-reference table from the document being written. The object offsets and `startxref` were fixed constants, so they addressed whatever bytes a real title and excerpt pushed into their place; no entry pointed at an object header and `startxref` did not point at the table. Each entry is now measured with `Buffer.byteLength` as the objects are assembled, and the records keep the fixed 20-byte width the format requires. This answers the open item the 19:00 UTC slice recorded as a non-claim.
+- Added a regression case to each of the three existing suites: HTML-shaped input in `tests/story-quality-evals.test.ts`, a preferred-intensity property over every creature and intensity in `tests/trope-subversion.test.ts`, and an xref-resolves-its-objects case over three title lengths in `tests/export-service.test.ts`.
+
+Self-review:
+
+- Good: Each fix was checked against a targeted revert of the source change with the new tests in place, and each fails there — `werewolf/subtle ... (got 1)`, `Paragraphs: 1` on a four-paragraph HTML story, and `startxref ... should point at the cross-reference table`.
+- Good: The trope and xref tests assert properties rather than fixtures — every creature and intensity combination, and every entry in the table against the object it addresses — so a later database entry or added PDF object is covered without editing the test.
+- Non-claim: The PDF remains the mock its own comment describes. The table is now internally consistent, which is not the same as a valid PDF; a real generator (pdfkit or similar) is still the open work, and the EPUB fragment still has no `unique-identifier`/`dc:identifier` pair, container, or chapter files.
+- Non-claim: The heuristic scan still reads only what the request carries. Nothing here changes the AI evaluation path, the scoring formulas, or the dimension list — only the text those formulas are applied to.
+
+Validation:
+
+- `npm run test:all`: passed.
+- Targeted counterfactual: `git stash push -- api/` with the new tests in place; all three suites failed with the messages quoted above; restored immediately and not committed.
+- `tsc --noEmit --strict` over the three changed source files: passed with no diagnostics.
+- `git diff --check`: passed.
+- Note: `node_modules` is tracked in this repository. Installing dependencies to run the suite modified those tracked files; they were restored so the slice diff stays source-only.
+
 ## 2026-08-24 19:00 UTC - PDF Stream Length, PDF Excerpt Cut Boundary, EPUB Namespace, And Level-Filtered Log Reads
 
 Actions:

--- a/api/_lib/services/exportService.ts
+++ b/api/_lib/services/exportService.ts
@@ -160,24 +160,17 @@ export class ExportService {
 (${excerpt}...) Tj
 ET`;
 
-    return `%PDF-1.4
-1 0 obj
-<<
+    const objects = [
+      `<<
 /Type /Catalog
 /Pages 2 0 R
->>
-endobj
-
-2 0 obj
-<<
+>>`,
+      `<<
 /Type /Pages
 /Kids [3 0 R]
 /Count 1
->>
-endobj
-
-3 0 obj
-<<
+>>`,
+      `<<
 /Type /Page
 /Parent 2 0 R
 /MediaBox [0 0 612 792]
@@ -187,42 +180,65 @@ endobj
 /F1 5 0 R
 >>
 >>
->>
-endobj
-
-4 0 obj
-<<
+>>`,
+      `<<
 /Length ${Buffer.byteLength(contentStream, 'utf8')}
 >>
 stream
 ${contentStream}
-endstream
-endobj
-
-5 0 obj
-<<
+endstream`,
+      `<<
 /Type /Font
 /Subtype /Type1
 /BaseFont /Helvetica
->>
-endobj
+>>`
+    ];
 
-xref
-0 6
-0000000000 65535 f
-0000000009 00000 n
-0000000058 00000 n
-0000000115 00000 n
-0000000274 00000 n
-0000000354 00000 n
+    return this.assemblePdfDocument(objects);
+  }
+
+  /**
+   * Write the objects out with a cross-reference table that points at them.
+   *
+   * A reader resolves an object by seeking to the byte offset the xref table
+   * gives for it, and finds the table itself through `startxref`. Those offsets
+   * therefore have to be measured from the document being written: they used to
+   * be fixed constants copied from some earlier draft, so they addressed the
+   * middle of whatever a real title and excerpt happened to push into their
+   * place, and every object lookup landed on bytes that are not an object
+   * header. Each entry is measured here as the document is assembled, so the
+   * table stays correct however long the story's title and excerpt are.
+   */
+  private assemblePdfDocument(objects: string[]): string {
+    let document = '%PDF-1.4\n';
+    const offsets: number[] = [];
+
+    objects.forEach((body, index) => {
+      offsets.push(Buffer.byteLength(document, 'utf8'));
+      document += `${index + 1} 0 obj\n${body}\nendobj\n\n`;
+    });
+
+    const xrefOffset = Buffer.byteLength(document, 'utf8');
+    const entries = [
+      // The head of the free-object list: object 0 is always free, and its
+      // generation number is the 65535 the spec reserves for it.
+      '0000000000 65535 f ',
+      ...offsets.map(offset => `${String(offset).padStart(10, '0')} 00000 n `)
+    ];
+
+    document += `xref
+0 ${objects.length + 1}
+${entries.join('\n')}
 trailer
 <<
-/Size 6
+/Size ${objects.length + 1}
 /Root 1 0 R
 >>
 startxref
-454
+${xrefOffset}
 %%EOF`;
+
+    return document;
   }
 
   private generateHTMLContent(content: string, metadata: ExportMetadata, input: SaveExportSeam['input']): string {

--- a/api/_lib/services/tropeSubversionService.ts
+++ b/api/_lib/services/tropeSubversionService.ts
@@ -174,11 +174,17 @@ export class TropeSubversionService {
   ): Trope[] {
     const selected: Trope[] = [];
     const usedIds = new Set<string>();
-    const poolCopy = preferredIntensity
+    const preferredPool = preferredIntensity
       ? pool.filter(trope => trope.intensity === preferredIntensity)
       : [...pool];
     const fallbackPool = [...pool];
-    const activePool = poolCopy.length >= count ? poolCopy : fallbackPool;
+    // The pool is weighted by repetition — every common trope is pushed three
+    // times — so its length says nothing about how many distinct tropes it can
+    // yield. Counting entries instead of distinct ids kept a preferred-intensity
+    // pool that held one trope three times, and the caller asking for two
+    // tropes then got one: the loop drains every copy of the only id it has and
+    // never reaches the wider pool that could have completed the selection.
+    const activePool = countDistinctTropes(preferredPool) >= count ? preferredPool : fallbackPool;
 
     while (selected.length < count && activePool.length > 0) {
       const randomIndex = randomInt(activePool.length);
@@ -223,4 +229,8 @@ ${tropeLines}
 ${tropeLines}
 - Do not reverse or contradict these established inversions.`;
   }
+}
+
+function countDistinctTropes(tropes: readonly Trope[]): number {
+  return new Set(tropes.map(trope => trope.id)).size;
 }

--- a/api/_lib/story-lab/evaluation/storyQualityHeuristics.ts
+++ b/api/_lib/story-lab/evaluation/storyQualityHeuristics.ts
@@ -18,19 +18,30 @@ type DimensionDraft = Omit<StoryQualityDimensionScore, 'score'> & {
 };
 
 export function buildStoryQualityHeuristicReport(input: StoryQualityHeuristicInput): StoryQualityHeuristicReport {
-  const storyText = collapseWhitespace(input.storyContent);
+  // Stories reach this scan as the HTML the generator produces: paragraphs are
+  // `<p>` elements on a single line, not blocks separated by blank lines. Read
+  // against the raw markup, every paragraph-shaped signal collapsed — the whole
+  // story counted as one paragraph, so the cliffhanger dimension scanned the
+  // entire text as if it were the ending and the audio dimension marked every
+  // story as one overlong block; `[Speaker]:` tags never started a line, so no
+  // story was ever credited with dialogue; and `<p>Hello</p>` counted as a
+  // single word. Recovering the block structure first makes every dimension
+  // read the prose the way the reader sees it, and leaves plain-text callers
+  // (blank-line separated, one tag per line) scoring exactly as before.
+  const paragraphs = splitIntoTextBlocks(input.storyContent);
+  const plainStory = paragraphs.join('\n\n');
+  const storyText = collapseWhitespace(plainStory);
   const lowerStory = storyText.toLowerCase();
-  const paragraphs = input.storyContent.split(/\n\s*\n/).map(paragraph => paragraph.trim()).filter(Boolean);
   const sentences = storyText.split(/[.!?]+/).map(sentence => sentence.trim()).filter(Boolean);
   const words = storyText.split(/\s+/).filter(Boolean);
-  const dialogueLines = input.storyContent.split('\n').filter(line => /^\s*\[[^\]]+\]:/.test(line));
+  const dialogueLines = plainStory.split('\n').filter(line => /^\s*\[[^\]]+\]:/.test(line));
   const dimensions: StoryQualityDimensionScore[] = [
     scoreContinuity(lowerStory, input.configuration),
     scoreCliffhangerQuality(lowerStory, paragraphs),
     scoreTropeFreshness(lowerStory),
     scoreEmotionalVariety(lowerStory),
-    scoreCharacterConsistency(input.storyContent, dialogueLines),
-    scoreProseQuality(input.storyContent, words.length, sentences.length, paragraphs.length),
+    scoreCharacterConsistency(plainStory, dialogueLines),
+    scoreProseQuality(plainStory, words.length, sentences.length, paragraphs.length),
     scoreAudioReadiness(dialogueLines, paragraphs)
   ].map(normalizeDimension);
   const overallScore = clampScore(Math.round(
@@ -225,6 +236,43 @@ function containsAny(value: string, needles: readonly string[]): boolean {
 
 function collapseWhitespace(value: string): string {
   return value.replace(/\s+/g, ' ').trim();
+}
+
+const BLOCK_LEVEL_TAG_NAMES = 'p|div|section|article|blockquote|li|ul|ol|h[1-6]|figure|figcaption|table|tr';
+const BLOCK_BOUNDARY_PATTERN = new RegExp(
+  String.raw`<\s*br\s*/?\s*>|<\s*/?\s*(?:${BLOCK_LEVEL_TAG_NAMES})(?:\s[^>]*)?\s*/?\s*>`,
+  'gi'
+);
+
+/**
+ * Split story content into the blocks a reader sees as paragraphs.
+ *
+ * Block-level tags and `<br>` become blank-line boundaries, remaining inline
+ * tags are dropped, and the basic entities the generator emits are decoded so
+ * that a quoted line still reads as dialogue. Plain text passes through with
+ * only its blank-line boundaries honoured, which is what the earlier
+ * blank-line split did on its own.
+ */
+function splitIntoTextBlocks(storyContent: string): string[] {
+  return storyContent
+    .replace(BLOCK_BOUNDARY_PATTERN, '\n\n')
+    .split(/\n\s*\n/)
+    .map(block => decodeBasicEntities(stripInlineTags(block)).trim())
+    .filter(Boolean);
+}
+
+function stripInlineTags(value: string): string {
+  return value.replace(/<[^>]*>/g, '');
+}
+
+function decodeBasicEntities(value: string): string {
+  return value
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/gi, '&');
 }
 
 function extractDialogueSpeakers(dialogueLines: string[]): string[] {

--- a/tests/export-service.test.ts
+++ b/tests/export-service.test.ts
@@ -150,8 +150,55 @@ async function testEpubBindsEveryNamespacePrefixItUses(): Promise<void> {
   }
 }
 
+// A reader resolves an object by seeking to the byte offset the xref table
+// gives for it, and finds the table through `startxref`. Both used to be fixed
+// constants, so they addressed whatever bytes a real title and excerpt pushed
+// into their place and no object lookup landed on an object header.
+async function testPdfCrossReferenceTablePointsAtItsObjects(): Promise<void> {
+  const exportService = new ExportService();
+
+  for (const title of ['A', 'Midnight Bargain', 'Élodie and the 🐉 of the Château (Part Two)']) {
+    const document = await exportService.generateExportContent(
+      createInput({ format: 'pdf', title, content: unicodeStory.repeat(4) })
+    );
+    const bytes = Buffer.from(document, 'utf8');
+
+    const startxref = /startxref\n(\d+)\n%%EOF$/.exec(document);
+    assert(startxref, `the PDF for "${title}" should end with a startxref offset`);
+    assert(
+      bytes.subarray(Number(startxref[1])).toString('utf8').startsWith('xref\n'),
+      `startxref for "${title}" should point at the cross-reference table`
+    );
+
+    const table = /\nxref\n0 (\d+)\n([\s\S]*?)\ntrailer\n/.exec(document);
+    assert(table, `the PDF for "${title}" should contain a cross-reference table`);
+    const entries = table[2].split('\n');
+    assert(
+      entries.length === Number(table[1]),
+      `the table for "${title}" should hold one entry per object it declares ` +
+        `(declared=${table[1]}, entries=${entries.length})`
+    );
+    assert(
+      entries.every(entry => Buffer.byteLength(`${entry}\n`, 'utf8') === 20),
+      `every entry for "${title}" should keep the fixed 20-byte record width`
+    );
+    assert(entries[0] === '0000000000 65535 f ', `object 0 for "${title}" should head the free list`);
+
+    entries.slice(1).forEach((entry, index) => {
+      const objectNumber = index + 1;
+      const offset = Number(/^(\d{10}) \d{5} n $/.exec(entry)?.[1]);
+      assert(Number.isFinite(offset), `entry ${objectNumber} for "${title}" should be a well-formed xref record`);
+      assert(
+        bytes.subarray(offset).toString('utf8').startsWith(`${objectNumber} 0 obj\n`),
+        `entry ${objectNumber} for "${title}" should point at that object's header`
+      );
+    });
+  }
+}
+
 async function main(): Promise<void> {
   await testDownloadUrlMatchesReportedFilename();
+  await testPdfCrossReferenceTablePointsAtItsObjects();
   await testFileSizeIsMeasuredInBytes();
   await testPdfStreamLengthDescribesTheStream();
   await testPdfExcerptIsCutOnCharacterBoundaries();

--- a/tests/story-quality-evals.test.ts
+++ b/tests/story-quality-evals.test.ts
@@ -103,7 +103,69 @@ const classicStory: ClassicGenerationSeam['output'] = {
   nextChapterHint: 'Reveal which oath the shell recorded.'
 };
 
+// The evaluation route is called with the story exactly as the generator
+// renders it: `<p>` elements on one line, `[Speaker]:` tags inside those
+// elements, no blank lines anywhere. Scored against the raw markup, the whole
+// story counted as a single paragraph and no line ever started with a speaker
+// tag, so the paragraph-shaped and dialogue-shaped dimensions all reported the
+// opposite of what the story contains.
+function testHtmlStoriesAreScoredOnTheirProse(): void {
+  const htmlStory = '<section><h3>The Witness Shell</h3>'
+    + '<p>[Narrator]: Salt stung her wrist as the witness shell glowed under the reef arch.</p>'
+    + '<p>[Mira]: &quot;If the shell repeats my vow, Lord Brine owns the court by sunrise.&quot;</p>'
+    + '<p>[Lord Brine]: &quot;Then choose which secret survives the tide.&quot;</p>'
+    + '<p>Mira touched the blood oath hidden under her sleeve. Whose name would the shell give up?</p>'
+    + '</section>';
+
+  const report = buildStoryQualityHeuristicReport({
+    storyContent: htmlStory,
+    configuration: {
+      creature: 'siren',
+      themes: ['blood_oaths'],
+      spicyLevel: 3,
+      wordCount: 900
+    }
+  });
+
+  const dimension = (id: string) => {
+    const found = report.dimensions.find(entry => entry.id === id);
+    assert(found, `report should include the ${id} dimension`);
+    return found;
+  };
+
+  const proseQuality = dimension('prose_quality');
+  assert(
+    proseQuality.signals.some(signal => /^Paragraphs: [2-9]/.test(signal)),
+    `an HTML story should be counted as several paragraphs (signals=${JSON.stringify(proseQuality.signals)})`
+  );
+  assert(
+    !proseQuality.signals.includes('Words: 1'),
+    'markup should not be counted as a single word'
+  );
+
+  const audioReadiness = dimension('audio_readiness');
+  assert(
+    audioReadiness.signals.some(signal => signal.startsWith('Speaker variety: Narrator, Mira, Lord Brine')),
+    `speaker tags inside <p> elements should still be read as dialogue (signals=${JSON.stringify(audioReadiness.signals)})`
+  );
+  assert(
+    audioReadiness.signals.includes('No overlong paragraphs detected.'),
+    'a story of short paragraphs should not be penalised as one overlong block'
+  );
+
+  // The cliffhanger dimension is documented as reading the ending. Its hook
+  // words appear only in the last paragraph here, and the ending's question
+  // mark is the last character of the prose — not of the markup.
+  const cliffhanger = dimension('cliffhanger_quality');
+  assert(
+    cliffhanger.signals.includes('Ending closes on a question or exclamation.'),
+    `the ending should be read past its closing tags (signals=${JSON.stringify(cliffhanger.signals)})`
+  );
+}
+
 async function main(): Promise<void> {
+  testHtmlStoriesAreScoredOnTheirProse();
+
   const heuristicReport = buildStoryQualityHeuristicReport({
     storyContent: [
       '[Mira]: "If the shell repeats my vow, Lord Brine owns the court by sunrise."',

--- a/tests/trope-subversion.test.ts
+++ b/tests/trope-subversion.test.ts
@@ -37,4 +37,37 @@ for (const creature of Object.keys(TROPE_DATABASE) as Array<keyof typeof TROPE_D
   assert(restored.selectedTropeIds.length === selection.selectedTropeIds.length, `${creature}: restored ids should match`);
 }
 
+// The selection pool is weighted by repetition, so its length counts copies
+// rather than distinct tropes. A preferred intensity that leaves a single trope
+// in the pool still leaves three copies of it, which looked like enough to
+// satisfy a request for two — and the caller was handed one trope instead of
+// falling back to the wider pool that could supply the second.
+for (const creature of Object.keys(TROPE_DATABASE) as Array<keyof typeof TROPE_DATABASE>) {
+  const creatureTropes = TROPE_DATABASE[creature];
+  const allTropes = [...creatureTropes.common, ...creatureTropes.subversive];
+
+  for (const intensity of ['subtle', 'moderate', 'dramatic'] as const) {
+    const requestedCount = 2;
+    if (allTropes.length < requestedCount) {
+      continue;
+    }
+
+    const selection = service.selectTropesForSubversion({
+      creature,
+      preferredIntensity: intensity,
+      tropeCount: requestedCount
+    });
+
+    assert(
+      selection.selectedTropes.length === requestedCount,
+      `${creature}/${intensity}: a preferred intensity should never return fewer tropes than requested ` +
+        `(got ${selection.selectedTropes.length})`
+    );
+    assert(
+      new Set(selection.selectedTropeIds).size === requestedCount,
+      `${creature}/${intensity}: selected tropes should stay distinct`
+    );
+  }
+}
+
 console.log('Trope subversion service tests passed');


### PR DESCRIPTION
Three small, independent defects, each with a regression case in the suite that already covers its file.

## 1. Quality heuristics were blind to the HTML they are given

`api/story-lab/evaluate.ts` is called with the story exactly as the generator renders it — `<p>` elements on one line, `[Speaker]:` tags inside those elements, no blank lines anywhere (see `renderChapters` in `proving-grounds.ts`). `buildStoryQualityHeuristicReport` split paragraphs on blank lines and looked for speaker tags at the start of a line, so against real input:

- the whole story counted as **one paragraph**, so `cliffhanger_quality` scanned the entire text as if it were the ending, and `audio_readiness` marked every story as one overlong block (−18);
- **no** `[Speaker]:` tag ever started a line, so no story was ever credited with dialogue or speaker variety;
- `<p>Hello</p>` counted as a single word.

Story content is now split into text blocks first: block-level tags and `<br>` become block boundaries, inline tags are dropped, and basic entities are decoded. Plain-text callers are unaffected — their blank-line boundaries are honoured exactly as before, and the existing plain-text assertions still pass unchanged.

## 2. A preferred trope intensity could return fewer tropes than requested

The selection pool is weighted by repetition (every common trope is pushed three times), so its length counts copies rather than distinct tropes. One trope at the requested intensity looked like three candidates, which passed the "is this pool big enough?" check — the loop then drained every copy of the only id it held and never fell back to the wider pool. Asking for two `subtle` werewolf tropes returned one. The check now counts distinct ids.

## 3. The PDF cross-reference table pointed at nothing

The mock PDF's object offsets and `startxref` were fixed constants, so they addressed whatever bytes a real title and excerpt pushed into their place: no entry pointed at an object header and `startxref` did not point at the table. Offsets are now measured with `Buffer.byteLength` as the objects are assembled, and each record keeps the fixed 20-byte width the format requires. This closes the open item recorded as a non-claim in the previous slice.

## Tests

- `tests/story-quality-evals.test.ts` — generator-shaped HTML scores as several paragraphs, keeps its speaker variety, and has its ending read past the closing tags.
- `tests/trope-subversion.test.ts` — property over every creature and intensity: a preferred intensity never returns fewer tropes than requested.
- `tests/export-service.test.ts` — property over three title lengths: every xref entry resolves to its object's header, `startxref` resolves to the table, and records stay 20 bytes wide.

## Validation

- `npm run test:all`: passed.
- Counterfactual: with the new tests in place, `git stash push -- api/` fails all three (`werewolf/subtle ... (got 1)`, `Paragraphs: 1` on a four-paragraph HTML story, `startxref ... should point at the cross-reference table`). Restored immediately; not committed.
- `tsc --noEmit --strict` over the three changed source files: no diagnostics.
- `git diff --check`: passed.

## Non-claims

- The PDF is still the mock its own comment describes; the table is internally consistent, which is not the same as a valid PDF. A real generator is still open work, as is the EPUB fragment's missing `unique-identifier`/`dc:identifier` pair.
- Nothing here changes the AI evaluation path, the scoring formulas, or the dimension list — only the text those formulas are applied to.

`PR70_RECOVERY_CHANGELOG.md` carries the slice entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZ2LBb79Wd6aBaa91rWtJN)_

## Summary by Sourcery

Fix quality scoring, trope selection, and PDF cross-reference defects while adding regression coverage for each case.

Bug Fixes:
- Correct quality heuristic scoring for generator-rendered HTML so paragraph, dialogue, speaker variety, word count, audio readiness, and ending signals reflect the underlying prose.
- Ensure preferred-intensity trope selection returns the requested number of distinct tropes by falling back when necessary.
- Generate PDF cross-reference offsets and startxref values from the assembled document so object references remain valid for variable-length content.

Tests:
- Add regression coverage for HTML story scoring, preferred-intensity trope selection across creatures and intensities, and PDF cross-reference validity across title lengths.

Chores:
- Record the fixes and validation results in the recovery changelog.