### PR TITLE
Fix three defects in the continuation route, HTML export, and image service

### DIFF
--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -4,6 +4,28 @@ Created: 2026-05-26 00:12 EDT
 
 This is the chronological work log for the PR #70 recovery. It should capture commands, decisions, self-review notes, validation results, and anything that changes the plan.
 
+## 2026-08-24 23:00 UTC - A Continuation Route That Threw On A Non-String Id, An HTML Export That Doubled Its Own Entities, And An Image Response Nobody Checked
+
+Actions:
+
+- Read `storyId` with a `typeof` guard in `api/story-lab/stories/[storyId]/continue.ts`. The route did `input.storyId?.trim()` on a field that arrives straight from the request body, and optional chaining guards `null`/`undefined`, not the wrong type — so `{"storyId": 123}`, or a boolean, object, or array, threw `TypeError: input.storyId?.trim is not a function`. Nothing in the route catches it, so the request became an unhandled rejection instead of the 400 the field check two lines below exists to produce. The job route's own `normalizeContinuationInput` already reads the field this way; the route now matches it.
+- Stopped `sanitizeStoryHtmlForExport` re-escaping the references the generator wrote. The story arrives as generator HTML, where `&` and `"` are already `&amp;` and `&quot;`; escaping every `&` turned those into `&amp;amp;` and `&amp;quot;`, so the exported page rendered the entity text itself — a reader saw `feet &amp; the &quot;hunter&quot; smiled` — while the plain-text export of the same story decoded them and showed the punctuation. The HTML export now preserves exactly the references `BASIC_HTML_ENTITY_REPLACEMENTS` decodes, and escapes everything else as before.
+- Refused an image-provider response that carries no URL. `callGrokImageAI` read `response.data.data[0].url` unchecked, and reading a missing property yields `undefined` rather than throwing, so an entry with a `b64_json` payload — or one a content filter emptied — was returned as `success: true` with `imageUrl: undefined` beside a real `imageId` and dimensions. The contract types that field as a string, so callers rendered a broken image instead of seeing the failure. `readGeneratedImageUrl` validates the shape and throws, which the existing catch reports as `IMAGE_GENERATION_FAILED`.
+
+Self-review:
+
+- Good: Each fix was checked against a targeted revert with its new test in place. Restoring `input.storyId?.trim()` fails `tests/story-lab-route-status.test.ts` with the `TypeError` escaping the route; restoring the blanket escape fails the entity assertion in `tests/export-sanitizer.test.ts` with `&amp;amp;` in the output; restoring `response.data.data[0].url` fails the new service-level case in `tests/image-service.test.ts`, which drives `generateImage` with a stubbed `axios.post` rather than only calling the helper.
+- Correction: The first version of the export fix preserved any complete reference, including numeric ones and arbitrary names. Codex review caught two consequences and both were real. HTML parses a named reference by its longest valid prefix with no `;` required, so a story containing `&copycat;` would have reached a reader as `©cat;`; and preserving references the plain-text decoder does not know — `&#38;`, `&apos;` — recreated the very cross-format disagreement the fix was for. Narrowing preservation to the decoded set answers both, and the tests now assert that the HTML and plain-text exports of one story render the same text.
+- Non-claim: This does not make the two exports agree on references neither path handles. `&#38;` now stays literal in both, which is consistent but is not the character the story meant; widening that means teaching `decodeBasicEntities` numeric references, which is a larger change than this slice.
+- Non-claim: The image fix covers the response shape only. A provider that returns a URL which later 404s is still reported as a success, because nothing here fetches it.
+- Note: Codex also asked for these three fixes to be split into separate slices. They are not split. The review-boundary rule in `AGENTS.md` lists the independent risk areas a slice must split across — account/auth/profile/storage, route or function-budget changes, Angular UI, durable job claims, story-quality generation, Proving Grounds, CSS — and none of the three crosses one: each is a local input- or output-validation fix behind an existing seam, with its own test, and the function count is unchanged at 11/12. The preceding entry in this log covers three defects in one slice on the same reading.
+
+Validation:
+
+- `scripts/recovery/preflight.sh --skip-status`, the command CI runs: passed — Angular app and spec type checks, the Vercel API type check, `npm run test:all`, the Node 20 Angular production build, and build-output verification.
+- Targeted counterfactual per fix, as quoted under Self-review. Each mutation was reverted immediately and none is committed.
+- Note: `node_modules` is tracked in this repository and its devDependencies were absent again, so `npm install` was needed before `tsx` would run. Those tracked files and the `name` casing `npm` rewrote into `package-lock.json` were restored, so the slice diff stays source-only.
+
 ## 2026-08-24 22:36 UTC - A Streaming Error That Reconnects Forever, Jobs Stuck Running After A Throw, And A Comma-Joined Allow-Origin
 
 Actions:

--- a/api/_lib/services/exportSanitizer.ts
+++ b/api/_lib/services/exportSanitizer.ts
@@ -88,10 +88,52 @@ export function sanitizeStoryHtmlForExport(html: string): string {
         return sanitizeStoryTag(token);
       }
 
-      return escapeHtml(token);
+      return escapeStoryText(token);
     })
     .join('')
     .trim();
+}
+
+/**
+ * Match one HTML character reference: named (`&amp;`), decimal (`&#38;`), or
+ * hexadecimal (`&#x26;`).
+ *
+ * Each alternative is decided by the character after the `&`, and each ends at
+ * a `;` that its character class cannot cross, so a run that never reaches a
+ * `;` fails once per `&` rather than being re-split between the branches.
+ */
+const CHARACTER_REFERENCE_PATTERN = /&(?:[a-zA-Z][a-zA-Z0-9]*|#[0-9]+|#[xX][0-9a-fA-F]+);/g;
+
+/**
+ * Escape story text without escaping the character references already in it.
+ *
+ * The story reaches this module as the generator's HTML, where `&` and `"` are
+ * written as `&amp;` and `&quot;`. Escaping every `&` re-escaped those into
+ * `&amp;amp;` and `&amp;quot;`, so the exported HTML rendered the entity text
+ * itself — a reader saw `feet &amp; the &quot;hunter&quot; smiled` on the page.
+ * The plain-text export decodes the same references instead of doubling them,
+ * so the two exports of one story disagreed about their own punctuation.
+ *
+ * Passing a reference through is safe for the reason the plain-text path can
+ * decode it: a character reference in text content is text. `&#x3C;` renders as
+ * a literal `<` that the parser never reads as the start of a tag, and this
+ * sanitizer has already dropped every attribute, which is the one context where
+ * a reference could mean anything else. Everything that is not a complete
+ * reference — a bare `&`, an unterminated `&amp` — is escaped as before.
+ */
+function escapeStoryText(value: string): string {
+  let escaped = '';
+  let index = 0;
+
+  CHARACTER_REFERENCE_PATTERN.lastIndex = 0;
+  let match = CHARACTER_REFERENCE_PATTERN.exec(value);
+  while (match) {
+    escaped += escapeHtml(value.slice(index, match.index)) + match[0];
+    index = match.index + match[0].length;
+    match = CHARACTER_REFERENCE_PATTERN.exec(value);
+  }
+
+  return escaped + escapeHtml(value.slice(index));
 }
 
 export function stripStoryHtmlForExport(html: string): string {

--- a/api/_lib/services/exportSanitizer.ts
+++ b/api/_lib/services/exportSanitizer.ts
@@ -95,42 +95,58 @@ export function sanitizeStoryHtmlForExport(html: string): string {
 }
 
 /**
- * Match either one complete HTML character reference — named (`&amp;`),
- * decimal (`&#38;`), or hexadecimal (`&#x26;`) — or one character that has to
- * be escaped on its own.
+ * The character references the HTML export leaves alone.
  *
- * The reference alternatives come first, so an `&` that begins one is taken
- * whole instead of being matched as the bare ampersand the trailing class would
- * otherwise claim. Each reference alternative is decided by the character after
- * the `&` and ends at a `;` its character class cannot cross, so a run that
- * never reaches a `;` fails once per `&` rather than being re-split between the
- * branches.
+ * Derived from the table the plain-text export decodes, in the same lowercase
+ * and fully-uppercase forms `replaceEntity` recognises, so the two exports of
+ * one story agree character for character: every reference this set preserves
+ * is one the plain-text path turns into the character it stands for, and every
+ * reference outside it stays literal in both.
  */
-const STORY_TEXT_PATTERN = /&(?:[a-zA-Z][a-zA-Z0-9]*|#[0-9]+|#[xX][0-9a-fA-F]+);|[&<>"']/g;
+const PRESERVED_CHARACTER_REFERENCES = new Set(
+  BASIC_HTML_ENTITY_REPLACEMENTS.flatMap(([entity]) => [entity, entity.toUpperCase()])
+);
 
 /**
- * Escape story text without escaping the character references already in it.
+ * Match either something shaped like a character reference or one character
+ * that has to be escaped on its own.
+ *
+ * The reference shape comes first, so an `&` that begins one is offered whole
+ * rather than being taken as the bare ampersand the trailing class would
+ * otherwise claim; whether it is actually preserved is decided against
+ * `PRESERVED_CHARACTER_REFERENCES`, not by this pattern. The name characters
+ * cannot cross the `;` that ends the reference, so a run that never reaches one
+ * fails once per `&` rather than being rescanned from inside itself.
+ */
+const STORY_TEXT_PATTERN = /&[#0-9a-zA-Z]+;|[&<>"']/g;
+
+/**
+ * Escape story text without re-escaping the references already in it.
  *
  * The story reaches this module as the generator's HTML, where `&` and `"` are
  * written as `&amp;` and `&quot;`. Escaping every `&` re-escaped those into
  * `&amp;amp;` and `&amp;quot;`, so the exported HTML rendered the entity text
- * itself — a reader saw `feet &amp; the &quot;hunter&quot; smiled` on the page.
- * The plain-text export decodes the same references instead of doubling them,
- * so the two exports of one story disagreed about their own punctuation.
+ * itself — a reader saw `feet &amp; the &quot;hunter&quot; smiled` on the page
+ * — while the plain-text export of the same story decoded them and showed the
+ * punctuation.
  *
- * Passing a reference through is safe for the reason the plain-text path can
- * decode it: a character reference in text content is text. `&#x3C;` renders as
- * a literal `<` that the parser never reads as the start of a tag, and this
- * sanitizer has already dropped every attribute, which is the one context where
- * a reference could mean anything else. Everything that is not a complete
- * reference — a bare `&`, an unterminated `&amp` — is escaped as before.
+ * Only the references the plain-text path decodes are preserved, and that
+ * restriction is what makes preserving any of them safe. An entity-shaped
+ * literal that is not a reference cannot be passed through: HTML parses a
+ * named reference by its longest valid prefix, with no `;` required, so
+ * `&copycat;` in the text would reach a reader as `©cat;` rather than as the
+ * `&copycat;` the story says. Anything outside the set — that literal, a
+ * numeric reference, a bare `&`, an unterminated `&amp` — is escaped exactly as
+ * it was before, which is always safe and always what the plain-text export
+ * shows.
  */
 function escapeStoryText(value: string): string {
-  // A match is either a whole reference or a single character, so its length
-  // says which. `replace` drives the shared pattern's `lastIndex` itself, so
-  // no state survives the call — which an `exec` loop would have to reset by
-  // hand on every entry and every early return.
-  return value.replace(STORY_TEXT_PATTERN, token => (token.length > 1 ? token : escapeHtml(token)));
+  // `replace` drives the shared pattern's `lastIndex` itself, so no state
+  // survives the call — which an `exec` loop would have to reset by hand on
+  // every entry and every early return.
+  return value.replace(STORY_TEXT_PATTERN, token =>
+    PRESERVED_CHARACTER_REFERENCES.has(token) ? token : escapeHtml(token)
+  );
 }
 
 export function stripStoryHtmlForExport(html: string): string {

--- a/api/_lib/services/exportSanitizer.ts
+++ b/api/_lib/services/exportSanitizer.ts
@@ -95,14 +95,18 @@ export function sanitizeStoryHtmlForExport(html: string): string {
 }
 
 /**
- * Match one HTML character reference: named (`&amp;`), decimal (`&#38;`), or
- * hexadecimal (`&#x26;`).
+ * Match either one complete HTML character reference — named (`&amp;`),
+ * decimal (`&#38;`), or hexadecimal (`&#x26;`) — or one character that has to
+ * be escaped on its own.
  *
- * Each alternative is decided by the character after the `&`, and each ends at
- * a `;` that its character class cannot cross, so a run that never reaches a
- * `;` fails once per `&` rather than being re-split between the branches.
+ * The reference alternatives come first, so an `&` that begins one is taken
+ * whole instead of being matched as the bare ampersand the trailing class would
+ * otherwise claim. Each reference alternative is decided by the character after
+ * the `&` and ends at a `;` its character class cannot cross, so a run that
+ * never reaches a `;` fails once per `&` rather than being re-split between the
+ * branches.
  */
-const CHARACTER_REFERENCE_PATTERN = /&(?:[a-zA-Z][a-zA-Z0-9]*|#[0-9]+|#[xX][0-9a-fA-F]+);/g;
+const STORY_TEXT_PATTERN = /&(?:[a-zA-Z][a-zA-Z0-9]*|#[0-9]+|#[xX][0-9a-fA-F]+);|[&<>"']/g;
 
 /**
  * Escape story text without escaping the character references already in it.
@@ -122,18 +126,11 @@ const CHARACTER_REFERENCE_PATTERN = /&(?:[a-zA-Z][a-zA-Z0-9]*|#[0-9]+|#[xX][0-9a
  * reference — a bare `&`, an unterminated `&amp` — is escaped as before.
  */
 function escapeStoryText(value: string): string {
-  let escaped = '';
-  let index = 0;
-
-  CHARACTER_REFERENCE_PATTERN.lastIndex = 0;
-  let match = CHARACTER_REFERENCE_PATTERN.exec(value);
-  while (match) {
-    escaped += escapeHtml(value.slice(index, match.index)) + match[0];
-    index = match.index + match[0].length;
-    match = CHARACTER_REFERENCE_PATTERN.exec(value);
-  }
-
-  return escaped + escapeHtml(value.slice(index));
+  // A match is either a whole reference or a single character, so its length
+  // says which. `replace` drives the shared pattern's `lastIndex` itself, so
+  // no state survives the call — which an `exec` loop would have to reset by
+  // hand on every entry and every early return.
+  return value.replace(STORY_TEXT_PATTERN, token => (token.length > 1 ? token : escapeHtml(token)));
 }
 
 export function stripStoryHtmlForExport(html: string): string {

--- a/api/_lib/services/imageService.ts
+++ b/api/_lib/services/imageService.ts
@@ -43,6 +43,30 @@ const SUPPORTED_STYLES: ImageGenerationSeam['input']['style'][] = [
   'romantic'
 ];
 
+/**
+ * Read the image URL out of a provider response, or refuse the response.
+ *
+ * `response.data.data[0].url` was read straight through. The provider can
+ * answer with an entry that carries no `url` — a `b64_json` payload, or an
+ * entry a content filter emptied — and reading a missing property yields
+ * `undefined` rather than throwing, so the service reported `success: true`
+ * with `imageUrl: undefined` beside a real `imageId` and `width`/`height`. The
+ * contract types that field as a string, so every caller treats the response as
+ * an image it can display; the failure surfaced as a broken `<img>` instead of
+ * the error the request actually produced. Refusing here puts it back inside
+ * `callGrokImageAI`'s catch, which answers `IMAGE_GENERATION_FAILED`.
+ */
+export function readGeneratedImageUrl(responseData: unknown): string {
+  const entries = (responseData as { data?: unknown })?.data;
+  const url = Array.isArray(entries) ? (entries[0] as { url?: unknown })?.url : undefined;
+
+  if (typeof url !== 'string' || url.trim().length === 0) {
+    throw new Error('Image provider returned no image URL');
+  }
+
+  return url.trim();
+}
+
 export class ImageService {
   private grokApiKey: string | undefined;
   private grokApiUrl: string;
@@ -140,7 +164,7 @@ export class ImageService {
         timeout: 60000 // 60 second timeout for image generation
       });
 
-      return response.data.data[0].url;
+      return readGeneratedImageUrl(response.data);
 
     } catch (error: any) {
       console.error('Grok Image API error:', error.response?.data || error.message);

--- a/api/story-lab/stories/[storyId]/continue.ts
+++ b/api/story-lab/stories/[storyId]/continue.ts
@@ -57,7 +57,13 @@ export function createStoryLabContinuationHandler(continueStory: ContinueStoryLa
       return;
     }
 
-    const storyId = input.storyId?.trim() ?? '';
+    // `storyId` arrives from the request body, so its type is whatever the
+    // caller sent. Calling `.trim()` on it directly threw a `TypeError` for
+    // every non-string — `{"storyId": 123}` was answered with an unhandled
+    // rejection rather than the 400 the field check below exists to give,
+    // because nothing here catches it. The job route's own normalizer already
+    // reads the field this way; this is the same check.
+    const storyId = typeof input.storyId === 'string' ? input.storyId.trim() : '';
     const transientSnapshot = storyId ? getTransientStorySnapshot(storyId) : null;
 
     const hasChapters = Array.isArray(input.previouslyGeneratedChapters);

--- a/tests/export-sanitizer.test.ts
+++ b/tests/export-sanitizer.test.ts
@@ -63,6 +63,43 @@ assert(entityPlainText.includes('&lt;encoded&gt;'), 'plain export should not dou
 assert(entityPlainText.includes('"quote"'), 'plain export should decode direct quote entities');
 assert(entityPlainText.includes('&quot;encoded quote&quot;'), 'plain export should not double-decode amp-escaped quote entities');
 
+// The story arrives as the generator's HTML, where `&` and `"` are already
+// written as `&amp;` and `&quot;`. Escaping every `&` re-escaped those, so the
+// HTML export rendered the entity text itself while the plain-text export of
+// the same story showed the punctuation it stands for.
+const entityStoryHtml = '<p>Blood pooled at her feet &amp; the &quot;hunter&quot; smiled.</p>';
+const entitySanitizedHtml = sanitizeStoryHtmlForExport(entityStoryHtml);
+assert(
+  entitySanitizedHtml === entityStoryHtml,
+  `HTML export should pass the generator's own entities through unchanged (got ${entitySanitizedHtml})`
+);
+assert(
+  !entitySanitizedHtml.includes('&amp;amp;') && !entitySanitizedHtml.includes('&amp;quot;'),
+  'HTML export should not double-escape character references'
+);
+assert(
+  sanitizeStoryHtmlForExport('<p>Rain &amp; ash &#38; smoke &#x26; salt.</p>')
+    === '<p>Rain &amp; ash &#38; smoke &#x26; salt.</p>',
+  'decimal and hexadecimal references should survive alongside named ones'
+);
+// Only a complete reference is a reference. A bare ampersand, and an `&amp`
+// with no semicolon, are still text and still have to be escaped.
+assert(
+  sanitizeStoryHtmlForExport('<p>Angel &amp demon & wolf &#zz; here</p>')
+    === '<p>Angel &amp;amp demon &amp; wolf &amp;#zz; here</p>',
+  'incomplete references should still be escaped'
+);
+// A reference in text content decodes to a character, never to markup, so
+// passing one through cannot reopen the injection the escaping guards against.
+const referenceInjection = sanitizeStoryHtmlForExport(
+  '<p>&#x3C;script&#x3E;stealPrivateStory()&#x3C;/script&#x3E;</p>'
+);
+assert(!referenceInjection.includes('<script'), 'a referenced tag must not become a real tag');
+assert(
+  referenceInjection.includes('&#x3C;script&#x3E;'),
+  `a referenced tag should stay the text it was (got ${referenceInjection})`
+);
+
 const commentedStoryHtml =
   '<p>Elena waited.</p><!-- editor note: cut this line <script>stealPrivateStory()</script> --><p>Dawn broke.</p>';
 const sanitizedComments = sanitizeStoryHtmlForExport(commentedStoryHtml);

--- a/tests/export-sanitizer.test.ts
+++ b/tests/export-sanitizer.test.ts
@@ -77,11 +77,6 @@ assert(
   !entitySanitizedHtml.includes('&amp;amp;') && !entitySanitizedHtml.includes('&amp;quot;'),
   'HTML export should not double-escape character references'
 );
-assert(
-  sanitizeStoryHtmlForExport('<p>Rain &amp; ash &#38; smoke &#x26; salt.</p>')
-    === '<p>Rain &amp; ash &#38; smoke &#x26; salt.</p>',
-  'decimal and hexadecimal references should survive alongside named ones'
-);
 // Only a complete reference is a reference. A bare ampersand, and an `&amp`
 // with no semicolon, are still text and still have to be escaped.
 assert(
@@ -89,16 +84,44 @@ assert(
     === '<p>Angel &amp;amp demon &amp; wolf &amp;#zz; here</p>',
   'incomplete references should still be escaped'
 );
-// A reference in text content decodes to a character, never to markup, so
-// passing one through cannot reopen the injection the escaping guards against.
-const referenceInjection = sanitizeStoryHtmlForExport(
-  '<p>&#x3C;script&#x3E;stealPrivateStory()&#x3C;/script&#x3E;</p>'
-);
-assert(!referenceInjection.includes('<script'), 'a referenced tag must not become a real tag');
+
+// HTML parses a named reference by its longest valid prefix, with no `;`
+// required, so passing an entity-shaped literal through corrupts the story:
+// `&copycat;` would reach a reader as `©cat;`. Only the references the
+// plain-text export decodes are preserved, which is what makes preserving any
+// of them safe — everything else is escaped and stays the text it was.
+const unpreservedReferences = '<p>&copycat; and &#38; and &apos; and &Amp; stay literal</p>';
+const unpreservedSanitized = sanitizeStoryHtmlForExport(unpreservedReferences);
 assert(
-  referenceInjection.includes('&#x3C;script&#x3E;'),
-  `a referenced tag should stay the text it was (got ${referenceInjection})`
+  unpreservedSanitized
+    === '<p>&amp;copycat; and &amp;#38; and &amp;apos; and &amp;Amp; stay literal</p>',
+  `an entity-shaped literal that is not a decoded reference must be escaped (got ${unpreservedSanitized})`
 );
+
+// A reference that survives must mean the same thing in every export, so the
+// HTML export preserves exactly the set the plain-text export decodes.
+const crossFormatSource = '<p>feet &amp; the &quot;hunter&quot;, &lt;him&gt; &#39;there&#39; &copycat; &#38;</p>';
+const crossFormatHtml = sanitizeStoryHtmlForExport(crossFormatSource);
+const crossFormatPlain = stripStoryHtmlForExport(crossFormatSource);
+assert(
+  decodeForComparison(crossFormatHtml) === `<p>${crossFormatPlain}</p>`,
+  `HTML and plain-text exports must render the same story text\n  html : ${decodeForComparison(crossFormatHtml)}\n  plain: <p>${crossFormatPlain}</p>`
+);
+
+/**
+ * Resolve an export's HTML to the text a reader sees, so the two formats can
+ * be compared as rendered output rather than as markup. Escaped `&amp;` is
+ * resolved last, exactly as a parser resolves each reference once.
+ */
+function decodeForComparison(html: string): string {
+  return html
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&');
+}
 
 const commentedStoryHtml =
   '<p>Elena waited.</p><!-- editor note: cut this line <script>stealPrivateStory()</script> --><p>Dawn broke.</p>';

--- a/tests/image-service.test.ts
+++ b/tests/image-service.test.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env tsx
 // Created: 2026-08-24 23:40 UTC
 
+import axios from 'axios';
 import { ImageService, readGeneratedImageUrl } from '../api/_lib/services/imageService';
 import { ImageGenerationSeam } from '../api/_lib/types/contracts';
 
@@ -162,11 +163,60 @@ function testProviderResponsesWithoutAUrlAreRefused(): void {
   );
 }
 
+/**
+ * Prove the same thing through the service, not just through the helper.
+ *
+ * A test that only calls `readGeneratedImageUrl` still passes if
+ * `callGrokImageAI` goes back to reading `response.data.data[0].url`, which is
+ * the wiring the fix is actually about. Driving `generateImage` with a stubbed
+ * provider fails in that case, because the service would again answer
+ * `success: true` with an undefined `imageUrl`.
+ *
+ * The service reads `XAI_API_KEY` in its constructor and takes the mock path
+ * without one, so the key is set for the duration and `axios.post` is replaced
+ * to keep the call off the network.
+ */
+async function testTheServiceRefusesAProviderResponseWithoutAUrl(): Promise<void> {
+  const originalPost = axios.post;
+  const originalKey = process.env['XAI_API_KEY'];
+  process.env['XAI_API_KEY'] = 'test-key';
+
+  try {
+    (axios as { post: unknown }).post = async () => ({ data: { data: [{ b64_json: 'aGVsbG8=' }] } });
+    const missingUrl = await new ImageService().generateImage(createInput());
+
+    assert(!missingUrl.success, 'a provider response with no URL should not be reported as a success');
+    assert(
+      missingUrl.error?.code === 'IMAGE_GENERATION_FAILED',
+      `a provider response with no URL should fail the request (got ${missingUrl.error?.code})`
+    );
+
+    (axios as { post: unknown }).post = async () => ({
+      data: { data: [{ url: 'https://images.example/story.png' }] }
+    });
+    const withUrl = await new ImageService().generateImage(createInput());
+
+    assert(withUrl.success, 'a provider response carrying a URL should still succeed');
+    assert(
+      (withUrl.data as ImageGenerationSeam['output']).imageUrl === 'https://images.example/story.png',
+      'the provider URL should reach the caller unchanged'
+    );
+  } finally {
+    (axios as { post: unknown }).post = originalPost;
+    if (originalKey === undefined) {
+      delete process.env['XAI_API_KEY'];
+    } else {
+      process.env['XAI_API_KEY'] = originalKey;
+    }
+  }
+}
+
 async function main(): Promise<void> {
   await testSceneDescriptionReadsAsProse();
   await testMalformedThemesAreRejectedAsCallerError();
   await testAspectRatioNeverContradictsTheDimensions();
   testProviderResponsesWithoutAUrlAreRefused();
+  await testTheServiceRefusesAProviderResponseWithoutAUrl();
 
   console.log('Image service tests passed');
 }

--- a/tests/image-service.test.ts
+++ b/tests/image-service.test.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env tsx
 // Created: 2026-08-24 23:40 UTC
 
-import { ImageService } from '../api/_lib/services/imageService';
+import { ImageService, readGeneratedImageUrl } from '../api/_lib/services/imageService';
 import { ImageGenerationSeam } from '../api/_lib/types/contracts';
 
 // The service reads `XAI_API_KEY` in its constructor and falls back to a mock
@@ -124,10 +124,49 @@ async function testAspectRatioNeverContradictsTheDimensions(): Promise<void> {
   assert(defaultedOutput.width === 1792 && defaultedOutput.height === 1024, 'the default ratio should report 1792x1024');
 }
 
+// `response.data.data[0].url` was read straight through, and reading a missing
+// property yields `undefined` rather than throwing — so a provider entry that
+// carried no URL was reported as `success: true` with `imageUrl: undefined`
+// beside a real `imageId` and dimensions, and callers rendered a broken image
+// instead of seeing the failure.
+function testProviderResponsesWithoutAUrlAreRefused(): void {
+  const responsesWithoutAUrl: unknown[] = [
+    undefined,
+    null,
+    {},
+    { data: null },
+    { data: [] },
+    { data: {} },
+    { data: [{}] },
+    { data: [{ b64_json: 'aGVsbG8=' }] },
+    { data: [{ url: '' }] },
+    { data: [{ url: '   ' }] },
+    { data: [{ url: 42 }] }
+  ];
+
+  for (const responseData of responsesWithoutAUrl) {
+    let threw = false;
+    try {
+      readGeneratedImageUrl(responseData);
+    } catch {
+      threw = true;
+    }
+
+    assert(threw, `a response of ${JSON.stringify(responseData)} should be refused, not returned as a URL`);
+  }
+
+  assert(
+    readGeneratedImageUrl({ data: [{ url: ' https://images.example/story.png ' }] })
+      === 'https://images.example/story.png',
+    'a well-formed response should yield its URL'
+  );
+}
+
 async function main(): Promise<void> {
   await testSceneDescriptionReadsAsProse();
   await testMalformedThemesAreRejectedAsCallerError();
   await testAspectRatioNeverContradictsTheDimensions();
+  testProviderResponsesWithoutAUrlAreRefused();
 
   console.log('Image service tests passed');
 }

--- a/tests/story-lab-route-status.test.ts
+++ b/tests/story-lab-route-status.test.ts
@@ -215,6 +215,27 @@ async function main(): Promise<void> {
     assert(!JSON.stringify(errorLogs).includes('secret continuation payload'), 'continuation error log should not include raw error message');
   });
 
+  // `storyId` was read as `input.storyId?.trim()`, which throws for every
+  // non-string a caller can put in a JSON body. Nothing in the route catches
+  // it, so the request that the field check exists to answer with 400 became
+  // an unhandled rejection instead.
+  for (const storyId of [123, true, {}, ['story-route-status'], null]) {
+    const response = new FakeResponse();
+    await continuationHandler(
+      createRequest('POST', { ...createContinuationBody(), storyId }),
+      response
+    );
+
+    assert(
+      response.statusCode === 400,
+      `storyId=${JSON.stringify(storyId)} should be answered with 400, got ${response.statusCode}`
+    );
+    assert(
+      (response.body as { error?: { code?: string } })?.error?.code === 'INVALID_REQUEST',
+      `storyId=${JSON.stringify(storyId)} is a caller error, not a service failure`
+    );
+  }
+
   console.log('Story Lab route status tests passed');
 }
 


### PR DESCRIPTION
Three small, independent fixes. Each one has a regression test that fails on the code as it stood and passes on the fix.

## 1. A non-string `storyId` crashed the continuation route

`POST /api/story-lab/stories/:id/continue` read `input.storyId?.trim()` straight off the request body. Optional chaining guards `null`/`undefined`, not the wrong type — so `{"storyId": 123}` (or a boolean, object, or array) threw `TypeError: input.storyId?.trim is not a function`. Nothing in the route catches it, so the request became an unhandled rejection rather than the 400 that the field check two lines below exists to produce.

The job route's own `normalizeContinuationInput` already reads the field with a `typeof` guard; the route now does the same.

**Before:**
```
storyId=123      -> THREW: input.storyId?.trim is not a function
storyId={}       -> THREW: input.storyId?.trim is not a function
storyId=["a"]    -> THREW: input.storyId?.trim is not a function
```
**After:** `400 INVALID_REQUEST` for each.

## 2. The HTML export double-escaped the generator's own character references

The story reaches the export as the generator's HTML, where `&` and `"` are already written as `&amp;` and `&quot;`. `sanitizeStoryHtmlForExport` escaped every `&` in the text tokens, turning those into `&amp;amp;` and `&amp;quot;` — so the exported page rendered the *entity text itself*, while the plain-text export of the same story decoded them and showed the punctuation. The two exports of one story disagreed about their own quotation marks:

```
html export : <p>Blood pooled at her feet &amp;amp; the &amp;quot;hunter&amp;quot; smiled.</p>
plain export: Blood pooled at her feet & the "hunter" smiled.
```

Text tokens now go through `escapeStoryText`, which preserves **exactly the references the plain-text export decodes** — the set is derived from `BASIC_HTML_ENTITY_REPLACEMENTS` itself, so the preserved set and the decoded set are the same set by construction — and escapes everything else exactly as before.

That narrowness is what makes preserving any of them safe. HTML resolves a named reference by its longest valid prefix with no `;` required, so passing an arbitrary entity-shaped literal through would corrupt the story: `&copycat;` would reach a reader as `©cat;`. An earlier revision of this PR did preserve any complete reference and had exactly that bug; Codex review caught it. Anything outside the set — that literal, a numeric reference, a bare `&`, an unterminated `&amp` — is escaped as before, which is always safe and always what the plain-text export shows.

Tests assert the escaping, the negative case, and that both exports of one story render the same text.

`escapeHtml` itself is unchanged, since it is also used on the story *title*, which is plain text rather than markup.

## 3. The image service could report success with no image URL

`callGrokImageAI` read `response.data.data[0].url` without checking it. Reading a missing property yields `undefined` rather than throwing, so a provider entry that carried no URL — a `b64_json` payload, or one a content filter emptied — was returned as `success: true` with `imageUrl: undefined` beside a real `imageId`, `width`, and `height`. The contract types that field as a string, so callers treated the response as a displayable image and rendered a broken one instead of surfacing the failure.

A new exported `readGeneratedImageUrl` validates the shape and refuses the response, which the existing catch reports as `IMAGE_GENERATION_FAILED`. The test drives `ImageService.generateImage` with a stubbed `axios.post`, not just the helper, so it fails if the call site goes back to reading the property directly.

## Verification

`scripts/recovery/preflight.sh --skip-status` passes end to end: Angular and Vercel API type checks, the full root test suite, the Angular production build under Node 20, and build output verification.

Each fix was checked against a targeted revert with its test in place:

```
export-sanitizer       Error: HTML export should pass the generator's own entities through unchanged
image-service          Error: a provider response with no URL should not be reported as a success
story-lab-route-status TypeError: input.storyId?.trim is not a function
```

Every mutation was reverted immediately; none is committed. The slice is recorded in `PR70_RECOVERY_CHANGELOG.md` with its counterfactuals and non-claims.

## Review follow-ups

Codex raised five findings. Four were addressed in df1f22a — two were real defects in the first pass (the `&copycat;` corruption and the cross-format disagreement, both fixed by narrowing preservation), one was a real gap in test coverage (the image test now exercises the wiring), and one was the missing changelog entry. The fifth asked for the three fixes to be split into separate PRs; I've replied on that thread explaining why I don't read `AGENTS.md:L46-L54` as requiring it here, and I'm happy to split if a maintainer disagrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Md3fANnetykoFhTEWDaJjr