### PR TITLE
Fix three defects in block splitting, cast counting, and URL redaction

### DIFF
--- a/api/_lib/story-lab/evaluation/storyQualityHeuristics.ts
+++ b/api/_lib/story-lab/evaluation/storyQualityHeuristics.ts
@@ -141,7 +141,7 @@ function scoreEmotionalVariety(storyText: string): DimensionDraft {
 
 function scoreCharacterConsistency(storyContent: string, dialogueLines: string[]): DimensionDraft {
   const speakers = extractDialogueSpeakers(dialogueLines);
-  const namedCharacters = extractNamedCharacters(storyContent);
+  const namedCharacters = extractNamedCharacters(storyContent, speakers);
   const agencyActions = extractAgencyActions(storyContent, namedCharacters);
   let rationale = 'Few character identity signals were detected.';
   if (agencyActions.length) {
@@ -307,9 +307,25 @@ const PRE_NAME_PUNCTUATION = new Set(['"', "'", '“', '”', '‘', '’', '(',
  * sentence-initially is still missed, which is the safe direction for an
  * advisory signal: reporting a cast that is not there is what made the score
  * meaningless.
+ *
+ * The one place a name needs no such inference is a `[Speaker]:` tag, which
+ * the generator writes to say who is talking — a character name by
+ * construction, whatever position it sits in. The scan proved the point and
+ * then threw it away: a line beginning `[Elena]:` starts the block, so the
+ * boundary rule dropped `Elena`, and the dimension reported `Named character
+ * count: 1` for a scene whose own signals already listed `Speaker: Elena`
+ * beside two other names. The agency scan reads this list too, so no action
+ * Elena took anywhere in the chapter could be credited to her either. Seeding
+ * the set with the speakers the same scan already extracted fixes both, and
+ * `Narrator` is excluded here for the reason it is excluded below: it names
+ * the telling, not a member of the cast.
  */
-function extractNamedCharacters(storyContent: string): string[] {
-  const names = new Set<string>();
+function extractNamedCharacters(storyContent: string, dialogueSpeakers: readonly string[] = []): string[] {
+  const names = new Set<string>(
+    dialogueSpeakers
+      .map(speaker => speaker.trim().split(/\s+/).slice(0, MAX_NAME_WORDS).join(' '))
+      .filter(speaker => speaker && speaker !== 'Narrator')
+  );
 
   for (const match of storyContent.matchAll(NAMED_CHARACTER_RUN_PATTERN)) {
     const words = match[0].split(/\s+/);

--- a/api/_lib/utils/storyTextBlocks.ts
+++ b/api/_lib/utils/storyTextBlocks.ts
@@ -40,7 +40,49 @@ export function stripStoryHtmlToText(storyContent: string): string {
   return splitStoryIntoTextBlocks(storyContent).join('\n\n');
 }
 
-const BLOCK_LEVEL_TAG_NAMES = 'br|p|div|section|article|blockquote|li|ul|ol|h[1-6]|figure|figcaption|table|tr';
+/**
+ * The tags that put a boundary between the text on either side of them.
+ *
+ * Every tag a reader sees a break at has to be here, because whatever is left
+ * over is deleted in place: `<td>One</td><td>Two</td>` had a boundary for the
+ * row but none for the cells, so the two cells came back as the single token
+ * `OneTwo` — the `door.Blood` welding this module exists to prevent, just one
+ * level further in. The list is the block-level and table-cell elements the
+ * generator's markup can contain, so a boundary is never left to the tag that
+ * happens to enclose it.
+ */
+const BLOCK_LEVEL_TAG_NAMES = [
+  'br',
+  'p',
+  'div',
+  'section',
+  'article',
+  'aside',
+  'header',
+  'footer',
+  'main',
+  'nav',
+  'blockquote',
+  'pre',
+  'hr',
+  'li',
+  'ul',
+  'ol',
+  'dl',
+  'dt',
+  'dd',
+  'h[1-6]',
+  'figure',
+  'figcaption',
+  'table',
+  'thead',
+  'tbody',
+  'tfoot',
+  'caption',
+  'tr',
+  'td',
+  'th'
+].join('|');
 /**
  * Match an opening or closing block-level tag, with or without attributes.
  *

--- a/shared/sensitiveTextRedaction.ts
+++ b/shared/sensitiveTextRedaction.ts
@@ -123,13 +123,14 @@ function redactUrls(value: string): string {
   let index = 0;
 
   while (index < value.length) {
-    if (startsWithIgnoreCase(value, 'http://', index) || startsWithIgnoreCase(value, 'https://', index)) {
+    const scheme = findUrlScheme(value, index);
+    if (scheme) {
       let cursor = index;
       while (cursor < value.length && !isUrlDelimiter(value[cursor] ?? '')) {
         cursor += 1;
       }
       redacted += REDACTED_SENSITIVE_TEXT;
-      index = cursor;
+      index = trimTrailingUrlPunctuation(value, index + scheme.length, cursor);
       continue;
     }
 
@@ -228,6 +229,72 @@ function isBearerTokenChar(char: string): boolean {
 
 function isApiKeyTokenChar(char: string): boolean {
   return isAsciiLetterOrDigit(char) || char === '_' || char === '-';
+}
+
+const URL_SCHEMES = ['https://', 'http://'];
+/**
+ * Punctuation that ends the sentence a URL was written into rather than the
+ * URL itself. A run of it is handed back to the surrounding prose.
+ */
+const URL_TRAILING_PUNCTUATION = new Set(['.', ',', ';', ':', '!', '?']);
+/** The closing brackets that may be enclosing a URL rather than part of it. */
+const URL_CLOSING_BRACKETS = new Map([[')', '('], [']', '['], ['}', '{']]);
+
+function findUrlScheme(value: string, index: number): string | undefined {
+  return URL_SCHEMES.find(scheme => startsWithIgnoreCase(value, scheme, index));
+}
+
+/**
+ * Give the sentence back the punctuation a URL run swallowed.
+ *
+ * A URL ends at whitespace or a quote, which is where it ends in a log line
+ * too — but a URL is usually written *into* a sentence, and the mark that
+ * closes the sentence has none of those before it. So `See https://host/a, then
+ * call` redacted the comma along with the URL and came back as `See [REDACTED]
+ * then call`, and `Visit (https://host/a) now` lost the closing parenthesis and
+ * left the opening one dangling: exactly the reading a log is hardest to do
+ * when something has gone wrong enough to need reading.
+ *
+ * Trailing `.,;:!?` is always the prose's. A closing bracket is the prose's
+ * only when the URL holds no unclosed opener to match it, so a path that really
+ * ends in one — `/wiki/Title_(disambiguation)` — keeps it. Nothing is given
+ * back past `start`, the end of the scheme, so the URL itself is never
+ * partially preserved.
+ */
+function trimTrailingUrlPunctuation(value: string, start: number, end: number): number {
+  let cursor = end;
+
+  while (cursor > start) {
+    const char = value[cursor - 1] ?? '';
+    if (URL_TRAILING_PUNCTUATION.has(char)) {
+      cursor -= 1;
+      continue;
+    }
+
+    const opener = URL_CLOSING_BRACKETS.get(char);
+    if (opener && !hasUnclosedOpener(value.slice(start, cursor - 1), opener, char)) {
+      cursor -= 1;
+      continue;
+    }
+
+    break;
+  }
+
+  return cursor;
+}
+
+function hasUnclosedOpener(value: string, opener: string, closer: string): boolean {
+  let depth = 0;
+
+  for (const char of value) {
+    if (char === opener) {
+      depth += 1;
+    } else if (char === closer && depth > 0) {
+      depth -= 1;
+    }
+  }
+
+  return depth > 0;
 }
 
 function isUrlDelimiter(char: string): boolean {

--- a/tests/cliffhanger-service.test.ts
+++ b/tests/cliffhanger-service.test.ts
@@ -42,9 +42,17 @@ const separatedChapters = [
   { label: 'self-closing <br />', markup: `She opened the door.<br />Blood pooled on the floor.<br />${hook}` },
   { label: 'uppercase <BR>', markup: `She opened the door.<BR CLASS="scene-break">Blood pooled on the floor.<BR CLASS="scene-break">${hook}` },
   { label: 'attributed <p>', markup: `<p class="lede">She opened the door.</p><p data-n="2">Blood pooled on the floor.</p><p>${hook}</p>` },
-  // The tag name has to end where the boundary list says it does: `<pre>` is
-  // not `<p>`, and `<paragraph>` is not either.
-  { label: 'near-miss tag names', markup: `<p>She opened the door.</p><p>A <pre>literal</pre> and a <paragraph>tag</paragraph>.</p><p>${hook}</p>` }
+  // The tag name has to end where the boundary list says it does: a tag whose
+  // name merely begins with a listed one is not a boundary, so `<press>` is
+  // neither `<p>` nor `<pre>`, `<tracker>` is not `<tr>`, and `<paragraph>` is
+  // not `<p>`.
+  { label: 'near-miss tag names', markup: `<p>She opened the door.</p><p>A <press>literal</press>, a <tracker>mark</tracker>, and a <paragraph>tag</paragraph>.</p><p>${hook}</p>` },
+  // A boundary the enclosing tag carries is not the boundary the reader sees.
+  // `<table>` and `<tr>` were boundaries while `<td>` was not, so a row's cells
+  // came back welded into one token and the whole table scanned as one block.
+  { label: '<td>', markup: `<table><tr><td>She opened the door.</td><td>Blood pooled on the floor.</td></tr><tr><td>${hook}</td></tr></table>` },
+  { label: '<li>', markup: `<ul><li>She opened the door.</li><li>Blood pooled on the floor.</li><li>${hook}</li></ul>` },
+  { label: '<dd>', markup: `<dl><dt>She opened the door.</dt><dd>Blood pooled on the floor.</dd><dd>${hook}</dd></dl>` }
 ];
 
 for (const chapter of separatedChapters) {
@@ -67,5 +75,25 @@ assert(
   `paragraph text should not be glued to its neighbour (got ${JSON.stringify(glued.cliffhangerText)})`
 );
 assert(glued.cliffhangerType === 'danger', 'shadow and footsteps should classify as danger');
+
+// The same welding, one level in: a row's cells are separate text to a reader,
+// so `<td>The shadow</td><td>Footsteps followed her home.</td>` must not scan
+// as the single token `The shadowFootsteps followed her home.`.
+const gluedCells = service.analyze('<table><tr><td>The shadow moved.</td><td>Footsteps followed her home.</td></tr></table>');
+
+assert(
+  gluedCells.cliffhangerText === 'Footsteps followed her home.',
+  `table cell text should not be glued to the next cell (got ${JSON.stringify(gluedCells.cliffhangerText)})`
+);
+
+// The other direction for the boundary list: a tag whose name merely begins
+// with a listed one is inline markup, so it must be dropped in place rather
+// than splitting the paragraph it sits inside.
+const nearMiss = service.analyze('<p>The shadow moved.</p><p>A <press>hidden</press> <tracker>door</tracker> waited. Who was there?</p>');
+
+assert(
+  nearMiss.cliffhangerText === 'A hidden door waited. Who was there?',
+  `a near-miss tag name is not a boundary (got ${JSON.stringify(nearMiss.cliffhangerText)})`
+);
 
 console.log('Cliffhanger service tests passed');

--- a/tests/log-redaction.test.ts
+++ b/tests/log-redaction.test.ts
@@ -99,6 +99,47 @@ for (const delimiter of ['=', ':', '/', '+', '"', ',', '(']) {
   );
 }
 
+// A URL is usually written into a sentence, and the mark that closes the
+// sentence has no whitespace before it — so the run that redacted the URL took
+// the punctuation with it and left the log line unreadable at exactly the
+// moment someone is reading it.
+const punctuated: Array<{ note: string; expected: string; why: string }> = [
+  {
+    note: 'See https://host.example/a, then call me.',
+    expected: 'See [REDACTED], then call me.',
+    why: 'a comma after a URL belongs to the sentence'
+  },
+  {
+    note: 'Visit (https://host.example/a) now.',
+    expected: 'Visit ([REDACTED]) now.',
+    why: 'a parenthesis enclosing a URL is not part of it'
+  },
+  {
+    note: 'Fetched https://host.example/a.',
+    expected: 'Fetched [REDACTED].',
+    why: 'a full stop after a URL belongs to the sentence'
+  },
+  {
+    // The other direction: a path that really does end in a bracket keeps it,
+    // because the URL holds the opener that matches it.
+    note: 'Fetched https://host.example/wiki/Title_(disambiguation) twice.',
+    expected: 'Fetched [REDACTED] twice.',
+    why: 'a balanced bracket inside a path is part of the URL'
+  }
+];
+
+for (const testCase of punctuated) {
+  const redactedNote = (redactSensitiveLogData({ note: testCase.note }) as Record<string, string>).note;
+  assert(
+    redactedNote === testCase.expected,
+    `${testCase.why} (got ${JSON.stringify(redactedNote)})`
+  );
+  assert(
+    !redactedNote.includes('host.example'),
+    `the URL itself must still be redacted (got ${JSON.stringify(redactedNote)})`
+  );
+}
+
 const cyclic: Record<string, unknown> = { model: 'grok-4' };
 cyclic['self'] = cyclic;
 const redactedCycle = redactSensitiveLogData(cyclic) as Record<string, any>;

--- a/tests/story-quality-evals.test.ts
+++ b/tests/story-quality-evals.test.ts
@@ -240,6 +240,42 @@ function testNamedProseStillScores(): void {
 }
 
 /**
+ * A `[Speaker]:` tag names a character outright, so the cast count must include
+ * the speakers the same scan already reports.
+ *
+ * The tag starts the line it is on, which is the one position the boundary rule
+ * throws a capital away — so a scene whose signals read `Speaker: Elena` next
+ * to `Named character count: 1` was reporting a cast of one for a cast of
+ * three, and no action Elena took anywhere in the chapter could be credited to
+ * her. `Narrator` stays out of the count for the reason it always has: it names
+ * the telling, not a member of the cast.
+ */
+function testDialogueSpeakersCountAsCast(): void {
+  const scan = (storyContent: string) => buildStoryQualityHeuristicReport({
+    storyContent,
+    configuration: { creature: 'siren', themes: [], spicyLevel: 3, wordCount: 900 }
+  })
+    .dimensions
+    .find(dimension => dimension.id === 'character_consistency');
+
+  const spoken = scan('<p>[Elena]: "Run."</p><p>Then Kael chose the door.</p>');
+  assert(
+    spoken?.signals.includes('Speaker: Elena'),
+    `the speaker tag should still be reported (signals=${JSON.stringify(spoken?.signals)})`
+  );
+  assert(
+    spoken?.signals.includes('Named character count: 2'),
+    `a speaker is a named character (signals=${JSON.stringify(spoken?.signals)})`
+  );
+
+  const narrated = scan('<p>[Narrator]: The tide turned at last.</p><p>Then Mira pressed the blood oath.</p>');
+  assert(
+    narrated?.signals.includes('Named character count: 1'),
+    `Narrator names the telling, not the cast (signals=${JSON.stringify(narrated?.signals)})`
+  );
+}
+
+/**
  * Both boundary rules have to reject only what they are aimed at.
  *
  * The Codex review on PR #213 caught each one overreaching. A sentence opener
@@ -294,6 +330,7 @@ async function main(): Promise<void> {
   testHtmlStoriesAreScoredOnTheirProse();
   testAnonymousProseScoresAsAnonymous();
   testNamedProseStillScores();
+  testDialogueSpeakersCountAsCast();
   testBoundaryRulesRejectOnlyTheBoundary();
 
   const heuristicReport = buildStoryQualityHeuristicReport({


### PR DESCRIPTION
Three small, independent defects, each with a regression test that fails on `main`.

## 1. Table cells were welded into one token — `api/_lib/utils/storyTextBlocks.ts`

`splitStoryIntoTextBlocks` had a boundary for `<table>` and `<tr>` but none for `<td>`, so a row's cells came back as a single block:

```
<table><tr><td>One</td><td>Two</td></tr></table>  ->  ["OneTwo"]
```

That is the `door.Blood` welding this module exists to prevent, one level further in, and it reached every caller: the cliffhanger scan read the whole table as its "final paragraph", the continuity prompt showed the model prose no reader ever saw, and the story-quality scan counted two words as one. `<li>` and `<dd>` sat behind their list containers the same way.

The boundary list now names the block-level and table-cell elements outright, so a boundary is never left to the tag that happens to enclose it.

## 2. Dialogue speakers were not counted as cast — `api/_lib/story-lab/evaluation/storyQualityHeuristics.ts`

A `[Speaker]:` tag names a character outright, but it also starts the line it sits on — the one position the named-character boundary rule throws a capital away. So a scene reported:

```
["Speaker: Elena", "Named character count: 1", ...]
```

a cast of one for a cast of three. Because `extractAgencyActions` reads the same list, no action Elena took anywhere in the chapter could be credited to her either.

The cast is now seeded with the speakers the same scan already extracted, minus `Narrator`, which names the telling rather than a member of the cast.

## 3. URL redaction swallowed the sentence's punctuation — `shared/sensitiveTextRedaction.ts`

A URL ends at whitespace or a quote, which is where it ends in a log line too — but a URL is usually written *into* a sentence, and the mark that closes the sentence has neither before it:

| before | after |
| --- | --- |
| `See [REDACTED] then call me.` | `See [REDACTED], then call me.` |
| `Visit ([REDACTED] now.` | `Visit ([REDACTED]) now.` |

Trailing `.,;:!?` is handed back to the prose, and so is a closing bracket the URL holds no opener to match — a path that really ends in one (`/wiki/Title_(disambiguation)`) keeps it. Nothing is ever given back past the scheme, so the URL itself is never partially preserved.

## Testing

- `npm run test:all` passes (39 suites).
- Each fix has a regression test that was confirmed to fail against the unfixed source: `tests/cliffhanger-service.test.ts` (`<td>`/`<li>`/`<dd>` separation, plus a new assertion that a near-miss tag name such as `<press>` or `<tracker>` is still *not* a boundary), `tests/story-quality-evals.test.ts` (`testDialogueSpeakersCountAsCast`), and `tests/log-redaction.test.ts` (URL punctuation cases, each also asserting the URL stays redacted).
- `tsc --noEmit --strict` clean on the three changed source files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Txys7oykje4CTTWrkKeu18)_

## Summary by Sourcery

Fix story text splitting, cast detection, and URL redaction so analysis remains accurate and redacted log messages retain readable punctuation.

Bug Fixes:
- Preserve separate text blocks for table cells and additional block-level/list elements so downstream story analysis no longer merges adjacent content.
- Count dialogue speakers as named characters while excluding Narrator from cast counts and agency attribution.
- Keep sentence punctuation and unmatched closing brackets outside redacted URLs without exposing URL content.

Tests:
- Add regression coverage for HTML text-block boundaries, dialogue-speaker cast counting, and URL punctuation redaction.