### PR TITLE
Give the reader back the paragraphs three renderings had welded shut

### DIFF
--- a/api/_lib/services/storyService.ts
+++ b/api/_lib/services/storyService.ts
@@ -58,6 +58,9 @@ const STORY_LAB_THEME_LABEL_MAX_LENGTH = 80;
 const STORY_LAB_THEME_DESCRIPTION_MAX_LENGTH = 280;
 const STORY_LAB_CONTEXT_VALUE_MAX_LENGTH = 320;
 const STORY_LAB_NO_GO_CONTENT_MAX_LENGTH = STORY_LAB_CONTEXT_VALUE_MAX_LENGTH;
+// How much of the closing passage the continuation prompt is shown as "what
+// just happened", in words.
+const SUMMARY_WORD_LIMIT = 150;
 
 export class StoryService {
   private readonly xaiClient = new XaiTextClient();
@@ -1471,12 +1474,19 @@ Write 400-600 words for this chapter. Use HTML: <h3> for chapter title, <p> for 
     
     // Get last 2-3 paragraphs as summary
     const lastParagraphs = paragraphs.slice(-3).join(' ');
-    
+
     // Truncate to ~150 words
     const words = lastParagraphs.split(/\s+/);
-    const summary = words.slice(0, 150).join(' ');
-    
-    return summary.length < lastParagraphs.length ? summary + '...' : summary;
+    const summary = words.slice(0, SUMMARY_WORD_LIMIT).join(' ');
+
+    // Whether the cut happened is a question about the words, not about the
+    // lengths of two strings. Joining on single spaces is itself shortening —
+    // any line break or double space inside the paragraphs comes back as one
+    // character — so comparing lengths reported a truncation for a summary that
+    // holds the whole passage. The marker is what tells the continuation prompt
+    // that the chapter it is being handed stops mid-thought, and the model is
+    // then prompted to resume from a sentence that had in fact already ended.
+    return words.length > SUMMARY_WORD_LIMIT ? summary + '...' : summary;
   }
 
   /**
@@ -2006,14 +2016,24 @@ ${renderBody()}`;
       .replace(/\n\s*\n/g, '\n\n') // Normalize multiple newlines
       .trim();
 
-    // Smart paragraph creation based on content structure
-    const lines = displayContent.split('\n').filter(line => line.trim());
+    // Smart paragraph creation based on content structure.
+    //
+    // The blank lines have to survive the split. Filtering them out here left
+    // the branch below — the one that reads a blank line as the paragraph break
+    // it is — unreachable, so the only breaks this method could ever make were
+    // the ones the dialogue and narrative-shift heuristics guessed at. A model
+    // that separated its paragraphs the ordinary way, with a blank line and no
+    // opening quote or `Suddenly` to give itself away, had every one of them
+    // welded into a single `<p>`: the reader was shown the chapter as one
+    // unbroken block, and the paragraph structure the generator had actually
+    // written was thrown away before anything downstream could read it.
+    const lines = displayContent.split('\n');
     const paragraphs = [];
     let currentParagraph = '';
 
     for (const line of lines) {
       const trimmedLine = line.trim();
-      
+
       // Empty line indicates paragraph break
       if (!trimmedLine) {
         if (currentParagraph) {

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -2598,6 +2598,29 @@ describe('App', () => {
     expect(component.statusMessage()).toBe('Story copied to your clipboard.');
   });
 
+  it('copies story text as paragraphs with decoded character references', async () => {
+    const writeText = jasmine.createSpy('writeText').and.resolveTo();
+    spyOnProperty(navigator, 'clipboard', 'get').and.returnValue({ writeText } as unknown as Clipboard);
+    component.workbench.set({
+      story: createSummary({ title: 'Copied Pact' }),
+      state: createState(),
+      chapterHistory: [createChapter({
+        title: 'First Ember',
+        htmlContent: '<p>She opened the door.</p><p>Blood &amp; ash pooled on the &quot;floor&quot;.</p>'
+      })],
+      activeBatchSize: 1
+    });
+
+    await component.copyStory();
+
+    const copied = writeText.calls.mostRecent().args[0] as string;
+    // Collapsing the markup to a single line welded the paragraphs together and
+    // left the generator's character references sitting in the prose as text.
+    expect(copied).toContain('She opened the door.\n\nBlood & ash pooled on the "floor".');
+    expect(copied).not.toContain('&amp;');
+    expect(copied).not.toContain('door. Blood');
+  });
+
   it('downloads generated story HTML locally', fakeAsync(() => {
     const originalCreateElement = document.createElement.bind(document);
     const anchor = originalCreateElement('a') as HTMLAnchorElement;

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -5,6 +5,7 @@ import { FormsModule } from '@angular/forms';
 import { DomSanitizer } from '@angular/platform-browser';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { Subscription, map } from 'rxjs';
+import { splitStoryIntoTextBlocks } from '../../../api/_lib/utils/storyTextBlocks';
 import { BlueprintValidationField, FormValidationService } from './form-validation.service';
 import {
   BatchProgressState,
@@ -2526,26 +2527,25 @@ ${chapters}
     return `${session.story.title}\n\n${session.story.synopsis}\n\n${chapters}`;
   }
 
+  /**
+   * Render a chapter's markup as the text a reader sees, for the clipboard.
+   *
+   * Deleting the tags and collapsing every whitespace run is not that. A
+   * chapter is a sequence of `<p>` elements, so the collapse turned the whole
+   * story into a single unbroken line — the reader who copied it to paste
+   * somewhere else got a wall of text with no paragraphs anywhere in it — and
+   * nothing decoded the character references the generator writes, so `&amp;`
+   * and `&quot;` were pasted as that literal entity text rather than as the
+   * punctuation they stand for.
+   *
+   * `splitStoryIntoTextBlocks` is the rendering the cliffhanger, image,
+   * continuity, and story-quality scanners already read: a block-level tag puts
+   * a paragraph break where the markup put one, and the basic entities are
+   * decoded. Joining the blocks with a blank line gives the plain-text shape a
+   * story has everywhere else it leaves this app.
+   */
   private stripHtml(html: string): string {
-    let text = '';
-    let insideTag = false;
-
-    for (const char of html) {
-      if (char === '<') {
-        insideTag = true;
-        text += ' ';
-        continue;
-      }
-      if (char === '>') {
-        insideTag = false;
-        continue;
-      }
-      if (!insideTag) {
-        text += char;
-      }
-    }
-
-    return this.normalizeInlineWhitespace(text);
+    return splitStoryIntoTextBlocks(html).join('\n\n');
   }
 
   private safeFileName(value: string): string {

--- a/tests/story-service-improved.test.ts
+++ b/tests/story-service-improved.test.ts
@@ -713,6 +713,66 @@ const storyTextTests = {
     }
 
     console.log(`   ✓ Hint: ${JSON.stringify(hint)}`);
+  }),
+
+  testLastChapterSummaryOnlyMarksRealTruncation: test('Last Chapter Summary Only Marks Real Truncation', () => {
+    const service = new StoryService();
+    const summarize = (content: string) => (service as any).extractLastChapterSummary(content) as string;
+
+    // A short closing passage that the 150-word cut cannot reach, written the
+    // way generator HTML actually arrives: the paragraphs carry line breaks and
+    // indentation inside them. Joining the words on single spaces shortens the
+    // string without dropping any of them, which is what the length comparison
+    // read as a truncation.
+    const untruncated = summarize('<p>\n  She opened the door.\n</p>\n<p>\n  Blood pooled on the floor.\n</p>');
+    if (untruncated.endsWith('...')) {
+      throw new Error(`A summary that holds the whole passage must not be marked truncated: ${JSON.stringify(untruncated)}`);
+    }
+    if (!untruncated.includes('Blood pooled on the floor.')) {
+      throw new Error(`The summary should still carry the closing paragraph: ${JSON.stringify(untruncated)}`);
+    }
+
+    // Past 150 words the marker is the point: the continuation prompt has to
+    // know the passage it was handed stops early.
+    const longParagraph = `<p>${Array.from({ length: 200 }, (_, index) => `word${index}`).join(' ')}</p>`;
+    const truncated = summarize(longParagraph);
+    if (!truncated.endsWith('...')) {
+      throw new Error('A summary cut at the word limit must be marked truncated');
+    }
+    // The marker is appended to the last word rather than written as a word of
+    // its own, so the cut passage is still exactly 150 tokens long.
+    if (truncated.split(/\s+/).length !== 150) {
+      throw new Error(`Expected the summary cut to 150 words, got ${truncated.split(/\s+/).length} tokens`);
+    }
+
+    console.log(`   ✓ Untruncated summary: ${JSON.stringify(untruncated)}`);
+    console.log(`   ✓ Truncated summary ends with the marker`);
+  }),
+
+  testDisplayContentKeepsBlankLineParagraphs: test('Display Content Keeps Blank-Line Paragraphs', () => {
+    const service = new StoryService();
+    // Plain paragraphs separated the ordinary way: a blank line, with no
+    // opening quote and no `Suddenly` for the shift heuristic to catch. Every
+    // one of them used to be welded into a single `<p>`.
+    const raw = [
+      '[Narrator]: She opened the door.',
+      '',
+      '[Narrator]: Blood pooled on the floor.',
+      '',
+      '[Narrator]: Nobody had been there for years.'
+    ].join('\n');
+
+    const display: string = (service as any).stripSpeakerTagsForDisplay(raw);
+    const paragraphCount = display.split('<p>').length - 1;
+
+    if (paragraphCount !== 3) {
+      throw new Error(`Expected 3 paragraphs from 3 blank-line-separated lines, got ${paragraphCount}: ${JSON.stringify(display)}`);
+    }
+    if (display.includes('door. Blood')) {
+      throw new Error(`Two paragraphs were welded into one: ${JSON.stringify(display)}`);
+    }
+
+    console.log(`   ✓ Display content: ${JSON.stringify(display)}`);
   })
 };
 


### PR DESCRIPTION
Three quick wins, each a place where paragraph structure a reader can see was thrown away before anything downstream could read it.

## 1. Copying a story to the clipboard produced one unbroken line

`AppComponent.stripHtml` deleted the tags and then collapsed every whitespace run, so a story copied to the clipboard arrived as a single line with no paragraphs anywhere in it. Nothing decoded character references either, so the generator's `&amp;` and `&quot;` were pasted as that literal entity text rather than as the punctuation they stand for.

It now goes through `splitStoryIntoTextBlocks` — the rendering the cliffhanger, image, continuity, and story-quality scanners already read — so a block-level tag puts a paragraph break where the markup put one and the basic entities are decoded. `normalizeInlineWhitespace` is still used by `safeFileName`, so nothing is left dead.

## 2. `stripSpeakerTagsForDisplay` could not see a blank-line paragraph break

The method split the content into lines with `.filter(line => line.trim())`, which removed the blank lines *before* the loop whose first branch reads a blank line as a paragraph break — leaving that branch unreachable. The only breaks the method could make were the ones its dialogue and narrative-shift heuristics guessed at, so a model that separated its paragraphs the ordinary way (blank line, no opening quote, no `Suddenly`) had every one of them welded into a single `<p>`.

Dropping the filter lets the blank lines reach the branch that was written for them. The trailing `.filter(para => para.length > 0)` already removes anything empty the change lets through.

## 3. `extractLastChapterSummary` marked untruncated summaries as truncated

Whether the 150-word cut happened is a question about the words, but the check compared the length of the joined summary against the length of the source passage. Joining the words on single spaces is itself shortening — every line break and double space inside the paragraphs comes back as one character — so a summary holding the entire closing passage was still given a trailing `...`.

That marker is what tells the continuation prompt the chapter it was handed stops mid-thought, and the model was then prompted to resume from a sentence that had in fact already ended. The check is now `words.length > SUMMARY_WORD_LIMIT`, which is the same test `summarizeHtml` in the Story Lab engine already uses.

## Testing

- `npm run test:all` — passes (exit 0, no failures), including two new cases in `tests/story-service-improved.test.ts`: one asserting the truncation marker appears only past the word limit, one asserting three blank-line-separated lines render as three paragraphs.
- `ng test --watch=false` in `story-generator/` — 143 tests, with a new spec asserting the clipboard text keeps its paragraph break and decodes `&amp;`/`&quot;`. One failure, `ProvingGroundsComponent disables generate button while generation is in progress`, reproduces identically on `main` with these changes stashed; it is not touched by this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9x5VHVwdhachi6ABqgLC1)_

## Summary by Sourcery

Restore paragraph structure across copied stories, displayed content, and continuation summaries.

Bug Fixes:
- Preserve paragraph breaks and decode basic character references when copying generated stories to the clipboard.
- Restore blank-line paragraph separation when preparing speaker-tagged content for display.
- Only mark chapter summaries as truncated when they exceed the summary word limit.

Tests:
- Add coverage for clipboard paragraph and entity handling, accurate summary truncation markers, and blank-line paragraph rendering.