### PR TITLE
Follow-up to #223: keep the query-string genesis stream out of navigation

### DIFF
--- a/story-generator/src/app/app.html
+++ b/story-generator/src/app/app.html
@@ -14,7 +14,6 @@
     </div>
     <nav class="hero-actions" aria-label="Story Lab actions">
       <a class="header-link" routerLink="/proving-grounds" *ngIf="showDebugPanel()">Proving Grounds</a>
-      <a class="header-link" routerLink="/live-stream-preview" *ngIf="showDebugPanel()">Live Stream Preview</a>
       <button type="button" class="ghost compact" (click)="saveActiveProject()" [disabled]="!workbench().story">
         Save
       </button>

--- a/story-generator/src/app/app.routes.ts
+++ b/story-generator/src/app/app.routes.ts
@@ -14,11 +14,6 @@ export const routes: Routes = [
     title: 'Fairytales with Spice - Proving Grounds'
   },
   {
-    path: 'live-stream-preview',
-    loadComponent: () => import('./streaming-story/streaming-story.component').then((module) => module.StreamingStoryComponent),
-    title: 'Fairytales with Spice - Live Stream Preview'
-  },
-  {
     path: '**',
     redirectTo: ''
   }


### PR DESCRIPTION
## Follow-up to #223

Shortly after #223 merged, a review comment (`chatgpt-codex-connector[bot]`) flagged a real problem with one part of it that I want to fix immediately rather than let sit: wiring `StreamingStoryComponent` into app navigation exposed a genuine privacy issue that the original PR's reasoning missed.

### What was wrong

`StoryService.streamStoryGeneration()` (`story-generator/src/app/story.service.ts`) builds its `EventSource` URL with `URLSearchParams` carrying **free-text fields the reader typed**: `logline`, `narrativeDirectives`, `protagonistName`, `antagonistName`, `worldDetails`, plus `themes` and `heatContract` JSON-stringified into the query string. `EventSource` can only issue `GET`, so there's no way to move this to a request body without changing the endpoint's transport.

A story premise in a URL query string ends up in server access logs, intermediate proxy logs, and browser history — precisely the kind of leak this repo's `log-redaction`, `export-sanitizer`, and `story-lab-privacy-contracts` test suites exist to prevent elsewhere. #223 reasoned that since the backend route and component were both real and tested, making the component reachable was a straightforward improvement; it didn't check whether the transport itself was privacy-safe to expose to real users.

It also wasn't actually debug-gated in any meaningful sense: `showDebugPanel()` (`story-generator/src/app/app.ts`) is driven by a plain `?debug=1` query parameter, not an auth check or environment flag — so the "Live Stream Preview" nav link was reachable by any visitor who added that to the URL, not just developers.

### What this PR does

Reverts exactly the navigation-wiring piece of #223:
- Removes the `live-stream-preview` route from `app.routes.ts`.
- Removes the "Live Stream Preview" nav link from `app.html`.

`StreamingStoryComponent` and `/api/story-lab/stream/genesis` are left in place, untouched, along with everything else #223 did (retiring the dead, duplicated `/api/story/stream` implementation). This only undoes the part that made the query-string transport reachable through the app before it's been migrated to something privacy-safe (an opaque id, or a body-backed request against a non-`EventSource` transport).

### Verification

- `npx tsc -p tsconfig.json --noEmit`: clean.
- `npm run build:prod`: succeeds; `streaming-story-component` no longer appears as a route-reachable lazy chunk (confirms it's unrouted again).
- `app.spec.ts`: 93/93 pass, headless Chromium.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXh6kugwSSWuVLCKiNDeeg)_

## Summary by Sourcery

Remove navigation access to the live stream preview until its query-string transport can be made privacy-safe.

Bug Fixes:
- Prevent exposing the privacy-sensitive live story generation stream through application navigation.

Enhancements:
- Remove the debug-only Live Stream Preview route and navigation link while retaining the underlying streaming implementation for future privacy-safe transport changes.