### PR TITLE
Three quick wins: an uncapped paid route, HTML for API failures, a dropped error body

### DIFF
--- a/api/_lib/http/expressApiRoutes.ts
+++ b/api/_lib/http/expressApiRoutes.ts
@@ -122,6 +122,152 @@ export function registerApiRoutes(registrar: ApiRouteRegistrar): void {
 }
 
 /**
+ * Answer an `/api` path no route claimed.
+ *
+ * Without this, an unregistered API path falls past `express.static` into the
+ * Angular SSR handler, which renders the index page and answers `200 OK`,
+ * `text/html` — the exact failure this module exists to end, only narrowed from
+ * "every Story Lab route" to "any path that is not in the table above": a typo
+ * in a client URL, a route retired on one deployment and not the other, or a
+ * `vercel.json` rewrite whose Express twin was never added. `HttpClient` reports
+ * that page as a JSON parse error, so the one thing the response does not say is
+ * that the path does not exist.
+ *
+ * Mount it directly after `registerApiRoutes`, before the static and SSR
+ * handlers, since falling through to them is the thing being prevented.
+ */
+export function apiNotFoundHandler(req: any, res: any): void {
+  sendApiEnvelope(res, 404, {
+    success: false,
+    error: {
+      code: 'API_ROUTE_NOT_FOUND',
+      message: `No API route matches ${readRequestMethod(req)} ${readRequestPath(req)}.`
+    }
+  });
+}
+
+/**
+ * Turn a failure anywhere under `/api` into the envelope every caller of this
+ * API already reads.
+ *
+ * `runApiRoute` hands a thrown or rejected handler to `next`, and the body
+ * parsers mounted ahead of the routes reject a malformed or oversized payload
+ * the same way. With no error middleware registered, all of that reached
+ * Express's default handler, which answers `text/html` — carrying the full stack
+ * trace whenever `NODE_ENV` is not `production`, which is the default. So a
+ * server-side bug was served to the browser as a stack trace that `HttpClient`
+ * could only report as a parse error, and a client that sent a truncated JSON
+ * body was told nothing it could act on.
+ *
+ * The two body-parser failures are caller errors and are named as such; anything
+ * else is this service failing and is reported as `500` with no detail beyond
+ * the code, because the detail is what the stack trace was leaking.
+ *
+ * Express recognises an error handler by its four declared parameters, so `next`
+ * has to stay in the signature even though a response that is already streaming
+ * is the only case that uses it.
+ */
+export function apiErrorHandler(
+  error: any,
+  _req: any,
+  res: any,
+  next: (error?: unknown) => void
+): void {
+  // A route that already began writing — an SSE stream, say — cannot be given a
+  // status and a body now. Express's default handler is what closes that socket.
+  if (res?.headersSent) {
+    next(error);
+    return;
+  }
+
+  const bodyError = readBodyParserError(error);
+  if (bodyError) {
+    sendApiEnvelope(res, bodyError.status, {
+      success: false,
+      error: { code: bodyError.code, message: bodyError.message }
+    });
+    return;
+  }
+
+  sendApiEnvelope(res, 500, {
+    success: false,
+    error: {
+      code: 'INTERNAL_ERROR',
+      message: 'The API failed to handle this request.'
+    }
+  });
+}
+
+/**
+ * Recognise the two failures `express.json` and `express.urlencoded` raise for
+ * a request the caller can fix. Both carry a `type` naming the check that
+ * failed; the status they set is used as-is so a change in Express does not
+ * silently become a 500 here.
+ */
+function readBodyParserError(
+  error: any
+): { status: number; code: string; message: string } | null {
+  const type = error && typeof error === 'object' ? (error as { type?: unknown }).type : undefined;
+  const status = readErrorStatus(error);
+
+  if (type === 'entity.parse.failed') {
+    return {
+      status: status ?? 400,
+      code: 'INVALID_INPUT',
+      message: 'Request body is not valid JSON.'
+    };
+  }
+
+  if (type === 'entity.too.large') {
+    return {
+      status: status ?? 413,
+      code: 'CONTENT_TOO_LARGE',
+      message: 'Request body is larger than this API accepts.'
+    };
+  }
+
+  return null;
+}
+
+function readErrorStatus(error: any): number | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+
+  const candidate = (error as { status?: unknown; statusCode?: unknown });
+  for (const value of [candidate.status, candidate.statusCode]) {
+    if (typeof value === 'number' && value >= 400 && value <= 599) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function sendApiEnvelope(res: any, status: number, body: unknown): void {
+  if (typeof res?.status === 'function' && typeof res.status(status)?.json === 'function') {
+    res.status(status).json(body);
+    return;
+  }
+
+  // A response double, or a bare `ServerResponse`, may carry neither helper.
+  // Saying so in JSON is still better than the HTML default.
+  res.statusCode = status;
+  res.setHeader?.('Content-Type', 'application/json');
+  res.end?.(JSON.stringify(body));
+}
+
+function readRequestMethod(req: any): string {
+  const method = req?.method;
+  return typeof method === 'string' && method ? method.toUpperCase() : 'GET';
+}
+
+function readRequestPath(req: any): string {
+  const path = req?.originalUrl ?? req?.url;
+  return typeof path === 'string' && path ? path.split('?')[0] : '/api';
+}
+
+/**
  * Exported for the same reason the route table is: this is where a rejected
  * handler stops being an unhandled rejection, and asserting on it through a
  * live server would prove nothing the fake registrar cannot.

--- a/api/story-lab/evaluate.ts
+++ b/api/story-lab/evaluate.ts
@@ -5,6 +5,7 @@ import { getXaiFastTimeoutMs } from '../_lib/config/xaiConfig';
 import { buildStoryQualityHeuristicReport } from '../_lib/story-lab/evaluation/storyQualityHeuristics';
 import { readJsonObjectBody } from '../_lib/http/jsonRequestBody';
 import { stripMarkdownJsonFence } from '../_lib/utils/modelJsonPayload';
+import { STORY_EVALUATION_LIMITS } from '../../shared/storyBlueprintLimits';
 
 interface NormalizedEvaluationRequest {
   storyContent: string;
@@ -159,6 +160,20 @@ function isFiniteNumber(value: unknown): boolean {
   return Number.isFinite(value);
 }
 
+/**
+ * Whether every entry of an already-validated string array is short enough to
+ * be a theme id rather than prose smuggled in under the field's name.
+ */
+function isShortStringArray(value: unknown): boolean {
+  return isStringArray(value)
+    && (value as string[]).length <= STORY_EVALUATION_LIMITS.maxThemes
+    && (value as string[]).every(entry => entry.length <= STORY_EVALUATION_LIMITS.maxConfigurationValueLength);
+}
+
+function isShortString(value: unknown): boolean {
+  return isString(value) && (value as string).length <= STORY_EVALUATION_LIMITS.maxConfigurationValueLength;
+}
+
 function normalizeEvaluationRequest(
   body: unknown
 ): { request: NormalizedEvaluationRequest } | { message: string } {
@@ -171,6 +186,17 @@ function normalizeEvaluationRequest(
 
   if (typeof input.storyContent !== 'string' || !input.storyContent.trim()) {
     return { message: 'storyContent is required and must be a non-empty string.' };
+  }
+
+  // The whole of this field is interpolated into the Grok prompt, so an
+  // unbounded one is an unbounded paid request: billed by the token, and given
+  // the function's entire time budget to send. The caller is the only party who
+  // can shorten it, so the answer is 400 rather than a truncation that silently
+  // evaluates a story the caller did not send.
+  if (input.storyContent.length > STORY_EVALUATION_LIMITS.maxStoryContentLength) {
+    return {
+      message: `storyContent must be ${STORY_EVALUATION_LIMITS.maxStoryContentLength} characters or fewer.`
+    };
   }
 
   // A `null` configuration reads as an absent one, which is what `?.` did
@@ -188,7 +214,19 @@ function normalizeEvaluationRequest(
   const wordCount = configuration?.wordCount;
   const fieldError =
     optionalFieldError('creature', creature, isString, 'a string') ??
+    optionalFieldError(
+      'creature',
+      creature,
+      isShortString,
+      `${STORY_EVALUATION_LIMITS.maxConfigurationValueLength} characters or fewer`
+    ) ??
     optionalFieldError('themes', themes, isStringArray, 'an array of strings') ??
+    optionalFieldError(
+      'themes',
+      themes,
+      isShortStringArray,
+      `no more than ${STORY_EVALUATION_LIMITS.maxThemes} entries of ${STORY_EVALUATION_LIMITS.maxConfigurationValueLength} characters or fewer`
+    ) ??
     optionalFieldError('spicyLevel', spicyLevel, isFiniteNumber, 'a number') ??
     optionalFieldError('wordCount', wordCount, isFiniteNumber, 'a number');
   if (fieldError) {

--- a/shared/storyBlueprintLimits.ts
+++ b/shared/storyBlueprintLimits.ts
@@ -12,8 +12,8 @@
  * the Grok prompt. A caller that skips the form, or a stale tab running an
  * older bundle, could therefore send a megabyte of prose into a paid model
  * call: the request is billed by the token, it eats the function's whole time
- * budget, and nothing on the server ever said no. The same reasoning capped
- * `storyContent` on `/api/story-lab/evaluate`.
+ * budget, and nothing on the server ever said no. `STORY_EVALUATION_LIMITS`
+ * below applies the same reasoning to `/api/story-lab/evaluate`.
  *
  * Defining them here rather than restating them on the server is what keeps a
  * later change to one of these numbers from splitting the two readings apart —
@@ -31,3 +31,31 @@ export const STORY_BLUEPRINT_LIMITS = {
 } as const;
 
 export type StoryBlueprintLimits = typeof STORY_BLUEPRINT_LIMITS;
+
+/**
+ * The size limits an evaluation request has to satisfy.
+ *
+ * `/api/story-lab/evaluate` checked that `storyContent` was a non-empty string
+ * and then interpolated the whole of it into the Grok prompt, with the
+ * configuration's `creature` and every entry of `themes` beside it. Nothing
+ * bounded any of the three, so the one route in this repository that takes
+ * arbitrary prose from the caller — rather than generating it — was also the
+ * one route that would forward any amount of it to a model billed by the
+ * token. The blueprint routes have refused an oversized field since
+ * `STORY_BLUEPRINT_LIMITS` was introduced; this route was described in the
+ * comment above as if it did the same, and did not.
+ *
+ * The story cap is the loose one on purpose. A caller evaluates a whole
+ * accumulated saga, not one batch, so the number has to clear a long story
+ * comfortably — 60,000 characters is roughly ten thousand words — while still
+ * being a number. The theme and creature caps match what the blueprint routes
+ * already accept, because these fields name the same things.
+ */
+export const STORY_EVALUATION_LIMITS = {
+  maxStoryContentLength: 60_000,
+  maxThemes: STORY_BLUEPRINT_LIMITS.maxThemes,
+  /** One theme id or creature name, not a paragraph wearing the field's name. */
+  maxConfigurationValueLength: 80
+} as const;
+
+export type StoryEvaluationLimits = typeof STORY_EVALUATION_LIMITS;

--- a/story-generator/src/app/error-logging.spec.ts
+++ b/story-generator/src/app/error-logging.spec.ts
@@ -109,6 +109,50 @@ describe('ErrorLoggingService', () => {
     expect(details).not.toContain('forged root cause');
   });
 
+  it('should keep a value that two branches share rather than calling it circular', () => {
+    // What `StoryService.handleHttpError` logs: the response body is reachable
+    // both as `payload` and as `originalError.error`, and nothing about that is
+    // a cycle. A visited-everything walk replaced whichever the key order
+    // reached second with `[Circular]`, dropping the response body from the
+    // error entry it belongs to.
+    const responseBody = { code: 'STORY_NOT_FOUND', hint: 'retry with a fresh id' };
+    const httpError = { status: 404, url: '/api/story-lab/stories/abc', error: responseBody };
+
+    service.logError(httpError, 'Shared Reference Test', 'error', {
+      status: httpError.status,
+      url: httpError.url,
+      payload: responseBody
+    });
+
+    const details = service.getLatestErrors(1)[0].details as any;
+
+    expect(details.payload.code).toBe('STORY_NOT_FOUND');
+    expect(details.originalError.error.code).toBe('STORY_NOT_FOUND');
+    expect(JSON.stringify(details)).not.toContain('[Circular]');
+  });
+
+  it('should redact a value that is only named as sensitive on its second path', () => {
+    // One array, reached first under a harmless key and then under a sensitive
+    // one. A visited-everything walk skipped the second visit, so the token was
+    // never collected — and an uncollected value is not removed from the message
+    // and stack text it also appears in. This one carries no recognisable key
+    // prefix, so the key it hangs under is the only thing that identifies it.
+    const sessionToken = 'q7f3a9c21d4e8b6a0';
+    const sharedTokens = [sessionToken];
+
+    service.logError(
+      { message: `upload rejected for ${sessionToken}` },
+      'Second Path Test',
+      'error',
+      { auditTrail: sharedTokens, accessTokens: sharedTokens }
+    );
+
+    const serialized = JSON.stringify(service.getLatestErrors(1)[0]);
+
+    expect(serialized).not.toContain(sessionToken);
+    expect(serialized).toContain('[REDACTED]');
+  });
+
   it('should serialize circular Error causes without recursion', () => {
     const circularError = new Error('loop root') as Error & { cause?: unknown };
     circularError.cause = circularError;

--- a/story-generator/src/app/error-logging.ts
+++ b/story-generator/src/app/error-logging.ts
@@ -190,7 +190,28 @@ export class ErrorLoggingService {
     return undefined;
   }
 
-  private redactSensitiveLogData(value: any, sensitiveValues: string[] = [], seen = new WeakSet<object>(), keyHint = ''): any {
+  /**
+   * `ancestors` holds only the objects on the current recursion path, so a
+   * value reachable from two branches is walked twice rather than mislabelled
+   * as a cycle — the same reading `redactSensitiveLogData` in
+   * `api/_lib/utils/logger.ts` uses, and for the same reason.
+   *
+   * A set of everything already visited says `[Circular]` for a graph that has
+   * no cycle in it, and this service's busiest caller builds exactly such a
+   * graph: `StoryService.handleHttpError` logs
+   * `{ status, url, payload: error.error, originalError: error }`, where
+   * `payload` and `originalError.error` are one object. Walked with a
+   * visited-everything set, whichever of the two the key order reached second
+   * was replaced by the string `[Circular]`, so the response body the log entry
+   * exists to preserve was dropped from the error it belonged to.
+   *
+   * `collectSensitiveStrings` below shares the failure and makes it a privacy
+   * one rather than a legibility one: an object it marked visited under a
+   * harmless key was skipped when it reappeared under a sensitive one, so the
+   * strings inside it were never collected, and never redacted from the message
+   * and stack text they also appear in.
+   */
+  private redactSensitiveLogData(value: any, sensitiveValues: string[] = [], ancestors = new WeakSet<object>(), keyHint = ''): any {
     if (value === null || value === undefined) {
       return value;
     }
@@ -207,46 +228,45 @@ export class ErrorLoggingService {
       return value;
     }
 
-    if (value instanceof Error) {
-      if (seen.has(value)) {
-        return '[Circular]';
-      }
-      seen.add(value);
-
-      const redactedError: Record<string, unknown> = {
-        name: value.name,
-        message: this.redactSensitiveText(value.message, sensitiveValues)
-      };
-      if (value.stack) {
-        redactedError['stack'] = this.redactSensitiveText(value.stack, sensitiveValues);
-      }
-      if ('cause' in value && value.cause !== undefined) {
-        redactedError['cause'] = this.redactSensitiveLogData(value.cause, sensitiveValues, seen, 'cause');
-      }
-      return redactedError;
-    }
-
     if (value instanceof Date) {
       return value;
     }
 
-    if (seen.has(value)) {
+    if (ancestors.has(value)) {
       return '[Circular]';
     }
-    seen.add(value);
+    ancestors.add(value);
 
-    if (Array.isArray(value)) {
-      return value.map(item => this.redactSensitiveLogData(item, sensitiveValues, seen, keyHint));
-    }
+    try {
+      if (value instanceof Error) {
+        const redactedError: Record<string, unknown> = {
+          name: value.name,
+          message: this.redactSensitiveText(value.message, sensitiveValues)
+        };
+        if (value.stack) {
+          redactedError['stack'] = this.redactSensitiveText(value.stack, sensitiveValues);
+        }
+        if ('cause' in value && value.cause !== undefined) {
+          redactedError['cause'] = this.redactSensitiveLogData(value.cause, sensitiveValues, ancestors, 'cause');
+        }
+        return redactedError;
+      }
 
-    const redacted: Record<string, unknown> = {};
-    for (const [key, child] of Object.entries(value)) {
-      redacted[key] = this.redactSensitiveLogData(child, sensitiveValues, seen, key);
+      if (Array.isArray(value)) {
+        return value.map(item => this.redactSensitiveLogData(item, sensitiveValues, ancestors, keyHint));
+      }
+
+      const redacted: Record<string, unknown> = {};
+      for (const [key, child] of Object.entries(value)) {
+        redacted[key] = this.redactSensitiveLogData(child, sensitiveValues, ancestors, key);
+      }
+      return redacted;
+    } finally {
+      ancestors.delete(value);
     }
-    return redacted;
   }
 
-  private collectSensitiveStrings(value: any, seen = new WeakSet<object>(), keyHint = ''): string[] {
+  private collectSensitiveStrings(value: any, ancestors = new WeakSet<object>(), keyHint = ''): string[] {
     if (value === null || value === undefined) {
       return [];
     }
@@ -259,21 +279,29 @@ export class ErrorLoggingService {
       return [];
     }
 
-    if (seen.has(value)) {
+    if (ancestors.has(value)) {
       return [];
     }
-    seen.add(value);
+    ancestors.add(value);
 
+    try {
+      return this.collectSensitiveStringsFromObject(value, ancestors, keyHint);
+    } finally {
+      ancestors.delete(value);
+    }
+  }
+
+  private collectSensitiveStringsFromObject(value: object, ancestors: WeakSet<object>, keyHint: string): string[] {
     const values: string[] = [];
     if (Array.isArray(value)) {
       for (const item of value) {
-        values.push(...this.collectSensitiveStrings(item, seen, keyHint));
+        values.push(...this.collectSensitiveStrings(item, ancestors, keyHint));
       }
       return values;
     }
 
     for (const [key, child] of Object.entries(value)) {
-      values.push(...this.collectSensitiveStrings(child, seen, key));
+      values.push(...this.collectSensitiveStrings(child, ancestors, key));
     }
     return values.filter(item => item.length > 0);
   }

--- a/story-generator/src/server.ts
+++ b/story-generator/src/server.ts
@@ -7,7 +7,11 @@ import {
 import express, { Request, Response, NextFunction } from 'express';
 import { join } from 'node:path';
 import { createCorsMiddleware } from '../../api/_lib/http/corsPolicy';
-import { registerApiRoutes } from '../../api/_lib/http/expressApiRoutes';
+import {
+  apiErrorHandler,
+  apiNotFoundHandler,
+  registerApiRoutes
+} from '../../api/_lib/http/expressApiRoutes';
 
 const browserDistFolder = join(import.meta.dirname, '../browser');
 
@@ -16,19 +20,24 @@ const angularApp = new AngularNodeAppEngine();
 
 // ==================== MIDDLEWARE ====================
 
-// Body parsing
-app.use(express.json({ limit: '10mb' }));
-app.use(express.urlencoded({ extended: true, limit: '10mb' }));
-
 // CORS for the API surface, through the same origin allow-list the serverless
 // routes use: `STORY_LAB_ALLOWED_ORIGINS`, `ALLOWED_ORIGINS`, and
 // `FRONTEND_URL` are comma-separated lists, and the response names the one
 // origin the request actually matched. Page responses are left alone — they are
 // same-origin, and an allow-list is not the SSR handler's business.
+//
+// Ahead of the body parsers so that a request the parsers reject is still
+// answered with the CORS headers the browser needs in order to show the caller
+// the 400 — and so a preflight, which carries no body worth parsing, is answered
+// without one being read.
 app.use('/api', createCorsMiddleware({
   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   credentials: true
 }));
+
+// Body parsing
+app.use(express.json({ limit: '10mb' }));
+app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 
 // ==================== API ROUTES ====================
 
@@ -38,6 +47,14 @@ app.use('/api', createCorsMiddleware({
 // on this deployment at all, and what stops the four legacy routes from being a
 // second, drifting implementation of routes that already exist.
 registerApiRoutes(app);
+
+// Anything left under `/api` is a path no route claimed, and it has to be said
+// here: past this point lie `express.static` and the Angular SSR handler, and
+// the SSR handler answers every path it is given with the rendered index page
+// and a `200`. That is what made the missing Story Lab routes look like
+// successes on the wire, and it does the same for any path the table above
+// does not carry.
+app.use('/api', apiNotFoundHandler);
 
 // ==================== STATIC FILES & ANGULAR SSR ====================
 
@@ -63,6 +80,16 @@ app.use((req: Request, res: Response, next: NextFunction) => {
     )
     .catch(next);
 });
+
+// ==================== API ERROR HANDLING ====================
+
+// Last, because Express matches error middleware in registration order and this
+// one has to be able to see a failure from anything above it — a body the
+// parsers rejected, and the handler errors `runApiRoute` deliberately forwards
+// here rather than letting them become unhandled rejections. Without it those
+// reached Express's default handler, which answers `text/html` and, outside
+// `NODE_ENV=production`, includes the stack trace.
+app.use('/api', apiErrorHandler);
 
 /**
  * Start the server if this module is the main entry point.

--- a/tests/express-api-routes.test.ts
+++ b/tests/express-api-routes.test.ts
@@ -10,6 +10,8 @@
 import assert from 'node:assert/strict';
 import {
   API_ROUTES,
+  apiErrorHandler,
+  apiNotFoundHandler,
   registerApiRoutes,
   runApiRoute,
   type ApiRouteDefinition
@@ -261,6 +263,128 @@ runApiRoute(
     asynchronousError = error;
   }
 );
+
+// ==================== what an unmatched or failing /api request answers ====================
+
+/**
+ * The two things a caller can tell apart: the status, and whether the body is
+ * the envelope the whole API answers with. Both used to be decided by handlers
+ * this module never registered — the SSR page for a path no route claimed, and
+ * Express's HTML default handler for anything that threw.
+ */
+class RecordingResponse {
+  statusCode = 0;
+  body: any = null;
+  headers: Record<string, string> = {};
+  headersSent = false;
+
+  status(code: number): this {
+    this.statusCode = code;
+    return this;
+  }
+
+  json(body: unknown): void {
+    this.body = body;
+    this.headersSent = true;
+  }
+
+  setHeader(name: string, value: string): void {
+    this.headers[name] = value;
+  }
+
+  end(chunk?: string): void {
+    if (chunk !== undefined) {
+      this.body = JSON.parse(chunk);
+    }
+    this.headersSent = true;
+  }
+}
+
+const notFound = new RecordingResponse();
+apiNotFoundHandler({ method: 'post', originalUrl: '/api/story-lab/storyz?debug=1' }, notFound);
+assert.equal(notFound.statusCode, 404, 'an unregistered API path is a 404, not the SSR index page');
+assert.equal(notFound.body.success, false);
+assert.equal(notFound.body.error.code, 'API_ROUTE_NOT_FOUND');
+assert.match(
+  notFound.body.error.message,
+  /POST \/api\/story-lab\/storyz/,
+  'the message should name the method and path, without the query string'
+);
+
+const bodyParserCases = [
+  {
+    label: 'a malformed JSON body',
+    error: Object.assign(new SyntaxError('Unexpected end of JSON input'), {
+      type: 'entity.parse.failed',
+      status: 400
+    }),
+    status: 400,
+    code: 'INVALID_INPUT'
+  },
+  {
+    label: 'a body past the parser limit',
+    error: Object.assign(new Error('request entity too large'), {
+      type: 'entity.too.large',
+      status: 413
+    }),
+    status: 413,
+    code: 'CONTENT_TOO_LARGE'
+  }
+];
+
+for (const testCase of bodyParserCases) {
+  const response = new RecordingResponse();
+  apiErrorHandler(testCase.error, fakeRequest(), response, error => {
+    assert.fail(`${testCase.label} should be answered here, not passed on: ${String(error)}`);
+  });
+
+  assert.equal(response.statusCode, testCase.status, `${testCase.label} should answer ${testCase.status}`);
+  assert.equal(response.body.error.code, testCase.code);
+}
+
+// Anything else is this service failing. The stack trace Express's default
+// handler prints into the body outside `NODE_ENV=production` is exactly what
+// must not reach the browser.
+const failed = new RecordingResponse();
+const leaky = new Error('connect ECONNREFUSED 10.0.0.4:5432');
+apiErrorHandler(leaky, fakeRequest(), failed, error => {
+  assert.fail(`a handler failure should be answered here: ${String(error)}`);
+});
+assert.equal(failed.statusCode, 500);
+assert.equal(failed.body.error.code, 'INTERNAL_ERROR');
+assert.ok(
+  !JSON.stringify(failed.body).includes('ECONNREFUSED'),
+  'the failure envelope should not carry the underlying error text'
+);
+
+// A route that already started writing — an SSE stream — cannot be given a
+// status and a body now, so the failure goes on to Express to close the socket.
+const streaming = new RecordingResponse();
+streaming.headersSent = true;
+let forwardedFromStream: unknown = null;
+apiErrorHandler(leaky, fakeRequest(), streaming, error => {
+  forwardedFromStream = error;
+});
+assert.equal(forwardedFromStream, leaky, 'a failure after headers were sent is passed on');
+assert.equal(streaming.statusCode, 0, 'and nothing is written over the stream that is already open');
+
+// A double with neither `status` nor `json` still answers JSON rather than
+// falling back to the HTML default.
+const bare: any = {
+  statusCode: 0,
+  headers: {} as Record<string, string>,
+  setHeader(name: string, value: string) {
+    this.headers[name] = value;
+  },
+  ended: null as string | null,
+  end(chunk?: string) {
+    this.ended = chunk ?? null;
+  }
+};
+apiErrorHandler(leaky, fakeRequest(), bare, error => assert.fail(`unexpected next: ${String(error)}`));
+assert.equal(bare.statusCode, 500);
+assert.equal(bare.headers['Content-Type'], 'application/json');
+assert.equal(JSON.parse(bare.ended).error.code, 'INTERNAL_ERROR');
 
 // The rejection is delivered on a microtask, so the assertion waits for one.
 async function assertRejectionWasForwarded(): Promise<void> {

--- a/tests/story-lab-evaluate-route.test.ts
+++ b/tests/story-lab-evaluate-route.test.ts
@@ -3,6 +3,7 @@
 
 import handler, { parseEvaluation } from '../api/story-lab/evaluate';
 import { stripMarkdownJsonFence } from '../api/_lib/utils/modelJsonPayload';
+import { STORY_EVALUATION_LIMITS } from '../shared/storyBlueprintLimits';
 
 interface FakeRequest {
   method: string;
@@ -220,7 +221,40 @@ async function main(): Promise<void> {
     { label: 'string themes', body: { storyContent: STORY, configuration: { themes: 'romance' } } },
     { label: 'non-string theme entry', body: { storyContent: STORY, configuration: { themes: ['romance', 3] } } },
     { label: 'string spicyLevel', body: { storyContent: STORY, configuration: { spicyLevel: 'very' } } },
-    { label: 'string wordCount', body: { storyContent: STORY, configuration: { wordCount: 'lots' } } }
+    { label: 'string wordCount', body: { storyContent: STORY, configuration: { wordCount: 'lots' } } },
+    // Every one of these reaches the Grok prompt verbatim. The blueprint routes
+    // have refused an oversized field since `STORY_BLUEPRINT_LIMITS` was
+    // introduced; this route forwarded any amount of prose to a paid model.
+    {
+      label: 'oversized storyContent',
+      body: { storyContent: 'a'.repeat(STORY_EVALUATION_LIMITS.maxStoryContentLength + 1) }
+    },
+    {
+      label: 'oversized creature',
+      body: {
+        storyContent: STORY,
+        configuration: { creature: 'v'.repeat(STORY_EVALUATION_LIMITS.maxConfigurationValueLength + 1) }
+      }
+    },
+    {
+      label: 'oversized theme entry',
+      body: {
+        storyContent: STORY,
+        configuration: { themes: ['t'.repeat(STORY_EVALUATION_LIMITS.maxConfigurationValueLength + 1)] }
+      }
+    },
+    {
+      label: 'too many themes',
+      body: {
+        storyContent: STORY,
+        configuration: {
+          themes: Array.from(
+            { length: STORY_EVALUATION_LIMITS.maxThemes + 1 },
+            (_unused, index) => `theme_${index}`
+          )
+        }
+      }
+    }
   ];
 
   for (const sample of malformedBodies) {
@@ -246,6 +280,18 @@ async function main(): Promise<void> {
     {
       storyContent: STORY_HTML,
       configuration: { creature: 'vampire', themes: ['forbidden_love'], spicyLevel: 4, wordCount: 900 }
+    },
+    // The caps bound the request; they must not refuse one that sits on them.
+    // A caller evaluates a whole accumulated saga, not a single batch.
+    {
+      storyContent: `<p>${'a'.repeat(STORY_EVALUATION_LIMITS.maxStoryContentLength - 7)}</p>`,
+      configuration: {
+        creature: 'v'.repeat(STORY_EVALUATION_LIMITS.maxConfigurationValueLength),
+        themes: Array.from(
+          { length: STORY_EVALUATION_LIMITS.maxThemes },
+          (_unused, index) => `theme_${index}`
+        )
+      }
     }
   ]) {
     const response = await post(body);


### PR DESCRIPTION
Three small gaps in code this repository has already reasoned about once. Each fix carries that reasoning to the place that needed it.

## 1. `/api/story-lab/evaluate` forwarded any amount of prose to a paid model

`shared/storyBlueprintLimits.ts` explains that the blueprint caps exist because every free-text field on those routes is interpolated straight into the Grok prompt, and its comment names this route as having been capped for the same reason. It had not been.

The route checked that `storyContent` was a non-empty string and then sent all of it into `buildEvaluationPrompt`, with `configuration.creature` and every entry of `configuration.themes` beside it. Nothing bounded any of the three. It is the one route here that takes arbitrary prose *from* the caller rather than generating it, and also the one that would forward any amount of it to a model billed by the token.

`STORY_EVALUATION_LIMITS` now bounds all three. The story cap is deliberately loose (60,000 characters, roughly ten thousand words) because a caller evaluates a whole accumulated saga rather than one batch; the theme and creature caps match what the blueprint routes already accept, because these fields name the same things. An oversized field is answered `400 INVALID_EVALUATION_REQUEST` naming the field, not truncated into a story the caller did not send.

## 2. The Node/Docker deployment answered API failures with HTML

Nothing was registered after the API routes, which left two holes:

- **An unregistered `/api` path fell through.** Past the route table lie `express.static` and the Angular SSR handler, and the SSR handler answers every path it is given with the rendered index page and a `200`. That is the failure `expressApiRoutes.ts` was written to end for the whole Story Lab API; it was still live for any path the table does not carry — a typo in a client URL, a route retired on one deployment and not the other, a `vercel.json` rewrite whose Express twin was never added.
- **Nothing handled errors.** `runApiRoute` deliberately forwards a rejected handler promise to `next`, and the body parsers reject a malformed or oversized payload the same way. With no error middleware, all of it reached Express's default handler, which answers `text/html` and includes the full stack trace whenever `NODE_ENV` is not `production` — which is the default. `HttpClient` can only report that as a JSON parse error.

`apiNotFoundHandler` and `apiErrorHandler` answer both in the `ApiResponse` envelope every caller of this API already reads. A body the parsers refused is named as the caller error it is (`INVALID_INPUT` / `CONTENT_TOO_LARGE`); anything else is `500 INTERNAL_ERROR` with no detail beyond the code, because the detail is what was leaking. A failure after headers were sent — an SSE stream — is passed on to Express to close the socket.

The `/api` CORS middleware also moves ahead of the body parsers, so a request the parsers reject still carries the headers the browser needs in order to show its sender the 400, and a preflight is answered without a body being read.

## 3. The browser error logger dropped the response body from the error it belonged to

`ErrorLoggingService.redactSensitiveLogData` marked every object it had ever visited rather than the ones on the current recursion path, so a value reachable from two branches came out as the string `[Circular]` — for a graph with no cycle in it.

Its busiest caller builds exactly such a graph. `StoryService.handleHttpError` logs `{ status, url, payload: error.error, originalError: error }`, where `payload` and `originalError.error` are one object; whichever the key order reached second was discarded. The same set made `collectSensitiveStrings` skip a value on its second path, so a token named as sensitive only there was never collected — and an uncollected value is not removed from the message and stack text it also appears in, which makes that half a redaction miss rather than a legibility one.

Both now walk ancestors only, with `try/finally` to unwind — the reading `api/_lib/utils/logger.ts` already uses, and documents in a comment saying why.

## Verification

- `npm test` — full root suite passes.
- `tsc` on `tsconfig.app.json`, `tsconfig.spec.json`, and every `api/**/*.ts` — all clean.
- `npm run build` in `story-generator/` — bundle generated.
- The built Express server was run and exercised by hand: an unknown `/api` path answers `404 application/json`, a truncated JSON body answers `400 INVALID_INPUT`, an oversized `storyContent` answers `400`, `/api/health` and a valid evaluate POST still work, the preflight still carries its CORS headers, and `/` still renders the page.
- Fix 3 was confirmed against the pre-fix code: `originalError.error.code` read `undefined` and the second-path token appeared in the serialized entry; both are correct after.

New coverage: `tests/story-lab-evaluate-route.test.ts` (each cap, plus a request sitting exactly on them), `tests/express-api-routes.test.ts` (the 404, both body-parser failures, a leaky handler error, a response already streaming, and a bare response double), `story-generator/src/app/error-logging.spec.ts` (a shared reference kept, and a second-path token redacted).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViLyn1V8GwNkzegvpKkqGN)_

## Summary by Sourcery

Harden paid story evaluation requests, standardize Express API failures as safe JSON responses, and correct error logging for shared object references.

Bug Fixes:
- Enforce request-size limits for story evaluation content, creatures, and themes before forwarding them to the paid model.
- Return consistent JSON API envelopes for unmatched routes, malformed or oversized request bodies, and internal failures without exposing stack traces.
- Preserve shared error payloads during logging while continuing to redact sensitive values reached through multiple object paths.

Enhancements:
- Apply API CORS handling before body parsing so rejected requests and preflights retain the required browser headers.
- Forward errors from already-started responses so streaming connections can be closed safely.

Tests:
- Add coverage for evaluation limits and boundary values, Express API failure handling, and shared-reference error logging and redaction.