### PR TITLE
Stop the API 404 reflecting the request path, and bind its declared JSON type

### DIFF
--- a/api/_lib/http/expressApiRoutes.ts
+++ b/api/_lib/http/expressApiRoutes.ts
@@ -135,13 +135,24 @@ export function registerApiRoutes(registrar: ApiRouteRegistrar): void {
  *
  * Mount it directly after `registerApiRoutes`, before the static and SSR
  * handlers, since falling through to them is the thing being prevented.
+ *
+ * The message names nothing from the request. It used to quote the method and
+ * path back — friendlier to read in a log, and a reflected-XSS sink: the path
+ * arrives from the caller and left again inside the response body. A browser
+ * percent-encodes the URL it sends, so `%3Cscript%3E` is what
+ * `req.originalUrl` holds and what came back; a client writing the request line
+ * itself is under no such constraint, and a raw `<script>` reached the body
+ * verbatim. It is served as `application/json`, which is why this was narrow
+ * rather than live — but "narrow" depends on a `Content-Type` being respected,
+ * and the caller already knows which URL it asked for, so the echo was buying
+ * nothing worth defending.
  */
-export function apiNotFoundHandler(req: any, res: any): void {
+export function apiNotFoundHandler(_req: any, res: any): void {
   sendApiEnvelope(res, 404, {
     success: false,
     error: {
       code: 'API_ROUTE_NOT_FOUND',
-      message: `No API route matches ${readRequestMethod(req)} ${readRequestPath(req)}.`
+      message: 'No API route matches this path.'
     }
   });
 }
@@ -245,6 +256,15 @@ function readErrorStatus(error: any): number | undefined {
 }
 
 function sendApiEnvelope(res: any, status: number, body: unknown): void {
+  // Defence in depth for the whole envelope path, not for the echo that was
+  // removed above: `application/json` only keeps a body from being read as
+  // markup while something honours it, and a browser that content-sniffs does
+  // not. `nosniff` is what makes the declared type binding, so a response here
+  // cannot be turned into a document by any later change to what these
+  // envelopes carry. Express's own `json escape` setting is the other half and
+  // is off by default, so `<` in a JSON string is written through literally.
+  res.setHeader?.('X-Content-Type-Options', 'nosniff');
+
   if (typeof res?.status === 'function' && typeof res.status(status)?.json === 'function') {
     res.status(status).json(body);
     return;
@@ -255,16 +275,6 @@ function sendApiEnvelope(res: any, status: number, body: unknown): void {
   res.statusCode = status;
   res.setHeader?.('Content-Type', 'application/json');
   res.end?.(JSON.stringify(body));
-}
-
-function readRequestMethod(req: any): string {
-  const method = req?.method;
-  return typeof method === 'string' && method ? method.toUpperCase() : 'GET';
-}
-
-function readRequestPath(req: any): string {
-  const path = req?.originalUrl ?? req?.url;
-  return typeof path === 'string' && path ? path.split('?')[0] : '/api';
 }
 
 /**

--- a/tests/express-api-routes.test.ts
+++ b/tests/express-api-routes.test.ts
@@ -300,15 +300,23 @@ class RecordingResponse {
   }
 }
 
+// The path carries markup a browser would not send but a client writing its own
+// request line can: `req.originalUrl` is whatever arrived. The 404 message used
+// to quote it back, which put caller-controlled bytes in the response body.
+const injectedPath = '/api/x"><script>alert(1)</script>?debug=1';
 const notFound = new RecordingResponse();
-apiNotFoundHandler({ method: 'post', originalUrl: '/api/story-lab/storyz?debug=1' }, notFound);
+apiNotFoundHandler({ method: 'post', originalUrl: injectedPath }, notFound);
 assert.equal(notFound.statusCode, 404, 'an unregistered API path is a 404, not the SSR index page');
 assert.equal(notFound.body.success, false);
 assert.equal(notFound.body.error.code, 'API_ROUTE_NOT_FOUND');
-assert.match(
-  notFound.body.error.message,
-  /POST \/api\/story-lab\/storyz/,
-  'the message should name the method and path, without the query string'
+assert.ok(
+  !JSON.stringify(notFound.body).includes('<script>'),
+  'the 404 envelope should reflect nothing from the request'
+);
+assert.equal(
+  notFound.headers['X-Content-Type-Options'],
+  'nosniff',
+  'the declared JSON type has to bind, so a body here can never be read as a document'
 );
 
 const bodyParserCases = [
@@ -384,6 +392,7 @@ const bare: any = {
 apiErrorHandler(leaky, fakeRequest(), bare, error => assert.fail(`unexpected next: ${String(error)}`));
 assert.equal(bare.statusCode, 500);
 assert.equal(bare.headers['Content-Type'], 'application/json');
+assert.equal(bare.headers['X-Content-Type-Options'], 'nosniff');
 assert.equal(JSON.parse(bare.ended).error.code, 'INTERNAL_ERROR');
 
 // The rejection is delivered on a microtask, so the assertion waits for one.


### PR DESCRIPTION
Follow-up to #230. SonarCloud's analysis of that PR completed seconds after it merged and flagged the handler it added — too late to act on before the merge, so this is a fresh PR against the merged `main`.

## The finding

`SonarCloud Code Analysis` — Quality Gate failed, **E Security Rating on New Code**: *Endpoints should not be vulnerable to reflected cross-site scripting (XSS) attacks*, at `api/_lib/http/expressApiRoutes.ts`. The sink is `apiNotFoundHandler`, which quoted the request method and path back into the response body:

```ts
message: `No API route matches ${readRequestMethod(req)} ${readRequestPath(req)}.`
```

The finding is correct, and I confirmed it against the built server rather than taking it on trust:

- Through a browser-shaped request, the URL arrives percent-encoded, so `req.originalUrl` holds `%3Cscript%3E` and that is what came back — inert.
- A client that writes its own request line is under no such constraint. `GET /api/x"><script>alert(1)</script>` was reflected into the body **verbatim**:

  ```
  {"success":false,"error":{"code":"API_ROUTE_NOT_FOUND","message":"No API route matches GET /api/x\"><script>alert(1)</script>."}}
  ```

The response is `application/json`, which is what kept this narrow rather than live. But "narrow" then rests entirely on that `Content-Type` being honoured, and the response carried no `X-Content-Type-Options` — so a content-sniffing browser was the only thing standing between the two states. Express's own `json escape` setting is the other half of that, and it is off by default, so a `<` inside a JSON string is written through literally.

## The fix

Both halves are closed rather than one:

- **The message names nothing from the request.** The caller already knows which URL it asked for, so the echo was buying nothing worth defending. A static message removes the sink outright instead of trying to encode around it.
- **`sendApiEnvelope` sets `X-Content-Type-Options: nosniff`** on every envelope it writes. This is defence in depth for the whole envelope path, not for the echo just removed: it makes the declared type binding for anything these responses may carry in future.

## Verification

- The same raw-request-line probe that reproduced the reflection now answers `{"...","message":"No API route matches this path."}` with `X-Content-Type-Options: nosniff` set, and the body contains no `<script>`.
- `/api/health` → 200, a malformed JSON body → 400, and the SSR page → 200, all unchanged.
- `npm test` (full root suite), `tsc` on `tsconfig.app.json` / `tsconfig.spec.json` / every `api/**/*.ts`, and the Angular production build are all clean.
- `tests/express-api-routes.test.ts` now drives the 404 handler with a path carrying real markup and asserts the envelope reflects none of it, plus `nosniff` on both the `res.json` and the bare-`ServerResponse` paths.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViLyn1V8GwNkzegvpKkqGN)_

## Summary by Sourcery

Harden API error responses against reflected XSS and content-type sniffing.

Bug Fixes:
- Remove request-controlled method and path data from API 404 responses to prevent reflected XSS.
- Add `X-Content-Type-Options: nosniff` to all API JSON envelopes to enforce their declared content type.

Tests:
- Update API route tests to verify that malicious paths are not reflected and that `nosniff` is set on error responses.