### PR TITLE
Three quick wins: an ignored path id, echoed caller text, a dropped field list

### DIFF
--- a/api/_lib/http/expressApiRoutes.ts
+++ b/api/_lib/http/expressApiRoutes.ts
@@ -59,12 +59,13 @@ const storyLabGenesisHandler = createStoryLabGenesisHandler();
 const storyLabContinuationHandler = createStoryLabContinuationHandler();
 
 /**
- * The query values Vercel's rewrites put on a request before the function sees
- * it. `vercel.json` turns `/api/story-lab/jobs/:jobId/events` into
+ * The query values a Vercel deployment puts on a request before the function
+ * sees it. `vercel.json` turns `/api/story-lab/jobs/:jobId/events` into
  * `/api/story-lab/jobs?jobId=:jobId&events=1`, and the account paths into
- * `?resource=…`; Express matches the path itself and puts the same values in
- * `req.params`, so they are bridged here rather than the handlers having to
- * learn a second shape.
+ * `?resource=…`; a dynamic route directory such as `[storyId]` does the same
+ * for its own segment with no rewrite at all. Express matches the path itself
+ * and puts the values in `req.params`, so they are bridged here rather than the
+ * handlers having to learn a second shape.
  */
 type RouteQuery = Record<string, string | undefined>;
 
@@ -82,7 +83,16 @@ export const API_ROUTES: readonly ApiRouteDefinition[] = [
   { path: '/api/export/save', handler: exportSaveHandler },
   { path: '/api/image/generate', handler: imageGenerateHandler },
   { path: '/api/story-lab/stories', handler: storyLabGenesisHandler },
-  { path: '/api/story-lab/stories/:storyId/continue', handler: storyLabContinuationHandler },
+  {
+    path: '/api/story-lab/stories/:storyId/continue',
+    handler: storyLabContinuationHandler,
+    // Vercel serves this route from `api/story-lab/stories/[storyId]/continue.ts`
+    // and puts the dynamic segment in `req.query` without a rewrite, so there is
+    // no `vercel.json` entry to mirror here — but the handler reads the segment
+    // from the same place on both deployments, and Express would otherwise leave
+    // it only in `req.params`.
+    query: params => ({ storyId: params['storyId'] })
+  },
   { path: '/api/story-lab/stream/genesis', handler: storyLabStreamGenesisHandler },
   { path: '/api/story-lab/evaluate', handler: storyLabEvaluateHandler },
   { path: '/api/story-lab/jobs', handler: handleStoryLabJobsRoute },

--- a/api/_lib/services/storyService.ts
+++ b/api/_lib/services/storyService.ts
@@ -19,6 +19,7 @@ import { getXaiFastTimeoutMs, getXaiPrimaryTimeoutMs, type XaiReasoningEffort } 
 import { XaiTextClient, type XaiTextResponse } from './xaiTextClient';
 import { splitStoryIntoTextBlocks, stripStoryHtmlToText } from '../utils/storyTextBlocks';
 import {
+  UNRECOGNIZED_PARAMETER,
   toLoggableBoolean,
   toLoggableCreature,
   toLoggableNumber,
@@ -1409,6 +1410,34 @@ Write 400-600 words for this chapter. Use HTML: <h3> for chapter title, <p> for 
     return tones.length > 0 ? tones.join(', ') : 'romantic with building tension';
   }
 
+  /**
+   * Reject a story request the service cannot serve, without repeating what the
+   * caller sent.
+   *
+   * Every branch below used to answer with `providedValue: input.<field>` — the
+   * raw value, verbatim. That object is both returned to the caller as the
+   * response `error` and passed to `logWarn` by `generateStory`, so it reaches
+   * the console, the log buffer the debug panel reads, and whatever sink the
+   * logger is wired to. Three of the fields carry caller text: `creature` and
+   * `themes` are typed as closed sets but arrive as whatever a raw POST or a
+   * query string held, and `userInput` is the reader's own prose.
+   *
+   * The `userInput` branch is the worst of the three, because the condition that
+   * fires it is the text being too long: the one rejection that exists to keep
+   * an oversized brief out of the request is the one that copied all of it into
+   * the log. `redactSensitiveLogData` cannot help — it blanks a *key* named like
+   * `userInput`, and this arrives under `providedValue` — and token redaction
+   * removes credentials and URLs, not prose.
+   *
+   * The request line these rejections sit beside already solved this: it reports
+   * `creature`, `themes`, and the numbers through `toLoggableCreature`,
+   * `toLoggableThemes`, and `toLoggableNumber`, which repeat a value only when
+   * it is on the contract's own allow-list. Reusing them here keeps the whole
+   * diagnostic — which field was wrong, and what was wrong with it — while the
+   * text stops travelling. Free text has no allow-list to be recognised against,
+   * so `userInput` is reported by its length, which is the only part of it the
+   * rule is about.
+   */
   private validateStoryInput(input: StoryGenerationSeam['input']): any {
     const supportedCreatures: readonly CreatureType[] = [
       'vampire',
@@ -1427,7 +1456,7 @@ Write 400-600 words for this chapter. Use HTML: <h3> for chapter title, <p> for 
         code: 'INVALID_INPUT',
         message: 'Invalid creature type',
         field: 'creature',
-        providedValue: input.creature,
+        providedValue: toLoggableCreature(input.creature),
         expectedType: 'CreatureType'
       };
     }
@@ -1437,7 +1466,7 @@ Write 400-600 words for this chapter. Use HTML: <h3> for chapter title, <p> for 
         code: 'INVALID_INPUT',
         message: `Too many themes (max ${VALIDATION_RULES.themes.maxCount})`,
         field: 'themes',
-        providedValue: input.themes,
+        providedValue: toLoggableThemes(input.themes),
         expectedType: 'ThemeType[]'
       };
     }
@@ -1451,7 +1480,7 @@ Write 400-600 words for this chapter. Use HTML: <h3> for chapter title, <p> for 
         code: 'INVALID_INPUT',
         message: `Invalid spicy level (${VALIDATION_RULES.spicyLevel.min}-${VALIDATION_RULES.spicyLevel.max})`,
         field: 'spicyLevel',
-        providedValue: input.spicyLevel,
+        providedValue: toLoggableNumber(input.spicyLevel),
         expectedType: 'SpicyLevel'
       };
     }
@@ -1461,19 +1490,39 @@ Write 400-600 words for this chapter. Use HTML: <h3> for chapter title, <p> for 
         code: 'INVALID_INPUT',
         message: 'Invalid word count',
         field: 'wordCount',
-        providedValue: input.wordCount,
+        providedValue: toLoggableNumber(input.wordCount),
         expectedType: 'WordCount'
       };
     }
 
-    if (input.userInput && input.userInput.length > VALIDATION_RULES.userInput.maxLength) {
-      return {
-        code: 'INVALID_INPUT',
-        message: `User input too long (max ${VALIDATION_RULES.userInput.maxLength} characters)`,
-        field: 'userInput',
-        providedValue: input.userInput,
-        expectedType: 'string'
-      };
+    if (input.userInput !== undefined && input.userInput !== null) {
+      // A non-string is checked for on its own rather than left to fail the
+      // length rule. `[]` has a `length` of 0, so a caller who sent an array
+      // under this name used to pass the rule and reach the prompt, where it is
+      // interpolated as text; and any other non-string was rejected only by
+      // accident, through a comparison against `undefined`.
+      if (typeof input.userInput !== 'string') {
+        return {
+          code: 'INVALID_INPUT',
+          message: 'User input must be a string',
+          field: 'userInput',
+          providedValue: UNRECOGNIZED_PARAMETER,
+          expectedType: 'string'
+        };
+      }
+
+      if (input.userInput.length > VALIDATION_RULES.userInput.maxLength) {
+        return {
+          code: 'INVALID_INPUT',
+          message: `User input too long (max ${VALIDATION_RULES.userInput.maxLength} characters)`,
+          field: 'userInput',
+          // The length, not the text: this branch fires *because* the text is
+          // long, so repeating it here is repeating the whole of an oversized
+          // brief into the response and the log.
+          providedValue: `${input.userInput.length} characters`,
+          expectedType: 'string'
+        };
+      }
     }
 
     if (!this.isValidRequestedChapterCount(input.requestedChapterCount)) {
@@ -1481,7 +1530,7 @@ Write 400-600 words for this chapter. Use HTML: <h3> for chapter title, <p> for 
         code: 'INVALID_INPUT',
         message: 'requestedChapterCount must be 1, 2, or 3',
         field: 'requestedChapterCount',
-        providedValue: input.requestedChapterCount,
+        providedValue: toLoggableNumber(input.requestedChapterCount),
         expectedType: '1 | 2 | 3'
       };
     }

--- a/api/story-lab/stories.ts
+++ b/api/story-lab/stories.ts
@@ -44,11 +44,21 @@ export function createStoryLabGenesisHandler(generateGenesis: GenerateStoryLabGe
 
     const parsed = parseStoryLabBlueprintFromBody(req.body);
     if (parsed.error) {
+      // `invalidFields` is the whole reason the parser collects every failure
+      // rather than returning at the first one, and it is what the seam
+      // contract declares an `INVALID_BLUEPRINT` carries. This route dropped it
+      // and sent the joined prose alone, so a caller that wanted to mark the
+      // fields a reader has to fix had to parse the message back apart. The
+      // Story Lab job route, which validates the same blueprint through the
+      // same parser, has always sent it; this is that answer.
       res.status(400).json({
         success: false,
         error: {
           code: parsed.error.code,
-          message: parsed.error.message
+          message: parsed.error.message,
+          details: {
+            invalidFields: parsed.error.invalidFields
+          }
         }
       });
       return;

--- a/api/story-lab/stories/[storyId]/continue.ts
+++ b/api/story-lab/stories/[storyId]/continue.ts
@@ -24,6 +24,50 @@ function logUnexpectedStoryLabRouteError(operation: string, error: unknown): voi
   console.error('Story Lab route failed unexpectedly', { operation, errorType });
 }
 
+/**
+ * The story this URL addresses.
+ *
+ * This route is `/api/story-lab/stories/:storyId/continue` on both deployments
+ * — the directory it lives in is named `[storyId]`, and `registerApiRoutes`
+ * mounts the same pattern on Express — and the segment was read by neither.
+ * `storyId` came only from the request body, which made the path parameter
+ * decorative and left two things wrong with it.
+ *
+ * A caller that follows the URL contract, naming the story in the path and not
+ * repeating it in the body, was answered `400 INVALID_REQUEST` saying `storyId`
+ * is required, from a URL that names the story it is required to name. And when
+ * the body did carry one, it won: `POST /stories/A/continue` with
+ * `{"storyId": "B"}` continued story B — reading B's transient snapshot and
+ * appending to B — while every log line, proxy rule, and reader of the request
+ * saw a request against A.
+ *
+ * The value arrives as a query parameter on both deployments: Vercel puts a
+ * dynamic segment in `req.query`, and the Express route table bridges
+ * `req.params` into the same place, which is the point of that mapping. Both
+ * decode the segment on the way, so nothing is decoded again here.
+ */
+function readRouteStoryId(req: any): string {
+  const raw = req?.query?.storyId;
+  const value = Array.isArray(raw) ? raw[0] : raw;
+
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+/**
+ * The story id the body carries: its trimmed text, `''` when the field is
+ * absent, and `null` when it is present but is not a string a story id could
+ * be. `null` is distinct from absent because a body that names the field has
+ * made a claim about which story this is, and a claim the route cannot read is
+ * a caller error rather than something to fall back from.
+ */
+function readBodyStoryId(value: unknown): string | null {
+  if (value === undefined) {
+    return '';
+  }
+
+  return typeof value === 'string' ? value.trim() : null;
+}
+
 export function createStoryLabContinuationHandler(continueStory: ContinueStoryLab = continueStoryLab) {
   return async function handler(req: any, res: any) {
     const cors = applyCorsPolicy(req, res, {
@@ -63,7 +107,36 @@ export function createStoryLabContinuationHandler(continueStory: ContinueStoryLa
     // rejection rather than the 400 the field check below exists to give,
     // because nothing here catches it. The job route's own normalizer already
     // reads the field this way; this is the same check.
-    const storyId = typeof input.storyId === 'string' ? input.storyId.trim() : '';
+    const routeStoryId = readRouteStoryId(req);
+    const bodyStoryId = readBodyStoryId(input.storyId);
+
+    if (bodyStoryId === null) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'INVALID_REQUEST',
+          message: 'storyId must be a string when the request body carries one.'
+        }
+      });
+      return;
+    }
+
+    // Two ids that disagree are refused rather than resolved. Either one could
+    // be the mistake, and quietly picking one continues a story the caller did
+    // not ask for — which is the failure this route had when the body always
+    // won.
+    if (routeStoryId && bodyStoryId && routeStoryId !== bodyStoryId) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'INVALID_REQUEST',
+          message: 'storyId in the request body must match the story id in the request path.'
+        }
+      });
+      return;
+    }
+
+    const storyId = routeStoryId || bodyStoryId;
     const transientSnapshot = storyId ? getTransientStorySnapshot(storyId) : null;
 
     const hasChapters = Array.isArray(input.previouslyGeneratedChapters);

--- a/tests/express-api-routes.test.ts
+++ b/tests/express-api-routes.test.ts
@@ -149,6 +149,17 @@ assert.deepEqual(
 );
 assert.deepEqual(queryFor('/api/story-lab/stories'), {}, 'a route with no rewrite adds nothing');
 
+// Not a `vercel.json` rewrite: `api/story-lab/stories/[storyId]/continue.ts` is
+// a dynamic route directory, and Vercel puts the segment in `req.query` on its
+// own. The handler reads it from there on both deployments, so Express has to
+// put it in the same place — without this the story id in the URL is invisible
+// to the route that is named after it.
+assert.deepEqual(
+  queryFor('/api/story-lab/stories/story_abc/continue'),
+  { storyId: 'story_abc' },
+  'the continuation route should see the story id its path names'
+);
+
 // ==================== the request the handler is actually given ====================
 
 function fakeRequest(overrides: Record<string, unknown> = {}): any {

--- a/tests/story-lab-route-status.test.ts
+++ b/tests/story-lab-route-status.test.ts
@@ -9,6 +9,12 @@ interface FakeRequest {
   method: string;
   body?: unknown;
   headers: Record<string, string>;
+  /**
+   * Where the story id in `/api/story-lab/stories/:storyId/continue` arrives:
+   * Vercel puts a `[storyId]` segment here, and the Express route table bridges
+   * `req.params` into the same place.
+   */
+  query?: Record<string, string | string[] | undefined>;
 }
 
 class FakeResponse {
@@ -81,11 +87,16 @@ async function withEnv(updates: Record<string, string | undefined>, fn: () => Pr
   }
 }
 
-function createRequest(method: string, body?: unknown): FakeRequest {
+function createRequest(
+  method: string,
+  body?: unknown,
+  query?: Record<string, string | string[] | undefined>
+): FakeRequest {
   return {
     method,
     body,
-    headers: {}
+    headers: {},
+    ...(query ? { query } : {})
   };
 }
 
@@ -234,6 +245,138 @@ async function main(): Promise<void> {
       (response.body as { error?: { code?: string } })?.error?.code === 'INVALID_REQUEST',
       `storyId=${JSON.stringify(storyId)} is a caller error, not a service failure`
     );
+  }
+
+  // The blueprint parser collects every invalid field rather than returning at
+  // the first one, and `INVALID_BLUEPRINT` is declared as carrying that list.
+  // This route sent the joined prose alone, so a caller that wanted to mark the
+  // fields a reader has to fix had to parse the message back apart.
+  {
+    const response = new FakeResponse();
+    const { creature, ...blueprintWithoutCreature } = createBlueprint();
+    await genesisHandler(
+      createRequest('POST', { ...blueprintWithoutCreature, spicyLevel: 9 }),
+      response
+    );
+
+    const payload = response.body as {
+      error?: { code?: string; details?: { invalidFields?: string[] } };
+    };
+
+    assert(response.statusCode === 400, `an invalid blueprint should return 400, got ${response.statusCode}`);
+    assert(
+      payload.error?.code === 'INVALID_BLUEPRINT',
+      `an invalid blueprint should be reported as INVALID_BLUEPRINT, got ${JSON.stringify(payload.error)}`
+    );
+    assert(
+      Array.isArray(payload.error?.details?.invalidFields)
+        && payload.error.details.invalidFields.includes('creature')
+        && payload.error.details.invalidFields.includes('spicyLevel'),
+      `every invalid field should be named, got ${JSON.stringify(payload.error?.details)}`
+    );
+  }
+
+  // ==================== the story id in the URL ====================
+  //
+  // This route is `/api/story-lab/stories/:storyId/continue` on both
+  // deployments, and read the segment on neither: `storyId` came only from the
+  // body. A caller that named the story in the path and not again in the body
+  // was told `storyId` is required, and a body id that disagreed with the path
+  // silently won — so `POST /stories/A/continue` with `{"storyId": "B"}`
+  // continued story B while every log line and proxy rule saw a request
+  // against A.
+  {
+    const continuationBody = createContinuationBody();
+    const pathStoryId = continuationBody.storyId;
+
+    function createRecordingHandler(): {
+      handler: ReturnType<typeof createStoryLabContinuationHandler>;
+      seen: { storyId?: string };
+    } {
+      const seen: { storyId?: string } = {};
+      const handler = createStoryLabContinuationHandler(async input => {
+        seen.storyId = input.storyId;
+        return { success: true, data: { continued: true } as never };
+      });
+
+      return { handler, seen };
+    }
+
+    // The path names the story and the body does not repeat it.
+    {
+      const { handler, seen } = createRecordingHandler();
+      const response = new FakeResponse();
+      const { storyId: _omitted, ...bodyWithoutStoryId } = continuationBody;
+      await handler(createRequest('POST', bodyWithoutStoryId, { storyId: pathStoryId }), response);
+
+      assert(
+        response.statusCode === 200,
+        `a story id in the path should be enough, got ${response.statusCode} ${JSON.stringify(response.body)}`
+      );
+      assert(
+        seen.storyId === pathStoryId,
+        `the continuation should run against the story the path names, got ${seen.storyId}`
+      );
+    }
+
+    // Both name the same story, which is what the Angular app sends.
+    {
+      const { handler, seen } = createRecordingHandler();
+      const response = new FakeResponse();
+      await handler(createRequest('POST', continuationBody, { storyId: pathStoryId }), response);
+
+      assert(response.statusCode === 200, `agreeing ids should be served, got ${response.statusCode}`);
+      assert(seen.storyId === pathStoryId, `the agreed id should be used, got ${seen.storyId}`);
+    }
+
+    // They disagree. Either one could be the mistake, so neither is guessed at.
+    {
+      const { handler, seen } = createRecordingHandler();
+      const response = new FakeResponse();
+      await handler(
+        createRequest('POST', { ...continuationBody, storyId: 'story-someone-elses' }, { storyId: pathStoryId }),
+        response
+      );
+
+      assert(
+        response.statusCode === 400,
+        `a body id that contradicts the path should be refused, got ${response.statusCode}`
+      );
+      assert(
+        (response.body as { error?: { code?: string } })?.error?.code === 'INVALID_REQUEST',
+        'contradicting story ids are a caller error'
+      );
+      assert(seen.storyId === undefined, 'a refused request should not reach the engine');
+    }
+
+    // A body id that is not a string is still a claim about which story this
+    // is, and one the route cannot read — not something to fall back from
+    // because the path happens to carry an id.
+    {
+      const { handler, seen } = createRecordingHandler();
+      const response = new FakeResponse();
+      await handler(
+        createRequest('POST', { ...continuationBody, storyId: 123 }, { storyId: pathStoryId }),
+        response
+      );
+
+      assert(
+        response.statusCode === 400,
+        `a non-string body storyId should be refused even when the path carries one, got ${response.statusCode}`
+      );
+      assert(seen.storyId === undefined, 'a refused request should not reach the engine');
+    }
+
+    // No path segment at all — a direct call to the serverless handler — still
+    // reads the body, which is how every existing caller works.
+    {
+      const { handler, seen } = createRecordingHandler();
+      const response = new FakeResponse();
+      await handler(createRequest('POST', continuationBody), response);
+
+      assert(response.statusCode === 200, `a body-only request should still be served, got ${response.statusCode}`);
+      assert(seen.storyId === pathStoryId, `the body id should still be used, got ${seen.storyId}`);
+    }
   }
 
   console.log('Story Lab route status tests passed');

--- a/tests/story-route-contracts.test.ts
+++ b/tests/story-route-contracts.test.ts
@@ -310,6 +310,119 @@ async function verifyRejectedBodiesDoNotLogCallerFieldNames(): Promise<void> {
 }
 
 /**
+ * A rejected story request must not repeat what the caller sent.
+ *
+ * `validateStoryInput` answered every rule with `providedValue: input.<field>`,
+ * the raw value. That object is returned to the caller as the response `error`
+ * *and* handed to `logWarn`, so it reached the console, the buffer the debug
+ * panel reads, and any sink behind the logger — through `providedValue`, a key
+ * `redactSensitiveLogData` has no reason to blank.
+ *
+ * Three fields carry caller text. `creature` and `themes` are closed sets in the
+ * contract and caller text at run time, which is the whole reason
+ * `toLoggableCreature` and `toLoggableThemes` exist for the request line these
+ * rejections sit beside. `userInput` is the reader's prose, and its rule fires
+ * *because* the prose is long: the rejection that exists to keep an oversized
+ * brief out of the request was the one that copied all of it into the log.
+ */
+async function verifyRejectedStoryInputDoesNotRepeatCallerText(): Promise<void> {
+  const prose = 'Dana is in treatment at the clinic on Rosewood';
+  const validBody = {
+    creature: 'vampire',
+    themes: ['forbidden_love'],
+    spicyLevel: 3,
+    wordCount: 900,
+    requestedChapterCount: 1
+  };
+
+  const cases = [
+    {
+      name: 'userInput',
+      // Past the documented cap, so the length rule is what refuses it.
+      body: { ...validBody, userInput: `${prose}. `.repeat(60) },
+      expectedProvidedValue: (body: any) => `${body.userInput.length} characters`
+    },
+    {
+      name: 'creature',
+      body: { ...validBody, creature: prose },
+      expectedProvidedValue: () => '[UNRECOGNIZED]'
+    },
+    {
+      name: 'themes',
+      // Six entries: past `VALIDATION_RULES.themes.maxCount`, so the rule fires
+      // with an array of caller text in hand.
+      body: { ...validBody, themes: Array.from({ length: 6 }, (_item, index) => `${prose} ${index}`) },
+      expectedProvidedValue: () => ({ themes: [], unrecognizedThemeCount: 6 })
+    }
+  ];
+
+  for (const testCase of cases) {
+    logger.clearLogs();
+
+    const { response, consoleOutput } = await captureConsole(async () => {
+      const res = new FakeResponse();
+      await generateHandler({ method: 'POST', headers: {}, body: testCase.body }, res);
+      return res;
+    });
+
+    assert(
+      response.statusCode === 400,
+      `an invalid ${testCase.name} should be a caller error, got ${response.statusCode}`
+    );
+
+    const payload = response.body as { error?: { code?: string; providedValue?: unknown } };
+    assert(
+      payload.error?.code === 'INVALID_INPUT',
+      `an invalid ${testCase.name} should be reported as INVALID_INPUT, got ${JSON.stringify(payload.error)}`
+    );
+
+    const rejected = logger
+      .getRecentLogs(50, 'warn')
+      .find(entry => entry.context?.endpoint === 'generateStory');
+    assert(rejected, `the service should log the ${testCase.name} rejection it made`);
+
+    for (const [sink, written] of [
+      ['response', JSON.stringify(payload)],
+      ['buffer', JSON.stringify(rejected.metadata)],
+      ['console', consoleOutput]
+    ] as const) {
+      assert(
+        !written.includes('Dana') && !written.includes('Rosewood'),
+        `caller text sent as ${testCase.name} must not reach the ${sink} (got ${written.slice(0, 300)})`
+      );
+    }
+
+    // The diagnostic survives: a rejection still says which field was wrong and
+    // what was wrong with it, which is the reason to report anything at all.
+    assert(
+      JSON.stringify(payload.error?.providedValue) ===
+        JSON.stringify(testCase.expectedProvidedValue(testCase.body)),
+      `the ${testCase.name} rejection should still describe what was provided (got ${JSON.stringify(payload.error?.providedValue)})`
+    );
+  }
+
+  // An array under `userInput` has a `length` of 0, so it passed the length rule
+  // and reached the prompt, where it is interpolated as text.
+  logger.clearLogs();
+  const arrayInputResponse = new FakeResponse();
+  await captureConsole(async () => {
+    await generateHandler(
+      { method: 'POST', headers: {}, body: { ...validBody, userInput: [prose] } },
+      arrayInputResponse
+    );
+    return arrayInputResponse;
+  });
+
+  const arrayInputPayload = arrayInputResponse.body as { error?: { code?: string; field?: string } };
+  assert(
+    arrayInputResponse.statusCode === 400 && arrayInputPayload.error?.field === 'userInput',
+    `a non-string userInput should be refused as a caller error, got ${arrayInputResponse.statusCode} ${JSON.stringify(arrayInputPayload.error)}`
+  );
+
+  logger.clearLogs();
+}
+
+/**
  * The export cap is a size in kilobytes, so it has to be measured in bytes.
  * Read with `String.length` it counted UTF-16 code units, and a story in a
  * non-Latin script is up to three bytes per unit — so a body well past the
@@ -429,6 +542,7 @@ async function main(): Promise<void> {
   await verifyContinueDoesNotLogProseStoryIds();
   await verifyMalformedBodiesAreClientErrors();
   await verifyRejectedBodiesDoNotLogCallerFieldNames();
+  await verifyRejectedStoryInputDoesNotRepeatCallerText();
   await verifyExportMeasuresItsSizeCapInBytes();
 
   console.log('Story route contract tests passed');


### PR DESCRIPTION
Three small, independent fixes, each with a test that fails without it.

## 1. The continuation route ignored the story id in its own URL

`/api/story-lab/stories/:storyId/continue` is a dynamic route on both deployments — an `[storyId]` directory on Vercel, the same pattern in the Express route table — and read the segment on neither. `storyId` came only from the request body, which left the path parameter decorative, and that went wrong in two directions:

- A caller that followed the URL contract — naming the story in the path, not repeating it in the body — was answered `400 INVALID_REQUEST` saying `storyId` is required, from a URL that names the story it is required to name.
- When the body did carry one, it won outright. `POST /stories/A/continue` with `{"storyId": "B"}` read B's transient snapshot and appended to B, while every log line, proxy rule, and reader of the request saw a request against A.

The segment is now read from `req.query` — where Vercel already puts a dynamic segment, and where the Express route table now bridges `req.params`, the way it already does for the jobs and account routes. It is used when the body omits the field, and two ids that disagree are refused rather than resolved: either one could be the mistake, and quietly picking one continues a story the caller did not ask for.

## 2. A rejected story request repeated what the caller sent

`validateStoryInput` answered every rule with `providedValue: input.<field>` — the raw value. That object is returned to the caller as the response `error` *and* handed to `logWarn` by `generateStory`, so it reached the console, the log buffer the debug panel reads, and any sink behind the logger — under `providedValue`, a key `redactSensitiveLogData` has no reason to blank, and token redaction removes credentials and URLs, not prose.

Three of the fields carry caller text. `creature` and `themes` are closed sets in the contract and caller text at run time, which is exactly why the request line these rejections sit beside already reports them through `toLoggableCreature` and `toLoggableThemes`. `userInput` is the reader's own prose, and its rule fires *because* the prose is long — so the one rejection that exists to keep an oversized brief out of the request was the one that copied all of it into the log and the response.

Each field is now reported the way the request line reports it, and `userInput` by its length, which is the only part of it the rule is about. A non-string `userInput` is refused on its own too: `[]` has a `length` of 0, so an array under that name passed the cap and reached the prompt, where it is interpolated as text.

## 3. The genesis route dropped the list of invalid fields

The blueprint parser collects every failure rather than returning at the first one, and `INVALID_BLUEPRINT` is declared as carrying that list. `POST /api/story-lab/stories` sent the joined message alone, so a caller that wanted to mark the fields a reader has to fix had to parse the prose back apart. The Story Lab job route validates the same blueprint through the same parser and has always sent `details.invalidFields`; this route now answers the same way.

## Testing

- `npm run test:all` — full suite green.
- New coverage: `tests/story-lab-route-status.test.ts` (path id used, agreeing ids served, disagreeing ids refused before the engine is reached, non-string body id refused, body-only requests unchanged; `invalidFields` named), `tests/story-route-contracts.test.ts` (no caller text in the response, the log buffer, or the console for `userInput`, `creature`, and `themes`, with the diagnostic still present), `tests/express-api-routes.test.ts` (the continuation route sees the story id its path names).
- Each fix was reverted individually to confirm its test fails without it.
- `npm run build` — Angular browser and server bundles build clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016MzMqq53nQEpnQf7LtDK6k)_

## Summary by Sourcery

Fix Story Lab request handling to honor URL story IDs, protect caller text in validation diagnostics, and expose invalid blueprint fields.

Bug Fixes:
- Use the continuation route’s path story ID, reject conflicting or malformed body IDs, and preserve body-only requests.
- Prevent rejected story input from echoing caller-provided text in responses and logs while retaining safe diagnostics and rejecting non-string user input.
- Return the complete list of invalid blueprint fields from the story genesis endpoint.

Tests:
- Add coverage for continuation path and body ID handling, invalid blueprint field reporting, and safe diagnostics across response, log, and console outputs.