### PR TITLE
***WORST TO BEST*** Proving Grounds: broken test + silently-faked evaluation scores, fixed

### DIFF
--- a/story-generator/src/app/contracts.ts
+++ b/story-generator/src/app/contracts.ts
@@ -647,6 +647,14 @@ export interface EvaluationCriteria {
   suggestions: string[];
   overallFeedback: string;
   heuristicReport?: StoryQualityHeuristicReport;
+  /**
+   * Set when this evaluation never reached the server — the evaluate call
+   * failed or errored, and `PromptEvaluationService` fell back to its fixed
+   * placeholder scoring. Distinguishes that placeholder from both a real AI
+   * score and the server's own honest `heuristicReport` fallback, so the UI
+   * never shows a fabricated score as if it were real feedback.
+   */
+  isMockEvaluation?: boolean;
 }
 
 export interface EvaluationRequest {

--- a/story-generator/src/app/proving-grounds/generation-logic.service.spec.ts
+++ b/story-generator/src/app/proving-grounds/generation-logic.service.spec.ts
@@ -1,0 +1,101 @@
+import { TestBed } from '@angular/core/testing';
+import { CreatureArchetype } from '../contracts';
+import { GenerationLogicService } from './generation-logic.service';
+
+describe('GenerationLogicService', () => {
+  let service: GenerationLogicService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(GenerationLogicService);
+  });
+
+  it('getAllAuthorStyles returns non-empty, creature-specific lists for every supported creature', () => {
+    const creatures: CreatureArchetype[] = [
+      'vampire', 'werewolf', 'fairy', 'siren', 'djinn', 'witch', 'dragon', 'demon', 'angel', 'mermaid'
+    ];
+
+    for (const creature of creatures) {
+      const styles = service.getAllAuthorStyles(creature);
+      expect(styles.length).withContext(creature).toBeGreaterThan(0);
+      for (const style of styles) {
+        expect(style.author.trim().length).withContext(`${creature} author name`).toBeGreaterThan(0);
+        expect(style.trait.trim().length).withContext(`${creature} trait`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('fairy, siren, and djinn share the same fairy-styles pool', () => {
+    const fairyStyles = service.getAllAuthorStyles('fairy');
+    const sirenStyles = service.getAllAuthorStyles('siren');
+    const djinnStyles = service.getAllAuthorStyles('djinn');
+
+    expect(sirenStyles).toEqual(fairyStyles);
+    expect(djinnStyles).toEqual(fairyStyles);
+  });
+
+  it('selectRandomAuthors never returns more authors than exist for the creature, and never duplicates one', () => {
+    for (let i = 0; i < 20; i++) {
+      const authors = service.selectRandomAuthors('witch');
+      expect(authors.length).toBeGreaterThanOrEqual(2);
+      expect(authors.length).toBeLessThanOrEqual(service.getAllAuthorStyles('witch').length);
+
+      const uniqueNames = new Set(authors.map(author => author.author));
+      expect(uniqueNames.size).toBe(authors.length);
+    }
+  });
+
+  it('selectRandomBeatStructure always returns one of the known beat structures', () => {
+    const knownNames = new Set(service.getAllBeatStructures().map(beat => beat.name));
+
+    for (let i = 0; i < 20; i++) {
+      expect(knownNames.has(service.selectRandomBeatStructure().name)).toBeTrue();
+    }
+  });
+
+  it('selectRandomChekovElements returns exactly two distinct elements from the known pool', () => {
+    const knownElements = new Set(service.getAllChekovElements());
+
+    for (let i = 0; i < 10; i++) {
+      const elements = service.selectRandomChekovElements();
+      expect(elements.length).toBe(2);
+      expect(elements[0].description).not.toBe(elements[1].description);
+      for (const element of elements) {
+        expect(knownElements.has(element.description)).toBeTrue();
+      }
+    }
+  });
+
+  it('generateRandomLogic assembles authors, a beat structure, and Chekov elements for the requested creature', () => {
+    const logic = service.generateRandomLogic('dragon');
+
+    expect(logic.selectedAuthors.length).toBeGreaterThan(0);
+    for (const author of logic.selectedAuthors) {
+      expect(service.getAllAuthorStyles('dragon')).toContain(author);
+    }
+    expect(logic.selectedBeatStructure).toBeTruthy();
+    expect(logic.chekovElements.length).toBe(2);
+  });
+
+  it('summarizeLogic renders the author styles, beat structure, and Chekov elements as readable text', () => {
+    const logic = service.generateRandomLogic('demon');
+
+    const summary = service.summarizeLogic(logic);
+
+    expect(summary).toContain('Author styles:');
+    expect(summary).toContain(logic.selectedAuthors[0].author);
+    expect(summary).toContain(`Beat structure: ${logic.selectedBeatStructure.name}`);
+    expect(summary).toContain('Chekov elements:');
+    expect(summary).toContain(logic.chekovElements[0].description);
+  });
+
+  it('summarizeLogic reports "none selected" when there are no author styles', () => {
+    const summary = service.summarizeLogic({
+      selectedAuthors: [],
+      selectedBeatStructure: service.getAllBeatStructures()[0],
+      chekovElements: []
+    });
+
+    expect(summary).toContain('Author styles: none selected.');
+  });
+});

--- a/story-generator/src/app/proving-grounds/prompt-evaluation.service.spec.ts
+++ b/story-generator/src/app/proving-grounds/prompt-evaluation.service.spec.ts
@@ -1,0 +1,99 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { EvaluationCriteria, EvaluationRequest } from '../contracts';
+import { PromptEvaluationService } from './prompt-evaluation.service';
+
+describe('PromptEvaluationService', () => {
+  let service: PromptEvaluationService;
+  let httpMock: HttpTestingController;
+
+  const request: EvaluationRequest = {
+    storyContent: '<p>The vampire lord waited in the dark.</p>',
+    configuration: {
+      creature: 'vampire',
+      themes: ['obsession'],
+      spicyLevel: 3,
+      wordCount: 900
+    }
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(PromptEvaluationService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('returns the server evaluation untouched when the API call succeeds', async () => {
+    const serverEvaluation: EvaluationCriteria = {
+      score: 91,
+      strengths: ['Vivid opening.'],
+      weaknesses: ['Pacing lags mid-scene.'],
+      suggestions: ['Trim the middle beat.'],
+      overallFeedback: 'Strong draft overall.'
+    };
+
+    const evaluationPromise = service.evaluateStory(request);
+
+    const req = httpMock.expectOne('/api/story-lab/evaluate');
+    expect(req.request.method).toBe('POST');
+    req.flush({ success: true, data: serverEvaluation });
+
+    const result = await evaluationPromise;
+
+    expect(result).toEqual(serverEvaluation);
+    expect(result.isMockEvaluation).toBeUndefined();
+  });
+
+  it('falls back to a clearly-marked mock evaluation when the API call errors', async () => {
+    const evaluationPromise = service.evaluateStory(request);
+
+    const req = httpMock.expectOne('/api/story-lab/evaluate');
+    req.error(new ProgressEvent('network error'), { status: 0, statusText: 'Unknown Error' });
+
+    const result = await evaluationPromise;
+
+    expect(result.isMockEvaluation).toBeTrue();
+    expect(result.score).toBe(75);
+    expect(result.strengths.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to a clearly-marked mock evaluation when the API reports success: false', async () => {
+    const evaluationPromise = service.evaluateStory(request);
+
+    const req = httpMock.expectOne('/api/story-lab/evaluate');
+    req.flush({ success: false, error: { code: 'EVALUATION_FAILED', message: 'no evaluator configured' } });
+
+    const result = await evaluationPromise;
+
+    expect(result.isMockEvaluation).toBeTrue();
+  });
+
+  it('falls back to a clearly-marked mock evaluation when the API reports success but omits data', async () => {
+    const evaluationPromise = service.evaluateStory(request);
+
+    const req = httpMock.expectOne('/api/story-lab/evaluate');
+    req.flush({ success: true });
+
+    const result = await evaluationPromise;
+
+    expect(result.isMockEvaluation).toBeTrue();
+  });
+
+  it('returns the same fixed mock evaluation content every time it falls back', async () => {
+    const first = service.evaluateStory(request);
+    httpMock.expectOne('/api/story-lab/evaluate').error(new ProgressEvent('network error'));
+    const firstResult = await first;
+
+    const second = service.evaluateStory(request);
+    httpMock.expectOne('/api/story-lab/evaluate').error(new ProgressEvent('network error'));
+    const secondResult = await second;
+
+    expect(firstResult).toEqual(secondResult);
+  });
+});

--- a/story-generator/src/app/proving-grounds/prompt-evaluation.service.ts
+++ b/story-generator/src/app/proving-grounds/prompt-evaluation.service.ts
@@ -44,7 +44,8 @@ export class PromptEvaluationService {
         'Vary dialogue patterns between characters for distinct voices',
         'Strengthen the final scene to increase stakes and reader investment'
       ],
-      overallFeedback: 'Solid story with good fundamentals. The pacing works well and sensory details are effective. Main area for improvement is making character voices more distinct and memorable.'
+      overallFeedback: 'Solid story with good fundamentals. The pacing works well and sensory details are effective. Main area for improvement is making character voices more distinct and memorable.',
+      isMockEvaluation: true
     };
   }
 }

--- a/story-generator/src/app/proving-grounds/prompt-templates.service.spec.ts
+++ b/story-generator/src/app/proving-grounds/prompt-templates.service.spec.ts
@@ -1,0 +1,81 @@
+import { TestBed } from '@angular/core/testing';
+import { PromptTemplatesService } from './prompt-templates.service';
+
+describe('PromptTemplatesService', () => {
+  let service: PromptTemplatesService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PromptTemplatesService);
+  });
+
+  it('returns a fixed set of templates covering both the production and experimental categories', () => {
+    const templates = service.getTemplates();
+
+    expect(templates.length).toBe(5);
+    expect(templates.filter(template => template.category === 'production').length).toBe(1);
+    expect(templates.filter(template => template.category === 'experimental').length).toBe(4);
+
+    const ids = templates.map(template => template.id);
+    expect(new Set(ids).size).withContext('template ids should be unique').toBe(ids.length);
+  });
+
+  it('every template carries a non-empty system prompt and user prompt template', () => {
+    for (const template of service.getTemplates()) {
+      expect(template.systemPrompt.trim().length).withContext(`${template.id} systemPrompt`).toBeGreaterThan(0);
+      expect(template.userPromptTemplate.trim().length).withContext(`${template.id} userPromptTemplate`).toBeGreaterThan(0);
+    }
+  });
+
+  it('getTemplate looks a template up by id', () => {
+    expect(service.getTemplate('production')?.name).toBe('Current Production');
+    expect(service.getTemplate('does-not-exist')).toBeUndefined();
+  });
+
+  it('fillUserTemplate substitutes every placeholder with the supplied variables', () => {
+    const filled = service.fillUserTemplate(
+      '{{CREATURE}} | {{THEMES}} | {{SPICY_LABEL}} (Level {{SPICY_LEVEL}}) | {{WORD_COUNT}} words | {{USER_INPUT}}',
+      {
+        creature: 'vampire',
+        themes: [
+          { id: 'obsession', label: 'Obsession', description: 'Desire narrows into fixation.' },
+          { id: 'betrayal', label: 'Betrayal', description: 'Trust becomes leverage.' }
+        ],
+        spicyLevel: 4,
+        wordCount: 1200,
+        userInput: 'Set it in an opera house.'
+      }
+    );
+
+    expect(filled).toBe('Vampire | Obsession, Betrayal | Scorching & Explicit (Level 4) | 1200 words | Set it in an opera house.');
+    expect(filled).not.toContain('{{');
+  });
+
+  it('fillUserTemplate replaces USER_INPUT with an empty string when none is supplied', () => {
+    const filled = service.fillUserTemplate('Notes: {{USER_INPUT}}', {
+      creature: 'witch',
+      themes: [],
+      spicyLevel: 1,
+      wordCount: 600
+    });
+
+    expect(filled).toBe('Notes: ');
+  });
+
+  it('fillTemplate keeps the system prompt untouched and fills the user prompt template', () => {
+    const template = service.getTemplate('concise')!;
+
+    const filled = service.fillTemplate(template, {
+      creature: 'dragon',
+      themes: [{ id: 'revenge', label: 'Revenge', description: 'Old wounds drive present choices.' }],
+      spicyLevel: 2,
+      wordCount: 900,
+      userInput: ''
+    });
+
+    expect(filled.system).toBe(template.systemPrompt);
+    expect(filled.user).toContain('Dragon');
+    expect(filled.user).toContain('Revenge');
+    expect(filled.user).not.toContain('{{');
+  });
+});

--- a/story-generator/src/app/proving-grounds/proving-grounds.css
+++ b/story-generator/src/app/proving-grounds/proving-grounds.css
@@ -468,6 +468,14 @@
   margin: 0 0 1.5rem;
   color: #c084fc;
 }
+.mock-evaluation-notice {
+  margin: 0 0 1.5rem;
+  padding: 0.75rem 1rem;
+  background: #7f1d1d4d;
+  border-radius: 8px;
+  color: #fee2e2;
+  font-weight: 600;
+}
 .score-display {
   display: flex;
   gap: 2rem;

--- a/story-generator/src/app/proving-grounds/proving-grounds.html
+++ b/story-generator/src/app/proving-grounds/proving-grounds.html
@@ -7,6 +7,7 @@
       <button
         type="button"
         class="btn btn-secondary"
+        data-testid="toggle-comparison-mode"
         (click)="comparisonMode.set(!comparisonMode())"
         [class.active]="comparisonMode()">
         {{ comparisonMode() ? '📊 Exit Comparison' : '📊 Compare Tests' }}
@@ -14,6 +15,7 @@
       <button
         type="button"
         class="btn btn-secondary"
+        data-testid="export-results"
         (click)="exportTestResults()"
         [disabled]="testHistory().length === 0">
         💾 Export Results
@@ -128,6 +130,7 @@
           <button
             type="button"
             class="btn btn-secondary"
+            data-testid="view-prompts"
             (click)="viewPrompts()"
             title="View the filled prompt templates">
             👁️ View Prompts
@@ -136,6 +139,7 @@
           <button
             type="button"
             class="btn btn-primary btn-large"
+            data-testid="generate-story"
             (click)="generateStory()"
             [disabled]="isGenerating() || selectedThemes.length === 0">
             @if (isGenerating()) {
@@ -162,7 +166,7 @@
         @if (showGenerationLogic && currentGenerationLogic()) {
           <div id="generation-logic-panel" class="generation-logic-viewer">
             <div class="logic-actions">
-              <button type="button" class="btn btn-sm btn-secondary" (click)="regenerateLogic()">
+              <button type="button" class="btn btn-sm btn-secondary" data-testid="regenerate-logic" (click)="regenerateLogic()">
                 🎲 Regenerate Random
               </button>
             </div>
@@ -282,6 +286,9 @@
                   <div class="score-badge" [ngClass]="scoreToneClass(test.aiEvaluation.score)">
                     {{ test.aiEvaluation.score }}/100
                   </div>
+                  @if (test.aiEvaluation.isMockEvaluation) {
+                    <p class="mock-evaluation-notice" data-testid="mock-evaluation-badge">⚠️ Offline mock evaluation — not a real AI score.</p>
+                  }
                   @if (test.aiEvaluation.heuristicReport) {
                     <p class="feedback"><strong>Quality:</strong> {{ test.aiEvaluation.heuristicReport.overallScore }}/100</p>
                   }
@@ -311,12 +318,15 @@
               <button
                 type="button"
                 class="btn btn-primary"
+                data-testid="evaluate-story"
                 (click)="evaluateStory(currentTest()!)"
-                [disabled]="isEvaluating() || currentTest()!.aiEvaluation">
+                [disabled]="isEvaluating() || (currentTest()!.aiEvaluation && !currentTest()!.aiEvaluation!.isMockEvaluation)">
                 @if (isEvaluating()) {
                   <span class="spinner">⏳</span> Evaluating...
-                } @else if (currentTest()!.aiEvaluation) {
+                } @else if (currentTest()!.aiEvaluation && !currentTest()!.aiEvaluation!.isMockEvaluation) {
                   ✅ Evaluated
+                } @else if (currentTest()!.aiEvaluation?.isMockEvaluation) {
+                  🔁 Retry Evaluation (offline mock)
                 } @else {
                   🤖 Evaluate with AI
                 }
@@ -328,6 +338,13 @@
           @if (currentTest()!.aiEvaluation) {
             <div class="evaluation-panel">
               <h3>AI Evaluation Results</h3>
+
+              @if (currentTest()!.aiEvaluation!.isMockEvaluation) {
+                <p class="mock-evaluation-notice" data-testid="mock-evaluation-badge">
+                  ⚠️ Offline mock evaluation — the evaluation API was unavailable, so this score is a fixed
+                  placeholder, not real AI feedback. Do not use it for comparisons.
+                </p>
+              }
 
               <div class="score-display">
                 <div class="score-circle" [ngClass]="scoreToneClass(currentTest()!.aiEvaluation!.score)">
@@ -481,8 +498,9 @@
                   @if (test.aiEvaluation) {
                     <span
                       class="score-badge mini"
-                      [ngClass]="scoreToneClass(test.aiEvaluation.score)">
-                      {{ test.aiEvaluation.score }}
+                      [ngClass]="scoreToneClass(test.aiEvaluation.score)"
+                      [attr.title]="test.aiEvaluation.isMockEvaluation ? 'Offline mock evaluation, not a real AI score' : 'AI evaluation'">
+                      {{ test.aiEvaluation.score }}{{ test.aiEvaluation.isMockEvaluation ? ' (mock)' : '' }}
                     </span>
                     @if (test.aiEvaluation.heuristicReport) {
                       <span
@@ -504,6 +522,7 @@
                     <button
                       type="button"
                       class="btn btn-sm"
+                      data-testid="select-comparison"
                       (click)="toggleComparison(test)"
                       [disabled]="!isSelectedForComparison(test) && selectedComparisons().length >= 3">
                       {{ isSelectedForComparison(test) ? '✓ Selected' : 'Select' }}
@@ -512,6 +531,7 @@
                     <button
                       type="button"
                       class="btn btn-sm"
+                      data-testid="view-test"
                       (click)="currentTest.set(test)">
                       View
                     </button>
@@ -519,6 +539,7 @@
                       <button
                         type="button"
                         class="btn btn-sm"
+                        data-testid="evaluate-history-item"
                         (click)="evaluateStory(test)">
                         Evaluate
                       </button>
@@ -526,6 +547,7 @@
                     <button
                       type="button"
                       class="btn btn-sm btn-danger"
+                      data-testid="delete-test"
                       (click)="deleteTest(test.id)">
                       Delete
                     </button>

--- a/story-generator/src/app/proving-grounds/proving-grounds.spec.ts
+++ b/story-generator/src/app/proving-grounds/proving-grounds.spec.ts
@@ -83,24 +83,26 @@ function createBasicResult(id: string): ProvingGroundsTestResult {
   return createTestResult(id, { aiEvaluation: undefined });
 }
 
+function getByTestId(fixture: ComponentFixture<ProvingGroundsComponent>, testId: string): HTMLButtonElement {
+  const button = fixture.nativeElement.querySelector(`[data-testid="${testId}"]`);
+  expect(button).withContext(`Element with data-testid="${testId}" should exist`).toBeTruthy();
+  return button as HTMLButtonElement;
+}
+
+function getAllByTestId(fixture: ComponentFixture<ProvingGroundsComponent>, testId: string): HTMLButtonElement[] {
+  return Array.from(fixture.nativeElement.querySelectorAll(`[data-testid="${testId}"]`)) as HTMLButtonElement[];
+}
+
 function getGenerateButton(fixture: ComponentFixture<ProvingGroundsComponent>): HTMLButtonElement {
-  const buttons = Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[];
-  const generateButton = buttons.find(button => button.textContent?.trim().includes('Generate Story'));
-  expect(generateButton).withContext('Generate Story button should exist').toBeTruthy();
-  return generateButton as HTMLButtonElement;
+  return getByTestId(fixture, 'generate-story');
 }
 
 function getExportButton(fixture: ComponentFixture<ProvingGroundsComponent>): HTMLButtonElement {
-  const buttons = Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[];
-  const exportButton = buttons.find(button => button.textContent?.trim().includes('Export Results'));
-  expect(exportButton).withContext('Export Results button should exist').toBeTruthy();
-  return exportButton as HTMLButtonElement;
+  return getByTestId(fixture, 'export-results');
 }
 
 function getCurrentEvaluateButton(fixture: ComponentFixture<ProvingGroundsComponent>): HTMLButtonElement {
-  const button = fixture.nativeElement.querySelector('.test-actions button');
-  expect(button).withContext('Current test evaluate button should exist').toBeTruthy();
-  return button as HTMLButtonElement;
+  return getByTestId(fixture, 'evaluate-story');
 }
 
 describe('ProvingGroundsComponent', () => {
@@ -183,9 +185,7 @@ describe('ProvingGroundsComponent', () => {
 
     fixture.detectChanges();
 
-    const selectButtons = Array.from(
-      fixture.nativeElement.querySelectorAll('.history-item-actions .btn.btn-sm')
-    ) as HTMLButtonElement[];
+    const selectButtons = getAllByTestId(fixture, 'select-comparison');
     const disabledSelectButton = selectButtons.find(button =>
       button.textContent?.trim() === 'Select'
     );
@@ -203,6 +203,37 @@ describe('ProvingGroundsComponent', () => {
     expect(evaluateButton.textContent).toContain('✅ Evaluated');
   });
 
+  it('shows a mock-evaluation warning and keeps the evaluate button enabled for a mock result', () => {
+    const mockResult = createTestResult('mock-evaluation', {
+      aiEvaluation: {
+        score: 75,
+        strengths: ['Strong opening hook that captures attention'],
+        weaknesses: ['Some dialogue feels generic or repetitive'],
+        suggestions: ['Vary dialogue patterns between characters for distinct voices'],
+        overallFeedback: 'Solid story with good fundamentals.',
+        isMockEvaluation: true
+      }
+    });
+    component.currentTest.set(mockResult);
+
+    fixture.detectChanges();
+
+    const badge = getByTestId(fixture, 'mock-evaluation-badge');
+    expect(badge.textContent).toContain('Offline mock evaluation');
+
+    const evaluateButton = getCurrentEvaluateButton(fixture);
+    expect(evaluateButton.disabled).toBeFalse();
+    expect(evaluateButton.textContent).toContain('Retry Evaluation');
+  });
+
+  it('does not show a mock-evaluation warning for a real AI evaluation', () => {
+    component.currentTest.set(createEvaluatedResult());
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="mock-evaluation-badge"]')).toBeNull();
+  });
+
   it('deletes the current history item when its delete action is clicked', () => {
     const firstResult = createBasicResult('delete-current');
     const secondResult = createBasicResult('delete-survivor');
@@ -212,8 +243,8 @@ describe('ProvingGroundsComponent', () => {
 
     fixture.detectChanges();
 
-    const deleteButtons = fixture.nativeElement.querySelectorAll('.history-item-actions .btn-danger');
-    (deleteButtons[0] as HTMLButtonElement).click();
+    const deleteButtons = getAllByTestId(fixture, 'delete-test');
+    deleteButtons[0].click();
 
     fixture.detectChanges();
 


### PR DESCRIPTION
## Worst-to-Best routine

Plan was posted to `#claude-routines` and `@codex` was tagged for critique; no critique arrived after ~20 minutes of waiting (same pattern as the prior two runs — the workspace's `chatgpt-codex-connector` doesn't reliably respond to mentions), so this executes on the posted plan. No corrections were needed to the plan itself.

### Feature chosen: Proving Grounds (`/proving-grounds` — the prompt A/B-testing & story-quality evaluation playground)

### Why it was the worst-implemented feature in the app

- **A confirmed broken test on `main`.** I installed dependencies and actually ran `ng test --include proving-grounds.spec.ts`: `disables generate button while generation is in progress` **FAILED**. `getGenerateButton()` found the button by its visible text "Generate Story", but `proving-grounds.html` swaps that label to "⏳ Generating…" while `isGenerating()` is true — the exact state the test means to exercise makes the element unfindable, so the test throws instead of asserting. PR #227's own verification notes call this a "pre-existing, unrelated failure" — it had been standing, unexamined.
- **Root cause: zero `data-testid` coverage.** The whole page had no `data-testid` attributes at all (grepped, confirmed 0), unlike the rest of the app (60+ in `app.html`), so its one spec file was forced into fragile text-matching — which broke the moment a loading label was added.
- **A silent-mock-evaluation bug.** `PromptEvaluationService.evaluateStory()` falls back to a hardcoded canned evaluation (`score: 75`, fixed strengths/weaknesses/suggestions) on *any* failure — network error, non-2xx, or `success:false` — with nothing in the returned `EvaluationCriteria` marking it as a mock. The backend already solved this exact problem correctly (`heuristicReport.source: 'heuristic'`, rendered as "Deterministic Quality Scan"), but this client-side fallback didn't reuse that convention. A user doing prompt A/B comparisons — the entire point of this tool — could silently compare a real AI score against an identical fabricated 75 with no way to tell, and the button then locked into a false "✅ Evaluated" state that blocked retrying.
- **Zero unit coverage on its supporting services.** `generation-logic.service.ts` (580 lines) and `prompt-templates.service.ts` (343 lines) had no dedicated tests at all; `prompt-evaluation.service.ts` (the one with the bug above) had none either.

### What changed

1. Added `data-testid` attributes to Proving Grounds' interactive controls (generate, view-prompts, export, evaluate, delete, select/compare, regenerate-logic, comparison toggle), matching the app-wide convention.
2. Rewrote the spec's button-finder helpers to query by `data-testid` instead of text content — fixes the previously-red test at its root cause instead of patching around the symptom.
3. Fixed the silent-mock bug: `PromptEvaluationService`'s fallback now tags its result with `isMockEvaluation: true` (new optional field on the frontend's `EvaluationCriteria`). The template shows a visible "⚠️ Offline mock evaluation" notice/badge wherever a score appears (current test, history list, comparison view), and the "Evaluate with AI" button no longer locks into a false "✅ Evaluated" state for a mock result — it now offers "🔁 Retry Evaluation (offline mock)" instead.
4. Added `generation-logic.service.spec.ts`, `prompt-templates.service.spec.ts`, and `prompt-evaluation.service.spec.ts`, covering random-selection bounds/uniqueness, template retrieval and placeholder-filling, and the real-vs-mock evaluation branch (network error, `success:false`, `success:true` with no `data`, and the happy path).
5. Extended `proving-grounds.spec.ts` with two new tests asserting the mock badge/retry behavior end-to-end through the component template.

### Verification

- `ng test --include '**/proving-grounds/**/*.spec.ts'` (headless Chromium): 29/29 passing, including the fixed test and 21 new tests across the four spec files.
- Full Angular suite: 170/171 passing — the one failure (`App downloads generated story HTML locally`, `revokeObjectURL` spy) is in `app.spec.ts`, in code this PR never touches (story-HTML-download blob handling), the same class of pre-existing/unrelated failure noted in PR #227.
- `npx tsc -p tsconfig.app.json --noEmit`: clean.
- `npm run build:prod`: succeeds (one pre-existing-adjacent `anyComponentStyle` budget *warning*, not error, on `proving-grounds.css`, now at 12.07kB vs. a 12.00kB warning threshold — the dedicated `tests/story-generator-component-style-budget.test.ts` CI gate, which measures compacted CSS against a 12,000-byte hard limit, still passes).
- `npm run test:all` (full backend/contract suite): all green, exit code 0.

### Worst-to-best running list (last 10)

1. **Proving Grounds** (`/proving-grounds`) — this PR.
2. **Image Generation** (`/api/image/generate`) — [#227](https://github.com/Phazzie/FairytaleswithSpice/pull/227).
3. **Real-Time Story Generation streaming** (`/api/story/stream`) — [#223](https://github.com/Phazzie/FairytaleswithSpice/pull/223), with follow-ups [#224](https://github.com/Phazzie/FairytaleswithSpice/pull/224) (SSE double-write) and [#225](https://github.com/Phazzie/FairytaleswithSpice/pull/225) (privacy-safe nav gating), and [#226](https://github.com/Phazzie/FairytaleswithSpice/pull/226) (Node deployment routing).

---
_Generated by [Claude Code](https://claude.ai/code/session_018Yh7iwQu72NWHcAmJHXtum)_

## Summary by Sourcery

Make Proving Grounds tests reliable and ensure unavailable evaluations are clearly identified instead of being mistaken for real AI scores.

New Features:
- Expose clear UI indicators when story evaluations are offline mock results and allow users to retry them.

Bug Fixes:
- Fix Proving Grounds component tests that failed when button labels changed during loading.
- Prevent fallback evaluation scores from appearing indistinguishable from genuine AI evaluations.

Enhancements:
- Add stable test identifiers to Proving Grounds controls and expand service and component test coverage for generation logic, prompt templates, and evaluation behavior.

Tests:
- Add unit coverage for generation logic, prompt templates, and real versus mock evaluation paths.
- Extend Proving Grounds component tests to verify mock-evaluation warnings and retry behavior.