### PR TITLE
Three quick wins: a bench that cannot generate, a dead export, a dropped image reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `downloadTextDocument` is the same attach-click-detach over an object URL that
   the story download already uses, parameterized by MIME type; `downloadHtmlDocument`
   now delegates to it, so both buttons share one implementation and one test.
+- The revoke moved inside that cleanup. It sat after the `try`, so a click that
+  throws — a browser that refuses the download, an extension that replaced the
+  handler — skipped it, and a browser holds a blob alive for the life of the tab
+  until its URL is revoked. Every refused attempt stranded a whole story or a
+  whole exported history in memory, on the path least likely to be noticed.
 
 #### A failed chapter illustration says why it failed
 - `generateChapterImage` was the one subscription in the component whose error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Three Quick Wins — the Proving Grounds bench, and a dropped image reason (August 26, 2026)
+
+#### Proving Grounds no longer spends a generation on a request the route always refuses
+- The page packs the selected template's system and user prompts — and the
+  generation-logic summary once the reader has asked to see it — into the
+  blueprint's `narrativeDirectives`, which `parseStoryLabBlueprintFromBody` caps
+  at `STORY_BLUEPRINT_LIMITS.maxNarrativeDirectivesLength` (1,200). The template
+  the page opens on, "Current Production", builds about 4,600 characters, so the
+  default configuration of the prompt bench could not generate at all, and the
+  shorter templates — which fit on their own — joined it once the generation
+  logic was attached to the run.
+- `describeNarrativeDirectivesOverflow` is asked before the request is sent, and
+  the page names the template, the length, the cap, and the three things the
+  reader can change. It measures `.trim().length` because the parser trims
+  before it measures — a check that counted the whitespace would refuse a
+  request the route would have taken. `tests/story-lab-blueprint-parser.test.ts`
+  takes both readings at the boundary so they cannot drift apart.
+- A generation that fails for any other reason now reports what the API said.
+  Since the routes answer real statuses, a refusal arrives through `HttpClient`'s
+  error path with the envelope on it, and the page was replacing that with
+  "Story generation failed. Check the debug panel or console for details."
+
+#### "Export Results" is a button that downloads something
+- The Proving Grounds history export built a `data:` URI and clicked an anchor it
+  had created but never attached — the pattern `downloadHtmlDocument` was
+  extracted to end. Firefox does not dispatch a synthetic click on a detached
+  anchor, so the button did nothing there at all, and a `data:` URI carries its
+  whole payload in the URL, which twenty-five generated stories with their
+  prompts and evaluations are not.
+- `downloadTextDocument` is the same attach-click-detach over an object URL that
+  the story download already uses, parameterized by MIME type; `downloadHtmlDocument`
+  now delegates to it, so both buttons share one implementation and one test.
+
+#### A failed chapter illustration says why it failed
+- `generateChapterImage` was the one subscription in the component whose error
+  handler ignored its argument, answering "Image generation failed. Please try
+  again." for every failure. An unsupported style, an exhausted image quota, and
+  a deployment with no image provider configured are all reasons that retrying
+  does not fix, and the route names each of them in the envelope that reaches
+  the error path.
+- It now reads through `formatHttpError` with that sentence as the fallback,
+  like every other subscription in the component.
+
 ### 🐛 Three Quick Wins (August 26, 2026)
 
 #### A keyless deployment no longer passes its canned evaluation off as a Grok score

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🐛 Three Quick Wins — the Proving Grounds bench, and a dropped image reason (August 26, 2026)
 
 #### Proving Grounds no longer spends a generation on a request the route always refuses
+
 - The page packs the selected template's system and user prompts — and the
   generation-logic summary once the reader has asked to see it — into the
   blueprint's `narrativeDirectives`, which `parseStoryLabBlueprintFromBody` caps
@@ -30,12 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "Story generation failed. Check the debug panel or console for details."
 
 #### "Export Results" is a button that downloads something
+
 - The Proving Grounds history export built a `data:` URI and clicked an anchor it
-  had created but never attached — the pattern `downloadHtmlDocument` was
-  extracted to end. Firefox does not dispatch a synthetic click on a detached
-  anchor, so the button did nothing there at all, and a `data:` URI carries its
-  whole payload in the URL, which twenty-five generated stories with their
-  prompts and evaluations are not.
+  had created but never attached — the same pattern the story download had before
+  `downloadHtmlDocument` replaced it with an attached anchor over an object URL.
+  Firefox does not dispatch a synthetic click on a detached anchor, so the button
+  did nothing there at all, and a `data:` URI carries its whole payload in the
+  URL, which twenty-five generated stories with their prompts and evaluations are
+  not.
 - `downloadTextDocument` is the same attach-click-detach over an object URL that
   the story download already uses, parameterized by MIME type; `downloadHtmlDocument`
   now delegates to it, so both buttons share one implementation and one test.
@@ -46,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whole exported history in memory, on the path least likely to be noticed.
 
 #### A failed chapter illustration says why it failed
+
 - `generateChapterImage` was the one subscription in the component whose error
   handler ignored its argument, answering "Image generation failed. Please try
   again." for every failure. An unsupported style, an exhausted image quota, and

--- a/shared/htmlDocumentDownload.ts
+++ b/shared/htmlDocumentDownload.ts
@@ -107,13 +107,17 @@ export function downloadTextDocument<TAnchor extends DownloadAnchorLike>(
   try {
     link.click();
   } finally {
-    // In a `finally` so a click that throws — a browser that refuses the
-    // download, an extension that replaced the handler — does not leave a stray
-    // anchor in the page for every attempt.
+    // Both halves of the cleanup are in the `finally`, because a click that
+    // throws — a browser that refuses the download, an extension that replaced
+    // the handler — has to leave the page as it found it. Detaching the anchor
+    // is the visible half. Scheduling the revoke is the half that used to sit
+    // after the `try` and was therefore skipped by the throw: the browser holds
+    // a blob alive for the life of the tab until its URL is revoked, so every
+    // refused attempt stranded a whole story or a whole exported history in
+    // memory, on the path already least likely to be noticed.
     host.document.body.removeChild(link);
+    host.scheduleRevoke(() => host.revokeObjectUrl(url));
   }
-
-  host.scheduleRevoke(() => host.revokeObjectUrl(url));
 }
 
 export function downloadHtmlDocument<TAnchor extends DownloadAnchorLike>(

--- a/shared/htmlDocumentDownload.ts
+++ b/shared/htmlDocumentDownload.ts
@@ -76,12 +76,29 @@ export interface HtmlDownloadHost<TAnchor extends DownloadAnchorLike = DownloadA
  */
 export const OBJECT_URL_REVOKE_DELAY_MS = 60_000;
 
-export function downloadHtmlDocument<TAnchor extends DownloadAnchorLike>(
-  html: string,
+/**
+ * Hand any generated text to the browser as a file the reader saves.
+ *
+ * The story download is not the only button that offers one. Proving Grounds
+ * exports its test history as JSON, and built that download the way the story
+ * download used to: a detached anchor, clicked, with the payload in a `data:`
+ * URI. It is the same silent failure — Firefox does not dispatch a synthetic
+ * click on an anchor that is not in the document — plus one the story download
+ * never had, because a `data:` URI carries the whole payload in the URL and a
+ * history of twenty-five generated stories is not a URL-sized thing. Routing
+ * both through this one function is what keeps the second button from
+ * rediscovering what the first one already learned.
+ *
+ * `mimeType` is the only thing that differs between them, so it is the only
+ * thing the caller supplies.
+ */
+export function downloadTextDocument<TAnchor extends DownloadAnchorLike>(
+  content: string,
   filename: string,
+  mimeType: string,
   host: HtmlDownloadHost<TAnchor>
 ): void {
-  const url = host.createObjectUrl(new Blob([html], { type: 'text/html' }));
+  const url = host.createObjectUrl(new Blob([content], { type: mimeType }));
   const link = host.document.createElement('a');
   link.href = url;
   link.download = filename;
@@ -97,6 +114,14 @@ export function downloadHtmlDocument<TAnchor extends DownloadAnchorLike>(
   }
 
   host.scheduleRevoke(() => host.revokeObjectUrl(url));
+}
+
+export function downloadHtmlDocument<TAnchor extends DownloadAnchorLike>(
+  html: string,
+  filename: string,
+  host: HtmlDownloadHost<TAnchor>
+): void {
+  downloadTextDocument(html, filename, 'text/html', host);
 }
 
 /**

--- a/shared/storyBlueprintLimits.ts
+++ b/shared/storyBlueprintLimits.ts
@@ -33,6 +33,34 @@ export const STORY_BLUEPRINT_LIMITS = {
 export type StoryBlueprintLimits = typeof STORY_BLUEPRINT_LIMITS;
 
 /**
+ * Say whether an assembled `narrativeDirectives` value will clear the cap the
+ * blueprint routes enforce, and by how much it misses.
+ *
+ * A caller that assembles this field from parts rather than from a textarea has
+ * no field length in front of the reader to warn them with. Proving Grounds is
+ * that caller: it packs the selected prompt template's system and user prompts —
+ * and, once the reader has asked to see it, the generation-logic summary — into
+ * this one field, which is thousands of characters for the template the page
+ * opens on. The route answers `400 INVALID_INPUT` for every one of those, so the
+ * page's own default configuration could not generate, and the round trip it
+ * spent to find that out told the reader only that generation had failed.
+ *
+ * `.trim().length` is not incidental: the parser reads this field through a
+ * helper that trims before it measures, so a value whose surrounding whitespace
+ * is what pushes it over the cap is one the API accepts. Measuring it any other
+ * way here would refuse a request the route would have taken — the mirror of the
+ * failure this exists to prevent.
+ */
+export function describeNarrativeDirectivesOverflow(directives: string): string | null {
+  const limit = STORY_BLUEPRINT_LIMITS.maxNarrativeDirectivesLength;
+  const length = directives.trim().length;
+
+  return length <= limit
+    ? null
+    : `Narrative directives are ${length} characters and this API accepts ${limit}.`;
+}
+
+/**
  * The size limits an evaluation request has to satisfy.
  *
  * `/api/story-lab/evaluate` checked that `storyContent` was a non-empty string

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -1438,9 +1438,15 @@ ${chapters}
             this.notificationService.error('Image generation failed', message);
           }
         },
-        error: () => {
+        // Read through `formatHttpError` like every other subscription in this
+        // component. A failed image generation is a real status now, so it
+        // arrives here rather than as a `success: false` body on a `200`, and
+        // the reason the route gave — an unsupported style, an exhausted image
+        // quota, a missing provider key — travels in the envelope this used to
+        // discard. "Please try again" is the wrong advice for all three.
+        error: error => {
           this.isGeneratingImage.set(false);
-          const message = 'Image generation failed. Please try again.';
+          const message = this.formatHttpError(error, 'Image generation failed. Please try again.');
           this.imageGenerationError.set(message);
           this.notificationService.error('Image generation failed', message);
         }

--- a/story-generator/src/app/proving-grounds/proving-grounds.ts
+++ b/story-generator/src/app/proving-grounds/proving-grounds.ts
@@ -21,6 +21,11 @@ import { StoryService } from '../story.service';
 import { GenerationLogic, GenerationLogicService } from './generation-logic.service';
 import { PromptEvaluationService } from './prompt-evaluation.service';
 import { PromptTemplatesService } from './prompt-templates.service';
+import {
+  createBrowserHtmlDownloadHost,
+  downloadTextDocument
+} from '../../../../shared/htmlDocumentDownload';
+import { describeNarrativeDirectivesOverflow } from '../../../../shared/storyBlueprintLimits';
 
 type TestResult = ProvingGroundsTestResult;
 type StoredTestResult = StoredProvingGroundsTestResult;
@@ -197,10 +202,21 @@ export class ProvingGroundsComponent implements OnInit {
       return;
     }
 
+    const input = this.buildGenerationInput(prompts, themes);
+    // The prompts under test travel to the API inside `narrativeDirectives`,
+    // which the blueprint routes cap. Asking first is what keeps a test the
+    // route is certain to refuse from being reported as a generation failure —
+    // and names the two things the reader can actually change.
+    const overflow = describeNarrativeDirectivesOverflow(input.narrativeDirectives ?? '');
+    if (overflow) {
+      this.statusMessage = `The "${template.name}" template does not fit: ${overflow} `
+        + 'Choose a shorter template, trim the custom prompt, or leave the generation logic out of this run.';
+      return;
+    }
+
     this.isGenerating.set(true);
     this.statusMessage = 'Generating Story Lab sample...';
     const startTime = Date.now();
-    const input = this.buildGenerationInput(prompts, themes);
 
     this.storyService.beginStory(input).subscribe({
       next: result => {
@@ -218,7 +234,8 @@ export class ProvingGroundsComponent implements OnInit {
       },
       error: error => {
         console.error('Error generating story:', error);
-        this.statusMessage = 'Story generation failed. Check the debug panel or console for details.';
+        this.statusMessage = this.readApiErrorMessage(error)
+          ?? 'Story generation failed. Check the debug panel or console for details.';
         this.isGenerating.set(false);
       }
     });
@@ -282,12 +299,18 @@ export class ProvingGroundsComponent implements OnInit {
       return;
     }
 
-    const dataStr = JSON.stringify(this.testHistory(), null, 2);
-    const dataUri = `data:application/json;charset=utf-8,${encodeURIComponent(dataStr)}`;
-    const linkElement = document.createElement('a');
-    linkElement.setAttribute('href', dataUri);
-    linkElement.setAttribute('download', `proving-grounds-results-${Date.now()}.json`);
-    linkElement.click();
+    // Through the shared download rather than a `data:` URI on a detached
+    // anchor: Firefox does not dispatch a synthetic click on an anchor that is
+    // not in the document, so this button did nothing there at all, and the
+    // history it exports — up to twenty-five generated stories with their
+    // prompts and evaluations — is far past what a browser will carry in a URL.
+    downloadTextDocument(
+      JSON.stringify(this.testHistory(), null, 2),
+      `proving-grounds-results-${Date.now()}.json`,
+      'application/json',
+      createBrowserHtmlDownloadHost(document, URL)
+    );
+    this.statusMessage = 'Exported the test history as JSON.';
   }
 
   deleteTest(testId: string): void {
@@ -377,6 +400,24 @@ export class ProvingGroundsComponent implements OnInit {
     return chapters
       .map(chapter => `<section><h3>${chapter.title}</h3>${chapter.htmlContent}<p><strong>Summary:</strong> ${chapter.summary}</p></section>`)
       .join('\n');
+  }
+
+  /**
+   * The message the API sent, when it sent one.
+   *
+   * A failed generation is a real status now, so `HttpClient` reports it through
+   * the error path rather than as a `success: false` body on a `200` — and the
+   * envelope that says which field the route refused travels with it, in
+   * `HttpErrorResponse.error`. Reporting a fixed sentence instead threw that
+   * away: "Story generation failed" for a blueprint the route named the invalid
+   * field of, and the same sentence for a provider outage.
+   */
+  private readApiErrorMessage(error: unknown): string | null {
+    const body = (error as { error?: unknown } | null | undefined)?.error;
+    const envelope = (body as { error?: { message?: unknown } } | null | undefined)?.error;
+    const message = envelope?.message;
+
+    return typeof message === 'string' && message.trim().length > 0 ? message : null;
   }
 
   private generateId(): string {

--- a/tests/html-document-download.test.ts
+++ b/tests/html-document-download.test.ts
@@ -135,6 +135,19 @@ try {
 assert(clickError instanceof Error, 'a click that throws should reach the caller');
 assert(failing.events.includes('removeChild'), 'a failed click should still detach the anchor');
 
+// …and still releases the blob. A browser holds one alive for the life of the
+// tab until its URL is revoked, so a revoke that the throw skipped would strand
+// a whole story or a whole exported history in memory on every refused attempt.
+assert(
+  failing.events.includes('scheduleRevoke'),
+  'a failed click should still schedule the object URL revoke'
+);
+failing.revokes.forEach(revoke => revoke());
+assert(
+  failing.events.includes('revokeObjectUrl:blob:story-download'),
+  'the scheduled revoke should release the object URL of a failed download'
+);
+
 // The Proving Grounds history export is the other download this module serves,
 // and it is JSON rather than a document. It has to reach the reader the same
 // way — an attached anchor over an object URL — because the two things that

--- a/tests/html-document-download.test.ts
+++ b/tests/html-document-download.test.ts
@@ -3,6 +3,7 @@
 
 import {
   downloadHtmlDocument,
+  downloadTextDocument,
   type DownloadAnchorLike,
   type DownloadDocumentLike,
   type HtmlDownloadHost
@@ -133,5 +134,40 @@ try {
 
 assert(clickError instanceof Error, 'a click that throws should reach the caller');
 assert(failing.events.includes('removeChild'), 'a failed click should still detach the anchor');
+
+// The Proving Grounds history export is the other download this module serves,
+// and it is JSON rather than a document. It has to reach the reader the same
+// way — an attached anchor over an object URL — because the two things that
+// went wrong for the story download are properties of the anchor and the URL,
+// not of what they carry.
+const json = JSON.stringify([{ id: 'test_1', generatedStory: '<h3>A vampire story</h3>' }], null, 2);
+const exported = createRecordingHost();
+downloadTextDocument(json, 'proving-grounds-results.json', 'application/json', exported.host);
+
+assert(
+  exported.events.includes('click:attached'),
+  'a text download must attach its anchor before clicking it'
+);
+assert(
+  exported.events.indexOf('click:attached') < exported.events.indexOf('removeChild'),
+  'a text download should detach its anchor only after the click'
+);
+assert(
+  exported.anchor.download === 'proving-grounds-results.json',
+  'the anchor should carry the export filename'
+);
+assert(exported.anchor.href === 'blob:story-download', 'the export should be offered as an object URL');
+assert(exported.blobs.length === 1, 'exactly one blob should be created per export');
+assert(exported.blobs[0].type === 'application/json', 'the export should be typed as JSON');
+assert(
+  exported.blobs[0].size === Buffer.byteLength(json, 'utf8'),
+  'the blob should carry the whole exported history'
+);
+
+exported.revokes.forEach(revoke => revoke());
+assert(
+  exported.events.includes('revokeObjectUrl:blob:story-download'),
+  'the export should release its object URL on the scheduled revoke'
+);
 
 console.log('HTML document download tests passed');

--- a/tests/story-lab-blueprint-parser.test.ts
+++ b/tests/story-lab-blueprint-parser.test.ts
@@ -6,7 +6,10 @@ import {
   parseStoryLabBlueprintFromQuery
 } from '../api/_lib/story-lab/validation/blueprintParser';
 import type { CreatureType } from '../api/_lib/types/contracts';
-import { STORY_BLUEPRINT_LIMITS } from '../shared/storyBlueprintLimits';
+import {
+  describeNarrativeDirectivesOverflow,
+  STORY_BLUEPRINT_LIMITS
+} from '../shared/storyBlueprintLimits';
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -164,6 +167,49 @@ const overTheLimitQuery = parseStoryLabBlueprintFromQuery({
 assert(
   overTheLimitQuery.error?.invalidFields.includes('logline'),
   'an over-long logline should be refused on the stream query path as well'
+);
+
+// A caller that assembles `narrativeDirectives` from parts asks
+// `describeNarrativeDirectivesOverflow` before it spends a request. That answer
+// is worth nothing unless it matches the one this parser gives, so both
+// readings are taken here, at the boundary and on either side of it.
+const directivesBody = (narrativeDirectives: string) =>
+  parseStoryLabBlueprintFromBody({ ...bodyForCreature('dragon'), narrativeDirectives });
+
+const directivesAtTheLimit = longText(STORY_BLUEPRINT_LIMITS.maxNarrativeDirectivesLength);
+assert(
+  describeNarrativeDirectivesOverflow(directivesAtTheLimit) === null,
+  'directives exactly at the cap should be described as fitting'
+);
+assert(
+  !directivesBody(directivesAtTheLimit).error,
+  'directives exactly at the cap should be accepted by the parser'
+);
+
+const directivesOverTheLimit = longText(STORY_BLUEPRINT_LIMITS.maxNarrativeDirectivesLength + 1);
+const overflowMessage = describeNarrativeDirectivesOverflow(directivesOverTheLimit);
+assert(overflowMessage !== null, 'directives past the cap should be described as too long');
+assert(
+  overflowMessage.includes(String(STORY_BLUEPRINT_LIMITS.maxNarrativeDirectivesLength))
+    && overflowMessage.includes(String(directivesOverTheLimit.length)),
+  'the overflow message should name both the length and the cap'
+);
+assert(
+  directivesBody(directivesOverTheLimit).error?.invalidFields.includes('narrativeDirectives'),
+  'directives past the cap should be refused by the parser'
+);
+
+// The parser trims before it measures, so surrounding whitespace is not what
+// makes a value too long. A client-side check that counted it would refuse a
+// request this route would have taken.
+const paddedToTheLimit = `\n  ${directivesAtTheLimit}  \n`;
+assert(
+  describeNarrativeDirectivesOverflow(paddedToTheLimit) === null,
+  'whitespace around directives at the cap should not be described as overflow'
+);
+assert(
+  !directivesBody(paddedToTheLimit).error,
+  'whitespace around directives at the cap should not be refused by the parser'
 );
 
 console.log('Story Lab shared blueprint parser tests passed');


### PR DESCRIPTION
## Scope

Three independent defects, each on a live surface, each with the fix beside it.

### 1. Proving Grounds spends a generation on a request the route always refuses

`buildGenerationInput` packs the selected template's system and user prompts — and the generation-logic summary, once the reader has clicked to see it — into the blueprint's `narrativeDirectives`. `parseStoryLabBlueprintFromBody` caps that field at `STORY_BLUEPRINT_LIMITS.maxNarrativeDirectivesLength` (1,200 characters).

Measured from the templates in `prompt-templates.service.ts`:

| template | system | user | directives sent |
| --- | ---: | ---: | ---: |
| Current Production (the default) | 3,289 | 1,308 | ~4,620 |
| Concise & Focused | 420 | 238 | ~680 |
| Emotional Depth | 571 | 388 | ~980 |
| Sensory Immersion | 641 | 318 | ~980 |
| Dialogue-Driven | 541 | 349 | ~910 |

So the configuration the page opens on could not generate at all, and the four shorter templates — which fit on their own — went over as soon as the generation logic (~500 more characters) was attached to the run. The reader was told `Story generation failed. Check the debug panel or console for details.`, while the route had answered `400 INVALID_INPUT` naming `narrativeDirectives` and its cap.

- `describeNarrativeDirectivesOverflow` (in `shared/storyBlueprintLimits.ts`, beside the limits it reads) is asked before the request is sent. The page names the template, the length, the cap, and the three things the reader can change.
- It measures `.trim().length` because the parser trims before it measures — a check that counted surrounding whitespace would refuse a request the route would have taken, which is the mirror of the failure being fixed. `tests/story-lab-blueprint-parser.test.ts` now takes both readings at the boundary, one past it, and with padding, so the two cannot drift apart.
- A failure that does reach the API now reports what the API said. The routes answer real statuses, so a refusal arrives through `HttpClient`'s error path with the envelope on it; the fixed sentence remains as the fallback.

**Not claimed:** this does not make the production template testable. Only 320 characters of `narrativeDirectives` reach the model anyway (`STORY_LAB_CONTEXT_VALUE_MAX_LENGTH` in `storyService.formatStoryLabContext`), so a bench that A/B-tests whole prompts needs a prompt-override contract on the genesis route rather than a bigger cap on this field. That is a feature, and it is not in this PR.

### 2. "Export Results" is a button that downloads something

The Proving Grounds history export built a `data:` URI and clicked an anchor it had created but never attached — the exact pattern `shared/htmlDocumentDownload.ts` was extracted to end. Firefox does not dispatch a synthetic click on a detached anchor, so the button did nothing there at all; and a `data:` URI carries its whole payload in the URL, which twenty-five stored test results with their prompts, stories, and evaluations are not.

`downloadTextDocument` is the same attach-click-detach over an object URL that the story download already uses, parameterized by MIME type. `downloadHtmlDocument` delegates to it, so both buttons are one implementation with one test.

### 3. A failed chapter illustration says why it failed

`generateChapterImage` was the one subscription in `App` whose error handler ignored its argument (`error: () => { … 'Image generation failed. Please try again.' }`). An unsupported style, an exhausted image quota, and a deployment with no image provider configured are all reasons retrying does not fix, and the route names each of them in the envelope that reaches the error path. It now reads through `formatHttpError` with that sentence as the fallback, like every other subscription in the component.

## Validation

Run from a clean install of both workspaces (`npm ci` at the root and in `story-generator/`):

- `tsc -p tsconfig.app.json --noEmit` — clean
- `tsc -p tsconfig.spec.json --noEmit` — clean
- API function typecheck (the `find api -name '*.ts' | xargs tsc --noEmit …` from `scripts/recovery/preflight.sh`) — clean
- `npm test` (the full root suite, 47 scripts) — passes, including the two files this PR extends
- `npm run build` in `story-generator/` — bundle generated; the one warning is the pre-existing `proving-grounds.css` budget overrun (12.07 kB against 12.00 kB), untouched here

## Files

- `shared/htmlDocumentDownload.ts` — `downloadTextDocument`; `downloadHtmlDocument` delegates
- `shared/storyBlueprintLimits.ts` — `describeNarrativeDirectivesOverflow`
- `story-generator/src/app/proving-grounds/proving-grounds.ts` — pre-flight, API error message, export
- `story-generator/src/app/app.ts` — image error reads the envelope
- `tests/html-document-download.test.ts`, `tests/story-lab-blueprint-parser.test.ts` — coverage for both new functions
- `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeRfKJeB6mkCKDkZrBrQTr

---
_Generated by [Claude Code](https://claude.ai/code/session_01DeRfKJeB6mkCKDkZrBrQTr)_

## Summary by Sourcery

Make Proving Grounds generation, history export, and chapter-image failures provide reliable, actionable behavior.

Bug Fixes:
- Prevent Proving Grounds from submitting blueprint requests that exceed the narrative-directives limit by warning users before generation.
- Show API-provided error messages for failed Proving Grounds generations and chapter illustration requests.
- Fix Proving Grounds history exports so JSON downloads work reliably across browsers and handle large export payloads.

Enhancements:
- Consolidate text and HTML downloads around shared object-URL download handling with reliable cleanup.

Documentation:
- Document the Proving Grounds validation, download, and error-reporting fixes in the changelog.

Tests:
- Extend coverage for narrative-directives boundary and whitespace handling and shared text-download behavior, including cleanup after failed clicks.