### PR TITLE
***WORST TO BEST*** Story Export/Download: dead backend wired up, fake zip/storage/metadata made real

### DIFF
--- a/api/_lib/services/exportService.ts
+++ b/api/_lib/services/exportService.ts
@@ -6,6 +6,7 @@ import {
   sanitizeStoryHtmlForExport,
   stripStoryHtmlForExport
 } from './exportSanitizer';
+import { buildZipArchive, ZipEntry } from './zipArchive';
 
 const PDF_EXCERPT_CODE_POINTS = 100;
 // Leaves room for the `_<timestamp>_<token>.<format>` suffix inside the
@@ -13,6 +14,14 @@ const PDF_EXCERPT_CODE_POINTS = 100;
 const EXPORT_FILENAME_STEM_MAX_LENGTH = 80;
 // Distinguishes two exports that collide on both stem and millisecond.
 const EXPORT_FILENAME_TOKEN_LENGTH = 8;
+
+const EXPORT_MIME_TYPES: Record<ExportFormat, string> = {
+  pdf: 'application/pdf',
+  html: 'text/html',
+  txt: 'text/plain',
+  epub: 'application/epub+zip',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+};
 
 /**
  * Take the first `limit` code points of `value`. Iterating a string yields
@@ -61,8 +70,6 @@ interface ExportMetadata {
 }
 
 export class ExportService {
-  private storageBaseUrl = process.env['STORAGE_BASE_URL'] || 'https://storage.example.com';
-
   async saveAndExport(input: SaveExportSeam['input']): Promise<ApiResponse<SaveExportSeam['output']>> {
     const startTime = Date.now();
 
@@ -80,7 +87,6 @@ export class ExportService {
         };
       }
 
-      // Generate export content based on format
       const exportContent = await this.generateExportContent(input);
 
       // The filename is timestamped, so it has to be generated once and shared:
@@ -89,20 +95,19 @@ export class ExportService {
       // does not match the filename it was told to save.
       const filename = this.generateFilename(input);
 
-      // Save to storage (mock implementation)
-      const fileUrl = await this.saveToStorage(filename);
+      // There is no object storage behind this service: the exported bytes are
+      // handed back directly as a `data:` URI rather than a link to somewhere
+      // they were uploaded. That URI resolves immediately, in the same
+      // response, with nothing left to expire.
+      const downloadUrl = this.buildDataUri(input.format, exportContent);
 
-      // Create response
       const output: SaveExportSeam['output'] = {
         exportId: this.generateExportId(),
         storyId: input.storyId,
-        downloadUrl: fileUrl,
+        downloadUrl,
         filename,
         format: input.format,
-        // The contract measures fileSize in bytes; `.length` counts UTF-16 code
-        // units, which undercounts every non-ASCII character a story contains.
-        fileSize: Buffer.byteLength(exportContent, 'utf8'),
-        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours
+        fileSize: exportContent.length,
         exportedAt: new Date()
       };
 
@@ -133,35 +138,34 @@ export class ExportService {
   }
 
   /**
-   * Render the export document for an input without running the mock upload.
+   * Render the export document for an input without building its data URI.
    *
    * Public because the document itself is the product: `saveAndExport` reports
-   * only its size and a storage URL, so this is the supported way to assert on
-   * what an export actually contains.
+   * only its size and a self-contained download URI, so this is the supported
+   * way to assert on what an export actually contains.
    */
-  async generateExportContent(input: SaveExportSeam['input']): Promise<string> {
+  async generateExportContent(input: SaveExportSeam['input']): Promise<Buffer> {
     const sanitizedHtml = sanitizeStoryHtmlForExport(input.content);
     const plainText = stripStoryHtmlForExport(input.content);
-    const metadata = this.generateMetadata(plainText);
+    const metadata = this.generateMetadata(plainText, input);
 
     switch (input.format) {
       case 'pdf':
-        return this.generatePDFContent(plainText, input);
+        return Buffer.from(this.generatePDFContent(plainText, input), 'utf8');
       case 'html':
-        return this.generateHTMLContent(sanitizedHtml, metadata, input);
+        return Buffer.from(this.generateHTMLContent(sanitizedHtml, metadata, input), 'utf8');
       case 'txt':
-        return this.generateTextContent(plainText, metadata, input);
+        return Buffer.from(this.generateTextContent(plainText, metadata, input), 'utf8');
       case 'epub':
-        return this.generateEPUBContent(input);
+        return this.generateEPUBContent(plainText, input);
       case 'docx':
-        return this.generateDOCXContent(plainText);
+        return this.generateDOCXContent(plainText, input);
       default:
         throw new Error(`Unsupported format: ${input.format}`);
     }
   }
 
   private generatePDFContent(content: string, input: SaveExportSeam['input']): string {
-    // Mock PDF generation - in real implementation, use pdfkit or puppeteer
     const title = escapePdfText(input.title);
     // The excerpt is cut from the source text and escaped afterwards. Cutting
     // the escaped text instead splits whatever escaping added at the boundary:
@@ -324,44 +328,138 @@ ${xrefOffset}
     return text;
   }
 
-  private generateEPUBContent(input: SaveExportSeam['input']): string {
-    // Mock EPUB generation - in real implementation, use epub-gen or similar
+  /**
+   * Build a real EPUB 3 container: the mandatory `mimetype` entry (stored,
+   * uncompressed, first), the OCF `container.xml` pointer, a package document
+   * with the nav item EPUB 3 requires, the nav document itself, and the
+   * chapter it points at — actually containing the story, where the previous
+   * version referenced a `chapter1.xhtml` it never wrote.
+   */
+  private generateEPUBContent(plainText: string, input: SaveExportSeam['input']): Buffer {
     const title = escapeHtml(input.title);
+    // Derived from the story being exported rather than a fresh `randomUUID()`
+    // per call: the same story exported twice should produce the same book
+    // identifier, and a real UUID would make otherwise-identical output
+    // (including the copy this method itself hands back for verification)
+    // vary from one call to the next.
+    const bookId = `urn:x-fairytales-with-spice:${escapeHtml(input.storyId)}`;
+    const chapterXhtml = this.toXhtmlBody(plainText);
 
-    // The metadata block is written with the `dc:` prefix, so the Dublin Core
-    // namespace it stands for has to be bound on the root element. Without the
-    // binding the prefix is undeclared and the package document is not
-    // well-formed XML, which every conforming reader rejects outright.
-    return `<?xml version="1.0" encoding="UTF-8"?>
-<package xmlns="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/" version="3.0">
-    <metadata>
-        <dc:title>${title}</dc:title>
-        <dc:creator>Fairytales with Spice</dc:creator>
-        <dc:language>en</dc:language>
-    </metadata>
-    <manifest>
-        <item id="chapter1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
-    </manifest>
-    <spine>
-        <itemref idref="chapter1"/>
-    </spine>
+    const containerXml = `<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`;
+
+    const contentOpf = `<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="bookid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="bookid">${bookId}</dc:identifier>
+    <dc:title>${title}</dc:title>
+    <dc:language>en</dc:language>
+    <dc:creator>Fairytales with Spice</dc:creator>
+  </metadata>
+  <manifest>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+    <item id="chapter1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="chapter1"/>
+  </spine>
 </package>`;
+
+    const navXhtml = `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>Navigation</title></head>
+<body>
+<nav epub:type="toc" id="toc">
+<ol><li><a href="chapter1.xhtml">${title}</a></li></ol>
+</nav>
+</body>
+</html>`;
+
+    const chapter1Xhtml = `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><title>${title}</title></head>
+<body>
+<h1>${title}</h1>
+${chapterXhtml}
+</body>
+</html>`;
+
+    const entries: ZipEntry[] = [
+      // Must be the first entry, stored uncompressed, for a conforming reader
+      // to identify the container by its first 38 bytes alone.
+      { path: 'mimetype', data: Buffer.from('application/epub+zip', 'ascii') },
+      { path: 'META-INF/container.xml', data: Buffer.from(containerXml, 'utf8') },
+      { path: 'OEBPS/content.opf', data: Buffer.from(contentOpf, 'utf8') },
+      { path: 'OEBPS/nav.xhtml', data: Buffer.from(navXhtml, 'utf8') },
+      { path: 'OEBPS/chapter1.xhtml', data: Buffer.from(chapter1Xhtml, 'utf8') }
+    ];
+
+    return buildZipArchive(entries);
   }
 
-  private generateDOCXContent(content: string): string {
-    // Mock DOCX generation - in real implementation, use docx or similar
-    return `PK                  docProps/PK                  word/PK                  [Content_Types].xmlPK                  _rels/PK                  word/_rels/document.xml.relsPK                  word/document.xml${escapeHtml(content)}`;
+  /**
+   * Build a real, minimal OOXML `.docx`: the package-level content-types and
+   * relationship parts every `.docx` reader requires, plus a `word/document.xml`
+   * holding the story as one paragraph per line. The previous version wrote
+   * literal text made to *look* like these zip entries' names, concatenated
+   * with escaped plain text — not a zip archive at all.
+   */
+  private generateDOCXContent(plainText: string, input: SaveExportSeam['input']): Buffer {
+    const contentTypesXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`;
+
+    const relsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`;
+
+    const paragraphs = [input.title, ...plainText.split('\n').map(line => line.trim())]
+      .filter(Boolean)
+      .map(line => `<w:p><w:r><w:t xml:space="preserve">${escapeHtml(line)}</w:t></w:r></w:p>`)
+      .join('\n    ');
+
+    const documentXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    ${paragraphs}
+    <w:sectPr/>
+  </w:body>
+</w:document>`;
+
+    const entries: ZipEntry[] = [
+      { path: '[Content_Types].xml', data: Buffer.from(contentTypesXml, 'utf8') },
+      { path: '_rels/.rels', data: Buffer.from(relsXml, 'utf8') },
+      { path: 'word/document.xml', data: Buffer.from(documentXml, 'utf8') }
+    ];
+
+    return buildZipArchive(entries);
   }
 
-  private async saveToStorage(filename: string): Promise<string> {
-    // Mock storage implementation - in real implementation, upload to S3, Cloudinary, etc.
-    // (which is where the export content will be needed; this mock only names it.)
+  /**
+   * Turn the plain-text export into well-formed XHTML paragraphs: each
+   * non-blank line becomes its own escaped `<p>`, which is enough structure for
+   * a real XHTML document without re-parsing the sanitizer's HTML-oriented
+   * output (whose unclosed `<br>` void tags are not valid XHTML).
+   */
+  private toXhtmlBody(plainText: string): string {
+    return plainText
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean)
+      .map(line => `<p>${escapeHtml(line)}</p>`)
+      .join('\n');
+  }
 
-    // Simulate upload delay
-    await new Promise(resolve => setTimeout(resolve, 300));
-
-    // Return mock URL
-    return `${this.storageBaseUrl}/exports/${filename}`;
+  private buildDataUri(format: ExportFormat, content: Buffer): string {
+    return `data:${EXPORT_MIME_TYPES[format]};base64,${content.toString('base64')}`;
   }
 
   private validateExportInput(input: SaveExportSeam['input']): any {
@@ -386,13 +484,13 @@ ${xrefOffset}
     return null;
   }
 
-  private generateMetadata(content: string): ExportMetadata {
+  private generateMetadata(content: string, input: SaveExportSeam['input']): ExportMetadata {
     return {
       generatedAt: new Date().toISOString(),
       wordCount: this.countWords(content),
       readTime: Math.ceil(this.countWords(content) / 200),
-      creature: 'vampire', // In real implementation, extract from story data
-      themes: ['romance', 'dark'] // In real implementation, extract from story data
+      creature: input.creature ?? 'unknown',
+      themes: input.themes ?? []
     };
   }
 

--- a/api/_lib/services/zipArchive.ts
+++ b/api/_lib/services/zipArchive.ts
@@ -1,0 +1,187 @@
+// Created: 2026-08-26 UTC
+
+/**
+ * A minimal ZIP container writer/reader, STORE method only (no compression).
+ *
+ * The export service used to hand out `.epub` and `.docx` files that were
+ * plain text made to *look* like a zip's local-file-header strings — not a
+ * real archive, so no reader could open them. Both formats are just a zip
+ * container around a handful of small XML parts, and STORE (uncompressed)
+ * entries are a fully spec-compliant way to write one: real EPUB and DOCX
+ * readers accept stored entries the same as deflated ones. This avoids
+ * pulling in a compression dependency for files that are a few kilobytes at
+ * most.
+ *
+ * `readZipEntries` exists so the parts this module writes can be verified by
+ * reading them back, rather than trusting the writer against its own byte
+ * offsets.
+ */
+
+const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
+const CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
+const END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
+const VERSION_NEEDED_TO_EXTRACT = 20;
+const STORE_METHOD = 0;
+
+const LOCAL_FILE_HEADER_SIZE = 30;
+const CENTRAL_DIRECTORY_HEADER_SIZE = 46;
+const END_OF_CENTRAL_DIRECTORY_SIZE = 22;
+
+export interface ZipEntry {
+  path: string;
+  data: Buffer;
+}
+
+const CRC32_TABLE = buildCrc32Table();
+
+function buildCrc32Table(): Uint32Array {
+  const table = new Uint32Array(256);
+
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+
+  return table;
+}
+
+export function crc32(data: Buffer): number {
+  let crc = 0xffffffff;
+
+  for (let i = 0; i < data.length; i++) {
+    crc = CRC32_TABLE[(crc ^ data[i]) & 0xff] ^ (crc >>> 8);
+  }
+
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+/**
+ * Write a set of entries as a real, spec-compliant ZIP archive: a local file
+ * header + data per entry, followed by the central directory and the end
+ * record every reader locates the directory through.
+ *
+ * Entries are written in the order given, which matters for EPUB: its `mimetype`
+ * entry has to be first and uncompressed for a conforming reader to recognize
+ * the container without reading the rest of the archive.
+ */
+export function buildZipArchive(entries: ZipEntry[]): Buffer {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const nameBytes = Buffer.from(entry.path, 'utf8');
+    const crc = crc32(entry.data);
+    const size = entry.data.length;
+
+    const localHeader = Buffer.alloc(LOCAL_FILE_HEADER_SIZE);
+    localHeader.writeUInt32LE(LOCAL_FILE_HEADER_SIGNATURE, 0);
+    localHeader.writeUInt16LE(VERSION_NEEDED_TO_EXTRACT, 4);
+    localHeader.writeUInt16LE(0, 6); // general purpose bit flag
+    localHeader.writeUInt16LE(STORE_METHOD, 8);
+    localHeader.writeUInt16LE(0, 10); // last mod file time
+    localHeader.writeUInt16LE(0, 12); // last mod file date
+    localHeader.writeUInt32LE(crc, 14);
+    localHeader.writeUInt32LE(size, 18); // compressed size == uncompressed size for STORE
+    localHeader.writeUInt32LE(size, 22);
+    localHeader.writeUInt16LE(nameBytes.length, 26);
+    localHeader.writeUInt16LE(0, 28); // extra field length
+
+    localParts.push(localHeader, nameBytes, entry.data);
+
+    const centralHeader = Buffer.alloc(CENTRAL_DIRECTORY_HEADER_SIZE);
+    centralHeader.writeUInt32LE(CENTRAL_DIRECTORY_SIGNATURE, 0);
+    centralHeader.writeUInt16LE(VERSION_NEEDED_TO_EXTRACT, 4); // version made by
+    centralHeader.writeUInt16LE(VERSION_NEEDED_TO_EXTRACT, 6); // version needed to extract
+    centralHeader.writeUInt16LE(0, 8); // general purpose bit flag
+    centralHeader.writeUInt16LE(STORE_METHOD, 10);
+    centralHeader.writeUInt16LE(0, 12); // last mod file time
+    centralHeader.writeUInt16LE(0, 14); // last mod file date
+    centralHeader.writeUInt32LE(crc, 16);
+    centralHeader.writeUInt32LE(size, 20);
+    centralHeader.writeUInt32LE(size, 24);
+    centralHeader.writeUInt16LE(nameBytes.length, 28);
+    centralHeader.writeUInt16LE(0, 30); // extra field length
+    centralHeader.writeUInt16LE(0, 32); // file comment length
+    centralHeader.writeUInt16LE(0, 34); // disk number start
+    centralHeader.writeUInt16LE(0, 36); // internal file attributes
+    centralHeader.writeUInt32LE(0, 38); // external file attributes
+    centralHeader.writeUInt32LE(offset, 42); // relative offset of local header
+
+    centralParts.push(centralHeader, nameBytes);
+
+    offset += LOCAL_FILE_HEADER_SIZE + nameBytes.length + size;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const centralDirectoryOffset = offset;
+
+  const endRecord = Buffer.alloc(END_OF_CENTRAL_DIRECTORY_SIZE);
+  endRecord.writeUInt32LE(END_OF_CENTRAL_DIRECTORY_SIGNATURE, 0);
+  endRecord.writeUInt16LE(0, 4); // number of this disk
+  endRecord.writeUInt16LE(0, 6); // disk where central directory starts
+  endRecord.writeUInt16LE(entries.length, 8); // central directory records on this disk
+  endRecord.writeUInt16LE(entries.length, 10); // total central directory records
+  endRecord.writeUInt32LE(centralDirectory.length, 12);
+  endRecord.writeUInt32LE(centralDirectoryOffset, 16);
+  endRecord.writeUInt16LE(0, 20); // comment length
+
+  return Buffer.concat([...localParts, centralDirectory, endRecord]);
+}
+
+/**
+ * Read the entries back out of a ZIP built by `buildZipArchive` (or any other
+ * STORE-only archive with entries at the offsets their central directory
+ * records name). Used to verify the archives this module writes rather than
+ * asserting on raw byte offsets in tests.
+ */
+export function readZipEntries(archive: Buffer): ZipEntry[] {
+  const eocdOffset = archive.lastIndexOf(
+    Buffer.from([
+      END_OF_CENTRAL_DIRECTORY_SIGNATURE & 0xff,
+      (END_OF_CENTRAL_DIRECTORY_SIGNATURE >>> 8) & 0xff,
+      (END_OF_CENTRAL_DIRECTORY_SIGNATURE >>> 16) & 0xff,
+      (END_OF_CENTRAL_DIRECTORY_SIGNATURE >>> 24) & 0xff
+    ])
+  );
+
+  if (eocdOffset === -1) {
+    throw new Error('Not a valid zip archive: end-of-central-directory record not found');
+  }
+
+  const entryCount = archive.readUInt16LE(eocdOffset + 10);
+  const centralDirectoryOffset = archive.readUInt32LE(eocdOffset + 16);
+
+  const entries: ZipEntry[] = [];
+  let cursor = centralDirectoryOffset;
+
+  for (let i = 0; i < entryCount; i++) {
+    if (archive.readUInt32LE(cursor) !== CENTRAL_DIRECTORY_SIGNATURE) {
+      throw new Error(`Not a valid zip archive: central directory record ${i} missing its signature`);
+    }
+
+    const compressedSize = archive.readUInt32LE(cursor + 20);
+    const nameLength = archive.readUInt16LE(cursor + 28);
+    const extraLength = archive.readUInt16LE(cursor + 30);
+    const commentLength = archive.readUInt16LE(cursor + 32);
+    const localHeaderOffset = archive.readUInt32LE(cursor + 42);
+    const path = archive.toString('utf8', cursor + CENTRAL_DIRECTORY_HEADER_SIZE, cursor + CENTRAL_DIRECTORY_HEADER_SIZE + nameLength);
+
+    if (archive.readUInt32LE(localHeaderOffset) !== LOCAL_FILE_HEADER_SIGNATURE) {
+      throw new Error(`Not a valid zip archive: local file header for "${path}" missing its signature`);
+    }
+
+    const localNameLength = archive.readUInt16LE(localHeaderOffset + 26);
+    const localExtraLength = archive.readUInt16LE(localHeaderOffset + 28);
+    const dataOffset = localHeaderOffset + LOCAL_FILE_HEADER_SIZE + localNameLength + localExtraLength;
+    const data = archive.subarray(dataOffset, dataOffset + compressedSize);
+
+    entries.push({ path, data: Buffer.from(data) });
+    cursor += CENTRAL_DIRECTORY_HEADER_SIZE + nameLength + extraLength + commentLength;
+  }
+
+  return entries;
+}

--- a/api/_lib/services/zipArchive.ts
+++ b/api/_lib/services/zipArchive.ts
@@ -59,6 +59,56 @@ export function crc32(data: Buffer): number {
 }
 
 /**
+ * Fills a fixed-size buffer field by field, so a header's layout reads as the
+ * sequence of fields the ZIP spec defines rather than as a list of byte
+ * offsets someone has to keep in sync by hand.
+ */
+class SequentialBufferWriter {
+  private readonly buffer: Buffer;
+  private offset = 0;
+
+  constructor(size: number) {
+    this.buffer = Buffer.alloc(size);
+  }
+
+  u16(value: number): this {
+    this.buffer.writeUInt16LE(value, this.offset);
+    this.offset += 2;
+    return this;
+  }
+
+  u32(value: number): this {
+    this.buffer.writeUInt32LE(value, this.offset);
+    this.offset += 4;
+    return this;
+  }
+
+  toBuffer(): Buffer {
+    return this.buffer;
+  }
+}
+
+/**
+ * The fields a local file header and a central directory record describe
+ * identically once past their signature and version fields: this entry was
+ * stored (never deflated), when (never — no timestamp is tracked), its CRC,
+ * its size (twice — STORE makes the compressed and uncompressed sizes equal),
+ * and how long its filename is. Shared so the two headers can't drift apart on
+ * a field neither of them actually varies.
+ */
+function writeStoreMethodFields(writer: SequentialBufferWriter, crc: number, size: number, nameLength: number): SequentialBufferWriter {
+  return writer
+    .u16(0) // general purpose bit flag
+    .u16(STORE_METHOD)
+    .u16(0) // last mod file time
+    .u16(0) // last mod file date
+    .u32(crc)
+    .u32(size) // compressed size == uncompressed size for STORE
+    .u32(size)
+    .u16(nameLength);
+}
+
+/**
  * Write a set of entries as a real, spec-compliant ZIP archive: a local file
  * header + data per entry, followed by the central directory and the end
  * record every reader locates the directory through.
@@ -77,39 +127,33 @@ export function buildZipArchive(entries: ZipEntry[]): Buffer {
     const crc = crc32(entry.data);
     const size = entry.data.length;
 
-    const localHeader = Buffer.alloc(LOCAL_FILE_HEADER_SIZE);
-    localHeader.writeUInt32LE(LOCAL_FILE_HEADER_SIGNATURE, 0);
-    localHeader.writeUInt16LE(VERSION_NEEDED_TO_EXTRACT, 4);
-    localHeader.writeUInt16LE(0, 6); // general purpose bit flag
-    localHeader.writeUInt16LE(STORE_METHOD, 8);
-    localHeader.writeUInt16LE(0, 10); // last mod file time
-    localHeader.writeUInt16LE(0, 12); // last mod file date
-    localHeader.writeUInt32LE(crc, 14);
-    localHeader.writeUInt32LE(size, 18); // compressed size == uncompressed size for STORE
-    localHeader.writeUInt32LE(size, 22);
-    localHeader.writeUInt16LE(nameBytes.length, 26);
-    localHeader.writeUInt16LE(0, 28); // extra field length
+    const localHeader = writeStoreMethodFields(
+      new SequentialBufferWriter(LOCAL_FILE_HEADER_SIZE).u32(LOCAL_FILE_HEADER_SIGNATURE).u16(VERSION_NEEDED_TO_EXTRACT),
+      crc,
+      size,
+      nameBytes.length
+    )
+      .u16(0) // extra field length
+      .toBuffer();
 
     localParts.push(localHeader, nameBytes, entry.data);
 
-    const centralHeader = Buffer.alloc(CENTRAL_DIRECTORY_HEADER_SIZE);
-    centralHeader.writeUInt32LE(CENTRAL_DIRECTORY_SIGNATURE, 0);
-    centralHeader.writeUInt16LE(VERSION_NEEDED_TO_EXTRACT, 4); // version made by
-    centralHeader.writeUInt16LE(VERSION_NEEDED_TO_EXTRACT, 6); // version needed to extract
-    centralHeader.writeUInt16LE(0, 8); // general purpose bit flag
-    centralHeader.writeUInt16LE(STORE_METHOD, 10);
-    centralHeader.writeUInt16LE(0, 12); // last mod file time
-    centralHeader.writeUInt16LE(0, 14); // last mod file date
-    centralHeader.writeUInt32LE(crc, 16);
-    centralHeader.writeUInt32LE(size, 20);
-    centralHeader.writeUInt32LE(size, 24);
-    centralHeader.writeUInt16LE(nameBytes.length, 28);
-    centralHeader.writeUInt16LE(0, 30); // extra field length
-    centralHeader.writeUInt16LE(0, 32); // file comment length
-    centralHeader.writeUInt16LE(0, 34); // disk number start
-    centralHeader.writeUInt16LE(0, 36); // internal file attributes
-    centralHeader.writeUInt32LE(0, 38); // external file attributes
-    centralHeader.writeUInt32LE(offset, 42); // relative offset of local header
+    const centralHeader = writeStoreMethodFields(
+      new SequentialBufferWriter(CENTRAL_DIRECTORY_HEADER_SIZE)
+        .u32(CENTRAL_DIRECTORY_SIGNATURE)
+        .u16(VERSION_NEEDED_TO_EXTRACT) // version made by
+        .u16(VERSION_NEEDED_TO_EXTRACT), // version needed to extract
+      crc,
+      size,
+      nameBytes.length
+    )
+      .u16(0) // extra field length
+      .u16(0) // file comment length
+      .u16(0) // disk number start
+      .u16(0) // internal file attributes
+      .u32(0) // external file attributes
+      .u32(offset) // relative offset of local header
+      .toBuffer();
 
     centralParts.push(centralHeader, nameBytes);
 
@@ -119,15 +163,16 @@ export function buildZipArchive(entries: ZipEntry[]): Buffer {
   const centralDirectory = Buffer.concat(centralParts);
   const centralDirectoryOffset = offset;
 
-  const endRecord = Buffer.alloc(END_OF_CENTRAL_DIRECTORY_SIZE);
-  endRecord.writeUInt32LE(END_OF_CENTRAL_DIRECTORY_SIGNATURE, 0);
-  endRecord.writeUInt16LE(0, 4); // number of this disk
-  endRecord.writeUInt16LE(0, 6); // disk where central directory starts
-  endRecord.writeUInt16LE(entries.length, 8); // central directory records on this disk
-  endRecord.writeUInt16LE(entries.length, 10); // total central directory records
-  endRecord.writeUInt32LE(centralDirectory.length, 12);
-  endRecord.writeUInt32LE(centralDirectoryOffset, 16);
-  endRecord.writeUInt16LE(0, 20); // comment length
+  const endRecord = new SequentialBufferWriter(END_OF_CENTRAL_DIRECTORY_SIZE)
+    .u32(END_OF_CENTRAL_DIRECTORY_SIGNATURE)
+    .u16(0) // number of this disk
+    .u16(0) // disk where central directory starts
+    .u16(entries.length) // central directory records on this disk
+    .u16(entries.length) // total central directory records
+    .u32(centralDirectory.length)
+    .u32(centralDirectoryOffset)
+    .u16(0) // comment length
+    .toBuffer();
 
   return Buffer.concat([...localParts, centralDirectory, endRecord]);
 }

--- a/api/_lib/types/contracts.ts
+++ b/api/_lib/types/contracts.ts
@@ -349,16 +349,21 @@ export interface SaveExportSeam {
     format: ExportFormat;
     includeMetadata?: boolean;
     includeChapters?: boolean;
+    creature?: string; // The story's actual creature, for the exported metadata
+    themes?: string[]; // The story's actual themes, for the exported metadata
   };
 
   output: {
     exportId: string;
     storyId: string;
-    downloadUrl: string; // Direct download URL for UI
+    // A self-contained `data:` URI holding the exported file. There is no
+    // object storage behind this service, so the file itself — not a link to
+    // somewhere it was uploaded — is what the caller gets back; it resolves
+    // immediately and never expires.
+    downloadUrl: string;
     filename: string;
     format: ExportFormat;
     fileSize: number;
-    expiresAt: Date; // When download URL expires
     exportedAt: Date;
   };
 
@@ -374,11 +379,6 @@ export interface SaveExportSeam {
       message: string;
       requestedFormat: ExportFormat;
       supportedFormats: ExportFormat[];
-    };
-    STORAGE_QUOTA_EXCEEDED: {
-      code: "STORAGE_QUOTA_EXCEEDED";
-      message: string;
-      quotaRemaining: number;
     };
   };
 }

--- a/shared/htmlDocumentDownload.ts
+++ b/shared/htmlDocumentDownload.ts
@@ -76,12 +76,16 @@ export interface HtmlDownloadHost<TAnchor extends DownloadAnchorLike = DownloadA
  */
 export const OBJECT_URL_REVOKE_DELAY_MS = 60_000;
 
-export function downloadHtmlDocument<TAnchor extends DownloadAnchorLike>(
-  html: string,
+/**
+ * Hand any blob to the browser as a file the reader saves, via the same
+ * attached-anchor-click sequence `downloadHtmlDocument` uses for HTML.
+ */
+export function downloadBlob<TAnchor extends DownloadAnchorLike>(
+  blob: Blob,
   filename: string,
   host: HtmlDownloadHost<TAnchor>
 ): void {
-  const url = host.createObjectUrl(new Blob([html], { type: 'text/html' }));
+  const url = host.createObjectUrl(blob);
   const link = host.document.createElement('a');
   link.href = url;
   link.download = filename;
@@ -97,6 +101,34 @@ export function downloadHtmlDocument<TAnchor extends DownloadAnchorLike>(
   }
 
   host.scheduleRevoke(() => host.revokeObjectUrl(url));
+}
+
+export function downloadHtmlDocument<TAnchor extends DownloadAnchorLike>(
+  html: string,
+  filename: string,
+  host: HtmlDownloadHost<TAnchor>
+): void {
+  downloadBlob(new Blob([html], { type: 'text/html' }), filename, host);
+}
+
+/**
+ * Decode a base64 `data:` URI into a `Blob`, so a file the backend returned
+ * inline can be handed to `downloadBlob` exactly like one built client-side.
+ */
+export function dataUriToBlob(dataUri: string): Blob {
+  const match = /^data:([^;]*);base64,(.*)$/s.exec(dataUri);
+  if (!match) {
+    throw new Error('Not a base64-encoded data: URI');
+  }
+
+  const [, mimeType, base64] = match;
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+
+  return new Blob([bytes], { type: mimeType || 'application/octet-stream' });
 }
 
 /**

--- a/story-generator/src/app/app.html
+++ b/story-generator/src/app/app.html
@@ -429,6 +429,25 @@
           >
             Download
           </button>
+          <select
+            class="ghost compact"
+            data-testid="export-format"
+            aria-label="Export format"
+            [ngModel]="selectedExportFormat()"
+            (ngModelChange)="selectedExportFormat.set($event)"
+          >
+            <option *ngFor="let format of exportFormats" [value]="format">{{ format.toUpperCase() }}</option>
+          </select>
+          <button
+            type="button"
+            class="ghost compact"
+            data-testid="export-story"
+            aria-label="Export story"
+            (click)="exportStory()"
+            [disabled]="isExporting()"
+          >
+            {{ isExporting() ? 'Exporting…' : 'Export' }}
+          </button>
           <button
             type="button"
             class="ghost compact"

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -65,6 +65,24 @@ function createSummary(overrides: Partial<StorySummary> = {}): StorySummary {
   };
 }
 
+/**
+ * Both the story-download and story-export tests drive the same
+ * attached-anchor-object-URL mechanic; sharing the spy setup keeps them from
+ * drifting into two slightly different fakes of the same browser API.
+ */
+function spyOnAttachedAnchorDownload(objectUrl: string): { anchor: HTMLAnchorElement; clickSpy: jasmine.Spy } {
+  const originalCreateElement = document.createElement.bind(document);
+  const anchor = originalCreateElement('a') as HTMLAnchorElement;
+  const clickSpy = spyOn(anchor, 'click');
+  spyOn(document, 'createElement').and.callFake((tagName: string) => {
+    return tagName.toLowerCase() === 'a' ? anchor : originalCreateElement(tagName);
+  });
+  spyOn(URL, 'createObjectURL').and.returnValue(objectUrl);
+  spyOn(URL, 'revokeObjectURL');
+
+  return { anchor, clickSpy };
+}
+
 function createState(overrides: Partial<StoryStateSnapshot> = {}): StoryStateSnapshot {
   const now = new Date().toISOString();
   return {
@@ -2683,14 +2701,7 @@ describe('App', () => {
   });
 
   it('downloads generated story HTML locally', fakeAsync(() => {
-    const originalCreateElement = document.createElement.bind(document);
-    const anchor = originalCreateElement('a') as HTMLAnchorElement;
-    const clickSpy = spyOn(anchor, 'click');
-    spyOn(document, 'createElement').and.callFake((tagName: string) => {
-      return tagName.toLowerCase() === 'a' ? anchor : originalCreateElement(tagName);
-    });
-    spyOn(URL, 'createObjectURL').and.returnValue('blob:story-download');
-    spyOn(URL, 'revokeObjectURL');
+    const { anchor, clickSpy } = spyOnAttachedAnchorDownload('blob:story-download');
     component.workbench.set({
       story: createSummary({ title: 'Downloaded Pact', synopsis: 'A pact worth keeping.' }),
       state: createState(),
@@ -2709,14 +2720,7 @@ describe('App', () => {
   }));
 
   it('exports the story in the selected format through the backend', fakeAsync(() => {
-    const originalCreateElement = document.createElement.bind(document);
-    const anchor = originalCreateElement('a') as HTMLAnchorElement;
-    const clickSpy = spyOn(anchor, 'click');
-    spyOn(document, 'createElement').and.callFake((tagName: string) => {
-      return tagName.toLowerCase() === 'a' ? anchor : originalCreateElement(tagName);
-    });
-    spyOn(URL, 'createObjectURL').and.returnValue('blob:story-export');
-    spyOn(URL, 'revokeObjectURL');
+    const { anchor, clickSpy } = spyOnAttachedAnchorDownload('blob:story-export');
 
     component.workbench.set({
       story: createSummary({ title: 'Exported Pact', synopsis: 'A pact worth exporting.' }),

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -5,6 +5,8 @@ import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
 import { App } from './app';
 import { StoryService } from './story.service';
 import { ErrorLoggingService } from './error-logging';
+import { NotificationService } from './notification.service';
+import { OBJECT_URL_REVOKE_DELAY_MS } from '../../../shared/htmlDocumentDownload';
 import {
   ApiResponse,
   CloudStoryProjectDeleteReceipt,
@@ -18,6 +20,7 @@ import {
   CloudStoryProjectSaveReceipt,
   GeneratedChapter,
   ImageGenerationSeam,
+  SaveExportSeam,
   SavedStoryProject
 } from './contracts';
 
@@ -308,7 +311,8 @@ describe('App', () => {
       'saveCloudStoryProject',
       'loadCloudStoryProject',
       'deleteCloudStoryProject',
-      'generateImage'
+      'generateImage',
+      'exportStory'
     ]);
     const errorLoggingSpy = jasmine.createSpyObj<ErrorLoggingService>('ErrorLoggingService', [
       'logInfo',
@@ -2703,4 +2707,71 @@ describe('App', () => {
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:story-download');
     expect(component.statusMessage()).toBe('Story download created.');
   }));
+
+  it('exports the story in the selected format through the backend', fakeAsync(() => {
+    const originalCreateElement = document.createElement.bind(document);
+    const anchor = originalCreateElement('a') as HTMLAnchorElement;
+    const clickSpy = spyOn(anchor, 'click');
+    spyOn(document, 'createElement').and.callFake((tagName: string) => {
+      return tagName.toLowerCase() === 'a' ? anchor : originalCreateElement(tagName);
+    });
+    spyOn(URL, 'createObjectURL').and.returnValue('blob:story-export');
+    spyOn(URL, 'revokeObjectURL');
+
+    component.workbench.set({
+      story: createSummary({ title: 'Exported Pact', synopsis: 'A pact worth exporting.' }),
+      state: createState(),
+      chapterHistory: [createChapter({ title: 'First Ember', htmlContent: '<p>Heat rose.</p>' })],
+      activeBatchSize: 1
+    });
+    component.selectedExportFormat.set('epub');
+
+    const exportOutput: SaveExportSeam['output'] = {
+      exportId: 'export-1',
+      storyId: component.workbench().story!.storyId,
+      downloadUrl: 'data:application/epub+zip;base64,QUJD',
+      filename: 'exported-pact.epub',
+      format: 'epub',
+      fileSize: 3,
+      exportedAt: new Date()
+    };
+    storyService.exportStory.and.returnValue(of({ success: true, data: exportOutput }));
+
+    component.exportStory();
+
+    expect(storyService.exportStory).toHaveBeenCalledWith(jasmine.objectContaining({
+      storyId: component.workbench().story!.storyId,
+      title: 'Exported Pact',
+      format: 'epub',
+      creature: component.blueprint().creature
+    }));
+    expect(component.isExporting()).toBeFalse();
+    expect(anchor.download).toBe('exported-pact.epub');
+    expect(clickSpy).toHaveBeenCalled();
+    // The revoke is scheduled `OBJECT_URL_REVOKE_DELAY_MS` out, not on the next
+    // microtask — `tick()` with no argument only flushes 0ms and never reaches it.
+    tick(OBJECT_URL_REVOKE_DELAY_MS);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:story-export');
+  }));
+
+  it('reports an error instead of downloading when export fails', () => {
+    const notificationService = TestBed.inject(NotificationService);
+    component.workbench.set({
+      story: createSummary({ title: 'Failed Pact' }),
+      state: createState(),
+      chapterHistory: [createChapter({ title: 'First Ember', htmlContent: '<p>Heat rose.</p>' })],
+      activeBatchSize: 1
+    });
+    storyService.exportStory.and.returnValue(of({
+      success: false,
+      error: { code: 'FORMAT_NOT_SUPPORTED', message: 'Format not supported', requestedFormat: 'epub', supportedFormats: ['pdf'] }
+    }));
+
+    component.exportStory();
+
+    expect(component.isExporting()).toBeFalse();
+    const notifications = notificationService.notifications();
+    expect(notifications[0]?.type).toBe('error');
+    expect(notifications[0]?.message).toBe('Format not supported');
+  });
 });

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -66,6 +66,21 @@ function createSummary(overrides: Partial<StorySummary> = {}): StorySummary {
 }
 
 /**
+ * Seeds a workbench with one story and one chapter — the minimum the
+ * download and export actions need to have something to act on. Several of
+ * their tests differ only in the story's title/synopsis, which this takes as
+ * an override rather than each test rebuilding the whole session shape.
+ */
+function seedWorkbenchWithSingleChapter(component: App, storyOverrides: Partial<StorySummary> = {}): void {
+  component.workbench.set({
+    story: createSummary(storyOverrides),
+    state: createState(),
+    chapterHistory: [createChapter({ title: 'First Ember', htmlContent: '<p>Heat rose.</p>' })],
+    activeBatchSize: 1
+  });
+}
+
+/**
  * Both the story-download and story-export tests drive the same
  * attached-anchor-object-URL mechanic; sharing the spy setup keeps them from
  * drifting into two slightly different fakes of the same browser API.
@@ -2702,12 +2717,7 @@ describe('App', () => {
 
   it('downloads generated story HTML locally', fakeAsync(() => {
     const { anchor, clickSpy } = spyOnAttachedAnchorDownload('blob:story-download');
-    component.workbench.set({
-      story: createSummary({ title: 'Downloaded Pact', synopsis: 'A pact worth keeping.' }),
-      state: createState(),
-      chapterHistory: [createChapter({ title: 'First Ember', htmlContent: '<p>Heat rose.</p>' })],
-      activeBatchSize: 1
-    });
+    seedWorkbenchWithSingleChapter(component, { title: 'Downloaded Pact', synopsis: 'A pact worth keeping.' });
 
     component.downloadStory();
 
@@ -2722,12 +2732,7 @@ describe('App', () => {
   it('exports the story in the selected format through the backend', fakeAsync(() => {
     const { anchor, clickSpy } = spyOnAttachedAnchorDownload('blob:story-export');
 
-    component.workbench.set({
-      story: createSummary({ title: 'Exported Pact', synopsis: 'A pact worth exporting.' }),
-      state: createState(),
-      chapterHistory: [createChapter({ title: 'First Ember', htmlContent: '<p>Heat rose.</p>' })],
-      activeBatchSize: 1
-    });
+    seedWorkbenchWithSingleChapter(component, { title: 'Exported Pact', synopsis: 'A pact worth exporting.' });
     component.selectedExportFormat.set('epub');
 
     const exportOutput: SaveExportSeam['output'] = {
@@ -2760,12 +2765,7 @@ describe('App', () => {
 
   it('reports an error instead of downloading when export fails', () => {
     const notificationService = TestBed.inject(NotificationService);
-    component.workbench.set({
-      story: createSummary({ title: 'Failed Pact' }),
-      state: createState(),
-      chapterHistory: [createChapter({ title: 'First Ember', htmlContent: '<p>Heat rose.</p>' })],
-      activeBatchSize: 1
-    });
+    seedWorkbenchWithSingleChapter(component, { title: 'Failed Pact' });
     storyService.exportStory.and.returnValue(of({
       success: false,
       error: { code: 'FORMAT_NOT_SUPPORTED', message: 'Format not supported', requestedFormat: 'epub', supportedFormats: ['pdf'] }

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -8,6 +8,8 @@ import { Subscription, map } from 'rxjs';
 import { splitStoryIntoTextBlocks } from '../../../api/_lib/utils/storyTextBlocks';
 import {
   createBrowserHtmlDownloadHost,
+  dataUriToBlob,
+  downloadBlob,
   downloadHtmlDocument
 } from '../../../shared/htmlDocumentDownload';
 import { BlueprintValidationField, FormValidationService } from './form-validation.service';
@@ -19,6 +21,7 @@ import {
   CloudStoryProjectListItem,
   ContinuityPanelViewModel,
   CreatureArchetype,
+  ExportFormat,
   GeneratedChapter,
   HeatContract,
   HeatIntimacyBoundary,
@@ -405,6 +408,9 @@ export class App implements OnDestroy {
   readonly isGeneratingImage = signal(false);
   readonly generatedChapterImage = signal<{ chapterId: string; image: ImageGenerationSeam['output'] } | null>(null);
   readonly imageGenerationError = signal<string | null>(null);
+  readonly exportFormats: ExportFormat[] = ['txt', 'pdf', 'epub', 'docx'];
+  readonly selectedExportFormat = signal<ExportFormat>('txt');
+  readonly isExporting = signal(false);
   readonly statusMessage = signal<string>('Tell us what kind of enchanted, spicy story you want.');
   readonly workspaceSaveStatus = signal<string>('No saved stories in this browser yet.');
   readonly savedProjects = signal<SavedStoryProject[]>([]);
@@ -1377,31 +1383,88 @@ export class App implements OnDestroy {
     }
 
     const safeTitle = this.safeFileName(session.story.title);
+    const html = this.buildStoryHtmlDocument(session);
+    downloadHtmlDocument(html, `${safeTitle}.html`, createBrowserHtmlDownloadHost(document, URL));
+    this.statusMessage.set('Story download created.');
+  }
+
+  private buildStoryHtmlDocument(session: StoryWorkbenchSession): string {
+    const story = session.story!;
     const chapters = session.chapterHistory
       .map(chapter => {
         const body = this.getSafeHtml(chapter.htmlContent);
         return `<section><h2>Chapter ${chapter.chapterNumber}: ${this.escapeHtml(chapter.title)}</h2>${body}</section>`;
       })
       .join('\n');
-    const html = `<!doctype html>
+
+    return `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>${this.escapeHtml(session.story.title)}</title>
+<title>${this.escapeHtml(story.title)}</title>
 <style>
 body{font-family:Georgia,serif;line-height:1.65;max-width:760px;margin:40px auto;padding:0 20px;color:#251914;background:#fff8ee}
 h1,h2{line-height:1.15}hr{border:0;border-top:1px solid #d8c5aa;margin:28px 0}
 </style>
 </head>
 <body>
-<h1>${this.escapeHtml(session.story.title)}</h1>
-<p>${this.escapeHtml(session.story.synopsis)}</p>
+<h1>${this.escapeHtml(story.title)}</h1>
+<p>${this.escapeHtml(story.synopsis)}</p>
 <hr>
 ${chapters}
 </body>
 </html>`;
-    downloadHtmlDocument(html, `${safeTitle}.html`, createBrowserHtmlDownloadHost(document, URL));
-    this.statusMessage.set('Story download created.');
+  }
+
+  exportStory() {
+    const session = this.workbench();
+    if (!session.story || !session.chapterHistory.length) {
+      this.notificationService.warning('Nothing to export', 'Generate a story first.');
+      return;
+    }
+
+    if (this.isExporting()) {
+      return;
+    }
+
+    const story = session.story;
+    const format = this.selectedExportFormat();
+    const safeTitle = this.safeFileName(story.title);
+
+    this.isExporting.set(true);
+
+    this.storyService
+      .exportStory({
+        storyId: story.storyId,
+        title: story.title,
+        content: this.buildStoryHtmlDocument(session),
+        format,
+        includeMetadata: true,
+        creature: this.blueprint().creature,
+        themes: this.blueprint().themes.map(theme => theme.id)
+      })
+      .subscribe({
+        next: response => {
+          this.isExporting.set(false);
+
+          if (response.success) {
+            downloadBlob(
+              dataUriToBlob(response.data.downloadUrl),
+              response.data.filename,
+              createBrowserHtmlDownloadHost(document, URL)
+            );
+            this.notificationService.success('Export ready', `${format.toUpperCase()} export created.`);
+            this.statusMessage.set(`${format.toUpperCase()} export created.`);
+          } else {
+            const message = response.error?.message ?? 'Export failed.';
+            this.notificationService.error('Export failed', message);
+          }
+        },
+        error: () => {
+          this.isExporting.set(false);
+          this.notificationService.error('Export failed', 'Could not reach the export service.');
+        }
+      });
   }
 
   generateChapterImage() {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -1376,16 +1376,33 @@ export class App implements OnDestroy {
   }
 
   downloadStory() {
-    const session = this.workbench();
-    if (!session.story || !session.chapterHistory.length) {
-      this.notificationService.warning('Nothing to download', 'Generate a story first.');
+    const exportable = this.requireExportableStory('download');
+    if (!exportable) {
       return;
     }
 
-    const safeTitle = this.safeFileName(session.story.title);
+    const { session, story } = exportable;
+    const safeTitle = this.safeFileName(story.title);
     const html = this.buildStoryHtmlDocument(session);
     downloadHtmlDocument(html, `${safeTitle}.html`, createBrowserHtmlDownloadHost(document, URL));
     this.statusMessage.set('Story download created.');
+  }
+
+  /**
+   * The story-download and story-export actions both need a generated story
+   * to act on and both refuse the same way when there isn't one; shared so
+   * that refusal can't drift between the two buttons that show it.
+   */
+  private requireExportableStory(
+    actionLabel: string
+  ): { session: StoryWorkbenchSession; story: NonNullable<StoryWorkbenchSession['story']> } | null {
+    const session = this.workbench();
+    if (!session.story || !session.chapterHistory.length) {
+      this.notificationService.warning(`Nothing to ${actionLabel}`, 'Generate a story first.');
+      return null;
+    }
+
+    return { session, story: session.story };
   }
 
   private buildStoryHtmlDocument(session: StoryWorkbenchSession): string {
@@ -1417,17 +1434,16 @@ ${chapters}
   }
 
   exportStory() {
-    const session = this.workbench();
-    if (!session.story || !session.chapterHistory.length) {
-      this.notificationService.warning('Nothing to export', 'Generate a story first.');
-      return;
-    }
-
     if (this.isExporting()) {
       return;
     }
 
-    const story = session.story;
+    const exportable = this.requireExportableStory('export');
+    if (!exportable) {
+      return;
+    }
+
+    const { session, story } = exportable;
     const format = this.selectedExportFormat();
     const safeTitle = this.safeFileName(story.title);
 

--- a/story-generator/src/app/contracts.ts
+++ b/story-generator/src/app/contracts.ts
@@ -28,6 +28,7 @@ export type WordBudget = 600 | 900 | 1200 | 1500;
 export type HeatTensionMode = 'slow_burn' | 'dangerous_proximity' | 'playful_banter' | 'devotional_longing';
 export type HeatIntimacyBoundary = 'fade_to_black' | 'closed_door' | 'literary_on_page';
 export type ImageStyle = 'artistic' | 'photorealistic' | 'fantasy' | 'dark' | 'romantic';
+export type ExportFormat = 'pdf' | 'txt' | 'html' | 'epub' | 'docx';
 
 export const IMAGE_STYLES = [
   'artistic',
@@ -480,6 +481,49 @@ export interface ImageGenerationSeam {
       message: string;
       quotaRemaining: number;
       resetTime: Date;
+    };
+  };
+}
+
+export interface SaveExportSeam {
+  seamName: 'Story Data → Save/Export System';
+  description: 'Saves or exports story data in various formats';
+
+  input: {
+    storyId: string;
+    content: string; // Full story HTML content
+    title: string;
+    format: ExportFormat;
+    includeMetadata?: boolean;
+    includeChapters?: boolean;
+    creature?: string;
+    themes?: string[];
+  };
+
+  output: {
+    exportId: string;
+    storyId: string;
+    // A self-contained `data:` URI holding the exported file — no separate
+    // fetch is needed to retrieve it.
+    downloadUrl: string;
+    filename: string;
+    format: ExportFormat;
+    fileSize: number;
+    exportedAt: Date;
+  };
+
+  errors: {
+    EXPORT_FAILED: {
+      code: 'EXPORT_FAILED';
+      message: string;
+      retryable: boolean;
+      format: ExportFormat;
+    };
+    FORMAT_NOT_SUPPORTED: {
+      code: 'FORMAT_NOT_SUPPORTED';
+      message: string;
+      requestedFormat: ExportFormat;
+      supportedFormats: ExportFormat[];
     };
   };
 }

--- a/story-generator/src/app/contracts.ts
+++ b/story-generator/src/app/contracts.ts
@@ -28,7 +28,13 @@ export type WordBudget = 600 | 900 | 1200 | 1500;
 export type HeatTensionMode = 'slow_burn' | 'dangerous_proximity' | 'playful_banter' | 'devotional_longing';
 export type HeatIntimacyBoundary = 'fade_to_black' | 'closed_door' | 'literary_on_page';
 export type ImageStyle = 'artistic' | 'photorealistic' | 'fantasy' | 'dark' | 'romantic';
-export type ExportFormat = 'pdf' | 'txt' | 'html' | 'epub' | 'docx';
+
+// `ExportFormat` and `SaveExportSeam` are re-exported from the backend's own
+// contract rather than redeclared here: the export pipeline runs entirely in
+// `api/_lib`, so its seam has exactly one definition instead of two that could
+// drift the way the classic `/api/story/*` routes already had (see
+// `expressApiRoutes.ts`).
+export type { ExportFormat, SaveExportSeam } from '../../../api/_lib/types/contracts';
 
 export const IMAGE_STYLES = [
   'artistic',
@@ -481,49 +487,6 @@ export interface ImageGenerationSeam {
       message: string;
       quotaRemaining: number;
       resetTime: Date;
-    };
-  };
-}
-
-export interface SaveExportSeam {
-  seamName: 'Story Data → Save/Export System';
-  description: 'Saves or exports story data in various formats';
-
-  input: {
-    storyId: string;
-    content: string; // Full story HTML content
-    title: string;
-    format: ExportFormat;
-    includeMetadata?: boolean;
-    includeChapters?: boolean;
-    creature?: string;
-    themes?: string[];
-  };
-
-  output: {
-    exportId: string;
-    storyId: string;
-    // A self-contained `data:` URI holding the exported file — no separate
-    // fetch is needed to retrieve it.
-    downloadUrl: string;
-    filename: string;
-    format: ExportFormat;
-    fileSize: number;
-    exportedAt: Date;
-  };
-
-  errors: {
-    EXPORT_FAILED: {
-      code: 'EXPORT_FAILED';
-      message: string;
-      retryable: boolean;
-      format: ExportFormat;
-    };
-    FORMAT_NOT_SUPPORTED: {
-      code: 'FORMAT_NOT_SUPPORTED';
-      message: string;
-      requestedFormat: ExportFormat;
-      supportedFormats: ExportFormat[];
     };
   };
 }

--- a/story-generator/src/app/story.service.ts
+++ b/story-generator/src/app/story.service.ts
@@ -9,6 +9,7 @@ import {
   CloudStoryProjectLoadResult,
   CloudStoryProjectSaveReceipt,
   ImageGenerationSeam,
+  SaveExportSeam,
   SavedStoryProject,
   StoryGenerationSeam,
   StoryIterationPayload,
@@ -362,6 +363,17 @@ export class StoryService {
     return this.http
       .post<ApiResponse<ImageGenerationSeam['output']>>('/api/image/generate', input)
       .pipe(catchError(error => this.handleHttpError(error, 'generateImage')));
+  }
+
+  exportStory(input: SaveExportSeam['input']): Observable<ApiResponse<SaveExportSeam['output']>> {
+    this.errorLogging.logInfo('Requesting story export', 'StoryService.exportStory', {
+      storyId: input.storyId,
+      format: input.format
+    });
+
+    return this.http
+      .post<ApiResponse<SaveExportSeam['output']>>('/api/export/save', input)
+      .pipe(catchError(error => this.handleHttpError(error, 'exportStory')));
   }
 
   private handleHttpError(error: HttpErrorResponse, context: string) {

--- a/tests/export-service.test.ts
+++ b/tests/export-service.test.ts
@@ -2,7 +2,7 @@
 // Created: 2026-08-24 18:05 UTC
 
 import { ExportService } from '../api/_lib/services/exportService';
-import { readZipEntries } from '../api/_lib/services/zipArchive';
+import { readZipEntries, ZipEntry } from '../api/_lib/services/zipArchive';
 import { SaveExportSeam } from '../api/_lib/types/contracts';
 
 function assert(condition: unknown, message: string): asserts condition {
@@ -137,6 +137,20 @@ async function pdfTextOf(input: SaveExportSeam['input']): Promise<string> {
   return document.toString('utf8');
 }
 
+/**
+ * Confirm a document is actually a zip archive, then read its entries back by
+ * path — the check both the epub and docx tests below start from, since both
+ * formats used to be plain text made to merely *look* like a zip.
+ */
+function readAsRealZipContainer(document: Buffer, formatLabel: string): Map<string, ZipEntry> {
+  assert(
+    document.subarray(0, 4).equals(Buffer.from([0x50, 0x4b, 0x03, 0x04])),
+    `a ${formatLabel} should start with a zip local file header signature`
+  );
+
+  return new Map(readZipEntries(document).map(entry => [entry.path, entry]));
+}
+
 // The EPUB used to be a bare, unzipped OPF XML fragment referencing a
 // `chapter1.xhtml` that was never produced — not a real `.epub` (a zip
 // container) at all. This confirms it now is one: `mimetype` first and
@@ -147,12 +161,9 @@ async function testEpubIsARealZipContainerWithItsChapter(): Promise<void> {
     createInput({ format: 'epub', title: 'Élodie & the Dragon' })
   );
 
-  assert(document.subarray(0, 4).equals(Buffer.from([0x50, 0x4b, 0x03, 0x04])), 'an epub should start with a zip local file header signature');
+  const byPath = readAsRealZipContainer(document, 'epub');
 
-  const entries = readZipEntries(document);
-  const byPath = new Map(entries.map(entry => [entry.path, entry]));
-
-  assert(entries[0]?.path === 'mimetype', 'mimetype must be the first entry in an epub');
+  assert(byPath.keys().next().value === 'mimetype', 'mimetype must be the first entry in an epub');
   assert(
     byPath.get('mimetype')?.data.toString('ascii') === 'application/epub+zip',
     'the mimetype entry should hold the epub media type verbatim'
@@ -185,10 +196,7 @@ async function testDocxIsARealZipContainerWithItsDocument(): Promise<void> {
     createInput({ format: 'docx', title: 'Midnight Bargain' })
   );
 
-  assert(document.subarray(0, 4).equals(Buffer.from([0x50, 0x4b, 0x03, 0x04])), 'a docx should start with a zip local file header signature');
-
-  const entries = readZipEntries(document);
-  const byPath = new Map(entries.map(entry => [entry.path, entry]));
+  const byPath = readAsRealZipContainer(document, 'docx');
 
   for (const requiredPart of ['[Content_Types].xml', '_rels/.rels', 'word/document.xml']) {
     assert(byPath.has(requiredPart), `a docx should contain ${requiredPart}`);

--- a/tests/export-service.test.ts
+++ b/tests/export-service.test.ts
@@ -2,6 +2,7 @@
 // Created: 2026-08-24 18:05 UTC
 
 import { ExportService } from '../api/_lib/services/exportService';
+import { readZipEntries } from '../api/_lib/services/zipArchive';
 import { SaveExportSeam } from '../api/_lib/types/contracts';
 
 function assert(condition: unknown, message: string): asserts condition {
@@ -23,25 +24,31 @@ function createInput(overrides: Partial<SaveExportSeam['input']> = {}): SaveExpo
   };
 }
 
-// The filename carries a `Date.now()` stamp. It used to be generated twice —
-// once inside `saveToStorage` and again for the response — with the mock
-// upload's 300ms delay in between, so the two stamps never matched and the
-// client was handed a download URL that did not point at the filename it was
-// told to save under.
-async function testDownloadUrlMatchesReportedFilename(): Promise<void> {
+// There is no object storage behind this service: the exported bytes are
+// handed back directly as a `data:` URI. It used to be a mock upload that
+// returned a URL pointing at `storage.example.com` — a link that resolved
+// nowhere — so this now checks the URI actually carries the exported bytes,
+// not merely that it is shaped like one.
+async function testDownloadUrlCarriesTheExportedBytes(): Promise<void> {
   const exportService = new ExportService();
 
-  for (const format of ['txt', 'html', 'pdf'] as const) {
-    const result = await exportService.saveAndExport(createInput({ format }));
+  for (const format of ['txt', 'html', 'pdf', 'epub', 'docx'] as const) {
+    const input = createInput({ format });
+    const result = await exportService.saveAndExport(input);
+    const content = await exportService.generateExportContent(input);
 
     assert(result.success, `${format} export should succeed`);
     const output = result.data as SaveExportSeam['output'];
-    assert(
-      output.downloadUrl.endsWith(`/exports/${output.filename}`),
-      `${format} download URL should end with the reported filename ` +
-        `(url=${output.downloadUrl}, filename=${output.filename})`
-    );
     assert(output.filename.endsWith(`.${format}`), `${format} filename should keep the requested extension`);
+
+    const dataUriMatch = /^data:([^;]+);base64,(.+)$/.exec(output.downloadUrl);
+    assert(dataUriMatch, `${format} downloadUrl should be a data: URI (got ${output.downloadUrl.slice(0, 40)}...)`);
+    const decoded = Buffer.from(dataUriMatch[2], 'base64');
+    assert(
+      decoded.equals(content),
+      `${format} downloadUrl should decode to exactly the exported document's bytes`
+    );
+    assert(output.fileSize === content.length, `${format} fileSize should equal the exported document's byte length`);
   }
 }
 
@@ -84,9 +91,7 @@ async function exportedSizeOf(content: string): Promise<number> {
 // of the whole story, not the byte count of the short stream it actually
 // writes — so the declared span ran far past `endstream`.
 async function testPdfStreamLengthDescribesTheStream(): Promise<void> {
-  const document = await new ExportService().generateExportContent(
-    createInput({ format: 'pdf', content: unicodeStory })
-  );
+  const document = await pdfTextOf(createInput({ format: 'pdf', content: unicodeStory }));
 
   const declaredLength = Number(/\/Length (\d+)/.exec(document)?.[1]);
   const streamBody = extractPdfStreamBody(document);
@@ -107,9 +112,7 @@ async function testPdfStreamLengthDescribesTheStream(): Promise<void> {
 async function testPdfExcerptIsCutOnCharacterBoundaries(): Promise<void> {
   for (const boundary of ['(spice)', '🐉 tail']) {
     const content = `<p>${'x'.repeat(99)}${boundary}</p>`;
-    const document = await new ExportService().generateExportContent(
-      createInput({ format: 'pdf', content })
-    );
+    const document = await pdfTextOf(createInput({ format: 'pdf', content }));
     const streamBody = extractPdfStreamBody(document);
 
     assert(
@@ -129,25 +132,77 @@ function extractPdfStreamBody(document: string): string {
   return match[1];
 }
 
-// The EPUB package document writes its metadata with the `dc:` prefix. The
-// prefix was never bound to a namespace, so the document was not well-formed
-// XML and a conforming reader rejects it before reading any of the metadata.
-async function testEpubBindsEveryNamespacePrefixItUses(): Promise<void> {
+async function pdfTextOf(input: SaveExportSeam['input']): Promise<string> {
+  const document = await new ExportService().generateExportContent(input);
+  return document.toString('utf8');
+}
+
+// The EPUB used to be a bare, unzipped OPF XML fragment referencing a
+// `chapter1.xhtml` that was never produced — not a real `.epub` (a zip
+// container) at all. This confirms it now is one: `mimetype` first and
+// stored, the OCF pointer resolving to the package document, and the chapter
+// the package document references actually existing and holding the story.
+async function testEpubIsARealZipContainerWithItsChapter(): Promise<void> {
   const document = await new ExportService().generateExportContent(
-    createInput({ format: 'epub' })
+    createInput({ format: 'epub', title: 'Élodie & the Dragon' })
   );
 
-  const usedPrefixes = new Set(
-    Array.from(document.matchAll(/<\/?([A-Za-z][\w.-]*):/g), match => match[1])
+  assert(document.subarray(0, 4).equals(Buffer.from([0x50, 0x4b, 0x03, 0x04])), 'an epub should start with a zip local file header signature');
+
+  const entries = readZipEntries(document);
+  const byPath = new Map(entries.map(entry => [entry.path, entry]));
+
+  assert(entries[0]?.path === 'mimetype', 'mimetype must be the first entry in an epub');
+  assert(
+    byPath.get('mimetype')?.data.toString('ascii') === 'application/epub+zip',
+    'the mimetype entry should hold the epub media type verbatim'
   );
 
-  assert(usedPrefixes.has('dc'), 'the package document should still carry Dublin Core metadata');
+  const containerXml = byPath.get('META-INF/container.xml')?.data.toString('utf8');
+  assert(containerXml?.includes('OEBPS/content.opf'), 'container.xml should point at the package document');
+
+  const contentOpf = byPath.get('OEBPS/content.opf')?.data.toString('utf8');
+  assert(contentOpf, 'the package document should exist');
+  assert(contentOpf.includes('Élodie &amp; the Dragon'), 'the package document should carry the escaped title');
+  assert(contentOpf.includes('href="chapter1.xhtml"'), 'the package document should reference the chapter it ships');
+
+  const usedPrefixes = new Set(Array.from(contentOpf.matchAll(/<\/?([A-Za-z][\w.-]*):/g), match => match[1]));
   for (const prefix of usedPrefixes) {
-    assert(
-      document.includes(`xmlns:${prefix}="`),
-      `the \`${prefix}:\` prefix should be bound to a namespace on the package element`
-    );
+    assert(contentOpf.includes(`xmlns:${prefix}="`), `the \`${prefix}:\` prefix should be bound to a namespace`);
   }
+
+  const chapter = byPath.get('OEBPS/chapter1.xhtml')?.data.toString('utf8');
+  assert(chapter, 'the chapter the package document references should actually exist');
+  assert(chapter.includes('Élodie smiled'), 'the chapter should contain the real story content');
+}
+
+// The DOCX used to be literal text made to *look* like a zip's local-file-header
+// strings, concatenated with escaped plain text — not a valid archive. This
+// confirms the required OOXML package parts exist and the document body holds
+// the actual story.
+async function testDocxIsARealZipContainerWithItsDocument(): Promise<void> {
+  const document = await new ExportService().generateExportContent(
+    createInput({ format: 'docx', title: 'Midnight Bargain' })
+  );
+
+  assert(document.subarray(0, 4).equals(Buffer.from([0x50, 0x4b, 0x03, 0x04])), 'a docx should start with a zip local file header signature');
+
+  const entries = readZipEntries(document);
+  const byPath = new Map(entries.map(entry => [entry.path, entry]));
+
+  for (const requiredPart of ['[Content_Types].xml', '_rels/.rels', 'word/document.xml']) {
+    assert(byPath.has(requiredPart), `a docx should contain ${requiredPart}`);
+  }
+
+  const contentTypes = byPath.get('[Content_Types].xml')!.data.toString('utf8');
+  assert(contentTypes.includes('/word/document.xml'), 'Content_Types should declare the document part');
+
+  const rels = byPath.get('_rels/.rels')!.data.toString('utf8');
+  assert(rels.includes('word/document.xml'), 'the package relationships should point at the document part');
+
+  const documentXml = byPath.get('word/document.xml')!.data.toString('utf8');
+  assert(documentXml.includes('Midnight Bargain'), 'the document body should include the title');
+  assert(documentXml.includes('Élodie smiled'), 'the document body should include the real story content');
 }
 
 // A reader resolves an object by seeking to the byte offset the xref table
@@ -158,10 +213,10 @@ async function testPdfCrossReferenceTablePointsAtItsObjects(): Promise<void> {
   const exportService = new ExportService();
 
   for (const title of ['A', 'Midnight Bargain', 'Élodie and the 🐉 of the Château (Part Two)']) {
-    const document = await exportService.generateExportContent(
+    const bytes = await exportService.generateExportContent(
       createInput({ format: 'pdf', title, content: unicodeStory.repeat(4) })
     );
-    const bytes = Buffer.from(document, 'utf8');
+    const document = bytes.toString('utf8');
 
     const startxref = /startxref\n(\d+)\n%%EOF$/.exec(document);
     assert(startxref, `the PDF for "${title}" should end with a startxref offset`);
@@ -264,7 +319,7 @@ async function testFilenamesStayReadableAndPortable(): Promise<void> {
  */
 async function testPlainTextExportKeepsEveryBlockBreak(): Promise<void> {
   const exportService = new ExportService();
-  const text = await exportService.generateExportContent(createInput({
+  const buffer = await exportService.generateExportContent(createInput({
     content: [
       '<h4>The Vault</h4>',
       '<div>She opened the door.</div>',
@@ -272,6 +327,7 @@ async function testPlainTextExportKeepsEveryBlockBreak(): Promise<void> {
       '<table><tr><td>Cell A</td><td>Cell B</td></tr></table>'
     ].join('')
   }));
+  const text = buffer.toString('utf8');
 
   for (const [left, right] of [
     ['The Vault', 'She opened the door.'],
@@ -293,6 +349,35 @@ async function testPlainTextExportKeepsEveryBlockBreak(): Promise<void> {
   assert(!/\n{3,}/.test(text), `no run of blank lines should open up (got ${JSON.stringify(text)})`);
 }
 
+// The metadata used to be hardcoded to `creature: 'vampire'` and
+// `themes: ['romance', 'dark']` for every export, regardless of what story was
+// actually exported. The caller now supplies the real values.
+async function testMetadataReflectsTheActualStory(): Promise<void> {
+  const exportService = new ExportService();
+
+  const withMetadata = await exportService.generateExportContent(createInput({
+    format: 'txt',
+    includeMetadata: true,
+    creature: 'werewolf',
+    themes: ['mystery', 'adventure']
+  }));
+  const text = withMetadata.toString('utf8');
+
+  assert(text.includes('Creature: werewolf'), `export should carry the passed creature (got ${JSON.stringify(text)})`);
+  assert(text.includes('Themes: mystery, adventure'), `export should carry the passed themes (got ${JSON.stringify(text)})`);
+  assert(!text.includes('vampire'), 'export should not fall back to the old hardcoded creature');
+  assert(!text.includes('romance, dark'), 'export should not fall back to the old hardcoded themes');
+
+  const withoutMetadataInput = await exportService.generateExportContent(createInput({
+    format: 'txt',
+    includeMetadata: true
+  }));
+  assert(
+    withoutMetadataInput.toString('utf8').includes('Creature: unknown'),
+    'an export with no creature supplied should say so honestly rather than guessing one'
+  );
+}
+
 function escapeForAssertion(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
@@ -300,12 +385,14 @@ function escapeForAssertion(value: string): string {
 async function main(): Promise<void> {
   await testPlainTextExportKeepsEveryBlockBreak();
   await testFilenamesStayReadableAndPortable();
-  await testDownloadUrlMatchesReportedFilename();
+  await testDownloadUrlCarriesTheExportedBytes();
   await testPdfCrossReferenceTablePointsAtItsObjects();
   await testFileSizeIsMeasuredInBytes();
   await testPdfStreamLengthDescribesTheStream();
   await testPdfExcerptIsCutOnCharacterBoundaries();
-  await testEpubBindsEveryNamespacePrefixItUses();
+  await testEpubIsARealZipContainerWithItsChapter();
+  await testDocxIsARealZipContainerWithItsDocument();
+  await testMetadataReflectsTheActualStory();
 
   console.log('Export service tests passed');
 }


### PR DESCRIPTION
## Worst-to-Best routine

Plan was posted to `#claude-routines` and `@codex` was tagged for critique; no critique arrived after ~20 minutes of waiting (same pattern noted in the prior three runs — the workspace's `chatgpt-codex-connector` doesn't reliably respond to mentions), so this executes on the posted plan. No corrections were needed to the plan itself.

### Feature chosen: Story Export/Download (`api/export/save.ts`, `ExportService`, and the app's "Download" action)

### Why it was the worst-implemented feature in the app

1. **Two disconnected implementations.** The live "Download" button (`app.ts:downloadStory()`) built a single HTML-only blob client-side. The backend — `ExportService` (454 lines), a dedicated `exportSanitizer.ts` (545 lines), and a test file — implements PDF/HTML/TXT/EPUB/DOCX export, and was never called by the app: grepped the whole frontend, zero references, and `expressApiRoutes.ts:20` even comments that it isn't.
2. **Fake even on its own terms.** `generateEPUBContent`/`generateDOCXContent` returned plain text made to *look* like zip-container strings — not real ZIP archives — so no EPUB/DOCX reader could open the files.
3. **A mock upload sold as real.** `saveToStorage()` faked a successful upload (a 300ms `setTimeout` + string concatenation) and returned a `downloadUrl` pointing at `https://storage.example.com` — a link that resolves nowhere, returned with `success: true`.
4. **Hardcoded metadata.** `generateMetadata()` always returned `creature: 'vampire'` and `themes: ['romance', 'dark']`, regardless of what story was actually exported.
5. **Tests that couldn't have caught any of this.** `tests/export-service.test.ts` only asserted on string shape (URL suffix, filename extension) — never that the produced files were actually valid PDFs/EPUBs/DOCXs, or that the metadata reflected the real story.

### What changed

1. Added a minimal, dependency-free ZIP writer/reader (`api/_lib/services/zipArchive.ts`, STORE method — no compression dependency needed for files this small), matching this codebase's existing hand-rolled-bytes style (the PDF generator already assembles real PDF objects/xref tables by hand).
2. Rewrote EPUB generation into a real, spec-compliant EPUB 3 container: `mimetype` (stored, uncompressed, first entry), `META-INF/container.xml`, `OEBPS/content.opf`, `OEBPS/nav.xhtml`, and `OEBPS/chapter1.xhtml` — actually containing the story, where the old version referenced a chapter file it never wrote.
3. Rewrote DOCX generation into a real, minimal OOXML `.docx` (`[Content_Types].xml`, `_rels/.rels`, `word/document.xml`) via the same zip writer.
4. Dropped the fake `saveToStorage` roundtrip. There is no object storage anywhere in this project, so the exported bytes are now returned directly as a self-contained `data:` URI — it resolves immediately, in the same response, with nothing left to expire (removed the now-meaningless `expiresAt` field and `STORAGE_QUOTA_EXCEEDED` error from the `SaveExportSeam` contract).
5. Added optional `creature`/`themes` to `SaveExportSeam['input']`; the service now uses the caller's real values (falling back to an honest `'unknown'`/`[]`, not a fabricated specific answer) instead of hardcoding them.
6. Wired the frontend: added a format picker (txt/pdf/epub/docx) and an "Export" action next to the existing Download button, calling the real backend via a new `StoryService.exportStory()`. The existing client-side HTML download path is untouched. Generalized `shared/htmlDocumentDownload.ts` with a `downloadBlob`/`dataUriToBlob` pair so the new formats reuse the same tested attached-anchor-click download mechanic.
7. Rewrote `tests/export-service.test.ts`: EPUB/DOCX are now verified by actually reading back the zip structure (local-file-header signature, `mimetype` stored-and-first, required parts present, chapter/document containing the real story text), the `downloadUrl` is verified to decode to the exact exported bytes, and a new test confirms metadata reflects the passed-in creature/themes rather than the old hardcoded values.

### Verification

- `npx tsx tests/export-service.test.ts` and `tests/export-sanitizer.test.ts` — pass.
- `npm run test:all` (full backend/contract suite) — exit 0.
- `npx tsc -p tsconfig.app.json --noEmit` and `-p tsconfig.spec.json --noEmit` — clean.
- `ng test` (headless Chromium), full suite: 172/173 passing. The one failure (`App downloads generated story HTML locally`) is the pre-existing `revokeObjectURL`/`fakeAsync` timing issue already recorded as pre-existing and unrelated in PRs #233 and #234; this change adds a new export test using the same pattern and gives it the correct `tick(OBJECT_URL_REVOKE_DELAY_MS)` rather than reproducing that bug.
- `npm run build:prod` — succeeds (the one `proving-grounds.css` budget warning is pre-existing, recorded in PR #233, and unrelated to this change).
- `scripts/recovery/check-vercel-function-count.sh` — 11/12, unchanged; the new module lives under `api/_lib` and is not a deployable route.

### Worst-to-best running list (last 10)

1. **Story Export/Download** (`api/export/save.ts`) — this PR.
2. **Proving Grounds** (`/proving-grounds`) — [#233](https://github.com/Phazzie/FairytaleswithSpice/pull/233).
3. **Image Generation** (`/api/image/generate`) — [#227](https://github.com/Phazzie/FairytaleswithSpice/pull/227).
4. **Real-Time Story Generation streaming** (`/api/story/stream`) — [#223](https://github.com/Phazzie/FairytaleswithSpice/pull/223), with follow-ups [#224](https://github.com/Phazzie/FairytaleswithSpice/pull/224) (SSE double-write), [#225](https://github.com/Phazzie/FairytaleswithSpice/pull/225) (privacy-safe nav gating), and [#226](https://github.com/Phazzie/FairytaleswithSpice/pull/226) (Node deployment routing).

---
_Generated by [Claude Code](https://claude.ai/code/session_01F81E3t5ApUKVs3a3q8saxU)_

## Summary by Sourcery

Connect the story export workflow end to end and make generated files, download payloads, and metadata reflect the actual exported story.

New Features:
- Add backend-driven story export for TXT, PDF, EPUB, and DOCX formats with frontend format selection and downloading.

Bug Fixes:
- Replace invalid EPUB and DOCX placeholder content with readable ZIP-based document packages.
- Return exported bytes directly instead of unusable mock storage URLs.
- Use supplied story creature and themes instead of hardcoded metadata.

Enhancements:
- Share browser blob-download handling across client-generated and backend-provided files.
- Expose a self-contained data URI export contract without expiration or storage-quota fields.

Tests:
- Strengthen export coverage by validating archive structure, embedded story content, returned bytes, file sizes, and metadata propagation.