### PR TITLE
Three quick wins: two creatures written as a third, themes outside their own contract, a welded chapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Three Quick Wins — two creatures written as a third, themes outside the contract, a welded chapter (August 26, 2026)
+
+#### A siren is no longer written by the fae court, and neither is a djinn
+
+- `AUTHOR_STYLE_MAP` gives every creature the voice bank its prompt is built
+  from. `siren` and `djinn` both pointed at `FAIRY_STYLES`, so two of the ten
+  choices the blueprint offers had the one setting that most decides how the
+  prose sounds replaced by another creature's: Holly Black and Sarah J. Maas
+  directing a story about neither, while the eight other creatures each had a
+  bank of their own.
+- `SIREN_STYLES` and `DJINN_STYLES` are four voices each, in the same invented-
+  house form the witch, dragon, demon, angel, and mermaid banks use — drowning
+  song and salt debt for the siren, wish law and lamp-bound servitude for the
+  djinn. `getSecondaryAuthorStyles` gives each its own pairing too, rather than
+  the fae court's.
+- The style-bank test passed straight through this. Its creature-language
+  assertion looks for "siren", "bargain", and "debts" in the bank's combined
+  text, and `FAIRY_STYLES` ends on a Bargainer entry that says all three, so
+  siren and djinn were credited with creature-specific language they had
+  borrowed; the stricter "must not reuse another creature's bank" loop beneath
+  it named only the five creatures added last. Both creatures are in that loop
+  now, and a new assertion checks that no two creatures share a bank object at
+  all, which is what the three hard-coded comparisons were approximating.
+
+#### `themesContinued` reports themes
+
+- The contract types the field as `ThemeType[]` — the closed set of eighteen ids
+  the theme picker offers and `VALIDATION_RULES.themes.allowedValues` lists —
+  and `extractThemesFromContent` was declared `any[]`, which is what let two
+  things through it.
+- When nothing matched, the answer was `['romance', 'fantasy']`. Neither is a
+  theme: no story can be generated with either, no picker can render either, and
+  a caller mapping the ids back to labels gets nothing for both. The honest
+  answer is the empty list, which is what a continuation that carried no
+  configured theme now returns.
+- Six of the eighteen themes had no keywords at all, so `dominance`,
+  `submission`, `temptation`, `sin`, `lust`, and `deceit` could never be
+  reported however plainly a chapter carried them — a scene naming all six came
+  back as `power_dynamics, desire`. `lust` was worse than merely absent: the word
+  sat in `desire`'s keyword list, so it was credited to a theme the reader may
+  not have chosen while its own theme stayed unreachable. The table is keyed by
+  `ThemeType` now, so a theme added to the contract without keywords here is a
+  compile error rather than a silent blind spot.
+- Keywords are matched as whole words. That is what makes the six new entries
+  safe to spell as their own names: `sin` as a substring is inside `rising`,
+  `using`, and `singing`, and `lust` is inside `lustre`. The inflections the
+  substring form picked up for free are listed instead, and `used` is gone from
+  `manipulation` — "she used the key" is not a story about being used.
+- The scan reads the rendered text rather than the markup, like the cliffhanger,
+  image, and story-quality scanners: the multi-word keywords (`secret love`,
+  `star-crossed`, `false promise`) are exactly the ones a welded
+  `door.</p><p>Blood` boundary hides.
+
+#### A plain-text chapter that opens with a title keeps its paragraphs
+
+- `formatStoryContent` wraps a provider answer that arrived as plain text. To
+  find the title it split on newlines and dropped every blank line — including
+  the ones two lines below, which are the paragraph separators the very next
+  step splits on. Rejoining what was left produced a body with no blank line
+  anywhere in it, so `split('\n\n')` returned the whole story as a single block
+  and every paragraph the model wrote was welded into one `<p>`.
+- It fired only for a story that opens with a title line; the same story without
+  one kept its paragraphs, because that branch never touched the lines. Only the
+  blank lines above the title are dropped now.
+
 ### 🐛 Three Quick Wins — the Proving Grounds bench, and a dropped image reason (August 26, 2026)
 
 #### Proving Grounds no longer spends a generation on a request the route always refuses

--- a/api/_lib/config/authorStyles.ts
+++ b/api/_lib/config/authorStyles.ts
@@ -199,6 +199,52 @@ export const FAIRY_STYLES: AuthorStyle[] = [
   }
 ];
 
+export const SIREN_STYLES: AuthorStyle[] = [
+  {
+    author: 'Drowning-Song Gothic',
+    voiceSample: 'She sang one note and the helmsman turned the wheel toward the rocks, smiling the whole way, certain he had chosen it himself.',
+    trait: 'Siren song as consent stolen politely, and the guilt that follows it'
+  },
+  {
+    author: 'Salt-Debt Bargainer',
+    voiceSample: '"You called me across four hundred miles of black water," she said. "Debts like that are not settled in coin, sailor."',
+    trait: 'Siren bargains, owed favours, and payment demanded at the worst hour'
+  },
+  {
+    author: 'Storm-Voice Romance',
+    voiceSample: 'Her voice cracked the squall open like an egg, and for one impossible breath the sea held still to listen to her.',
+    trait: 'Weather-bending siren power set against unguarded tenderness'
+  },
+  {
+    author: 'Harbour-Watch Longing',
+    voiceSample: 'Every night he left a lamp burning on the pier, and every night she surfaced just past its light, unwilling to be saved and unwilling to leave.',
+    trait: 'Shoreline distance, a siren who will not come in, and a lover who will not go home'
+  }
+];
+
+export const DJINN_STYLES: AuthorStyle[] = [
+  {
+    author: 'Three-Wish Jurisprudence',
+    voiceSample: '"Say it precisely," the djinn warned, delighted. "I am bound to give you exactly what you asked for, and nothing has ever hurt a mortal more."',
+    trait: 'Wish law read aloud like a contract, granted with ruinous precision'
+  },
+  {
+    author: 'Lamp-Bound Devotion',
+    voiceSample: 'Four hundred years of masters, and she was the first to ask what he wanted before she asked for anything at all.',
+    trait: 'Servitude, ownership, and the terror of being wished free'
+  },
+  {
+    author: 'Smokeless-Fire Epic',
+    voiceSample: 'He unfolded out of the brazier in a column of smokeless fire, and the desert night went to glass beneath him.',
+    trait: 'Elemental djinn grandeur, desert magic, and courts older than scripture'
+  },
+  {
+    author: 'Brass-Seal Bargain',
+    voiceSample: '"One wish left," she said, turning the brass seal over in her palm. "Spend it on me and you stay a slave. Spend it on you and I stay alone."',
+    trait: 'Bargains where the only winning move costs the romance itself'
+  }
+];
+
 export const WITCH_STYLES: AuthorStyle[] = [
   {
     author: 'Coven Hearth Gothic',
@@ -314,12 +360,25 @@ export const MERMAID_STYLES: AuthorStyle[] = [
   }
 ];
 
+/**
+ * The voice bank each creature's prompt is built from.
+ *
+ * `siren` and `djinn` pointed at `FAIRY_STYLES`. Every other creature has had
+ * its own bank since the Story Lab blueprint named ten of them, so a reader who
+ * chose a siren or a djinn — two of the ten choices the form offers — had the
+ * one setting that most decides how the prose sounds replaced by the fae court
+ * bank: Holly Black and Sarah J. Maas directing a story about neither. The gap
+ * survived the style-bank test because `FAIRY_STYLES` ends on a Bargainer entry
+ * that happens to say "siren", "bargain", and "debts", so the creature-specific
+ * language assertion passed on borrowed words, and the "must not reuse another
+ * creature's bank" loop below it named only the five creatures added last.
+ */
 const AUTHOR_STYLE_MAP: Record<CreatureType, AuthorStyle[]> = {
   vampire: VAMPIRE_STYLES,
   werewolf: WEREWOLF_STYLES,
   fairy: FAIRY_STYLES,
-  siren: FAIRY_STYLES,
-  djinn: FAIRY_STYLES,
+  siren: SIREN_STYLES,
+  djinn: DJINN_STYLES,
   witch: WITCH_STYLES,
   dragon: DRAGON_STYLES,
   demon: DEMON_STYLES,
@@ -332,9 +391,11 @@ function getSecondaryAuthorStyles(creature: CreatureType): AuthorStyle[] {
     case 'werewolf':
       return [...VAMPIRE_STYLES, ...FAIRY_STYLES];
     case 'fairy':
-    case 'siren':
-    case 'djinn':
       return [...VAMPIRE_STYLES, ...WEREWOLF_STYLES];
+    case 'siren':
+      return [...MERMAID_STYLES, ...FAIRY_STYLES];
+    case 'djinn':
+      return [...FAIRY_STYLES, ...DEMON_STYLES];
     case 'witch':
       return [...FAIRY_STYLES, ...VAMPIRE_STYLES];
     case 'dragon':

--- a/api/_lib/services/storyService.ts
+++ b/api/_lib/services/storyService.ts
@@ -9,7 +9,8 @@ import {
   SpicyLevel,
   Chapter,
   ChapterFailure,
-  CreatureType
+  CreatureType,
+  ThemeType
 } from '../types/contracts';
 import { selectRandomAuthorStyles } from '../config/authorStyles';
 import { CliffhangerService } from './cliffhangerService';
@@ -1792,34 +1793,80 @@ ${renderBody()}`;
     return this.cliffhangerService.analyze(content).cliffhangerDetected;
   }
 
-  private extractThemesFromContent(content: string): any[] {
-    const lowerContent = content.toLowerCase();
-    const detectedThemes: string[] = [];
-    
-    // Define theme keywords for detection
-    const themeKeywords = {
-      'forbidden_love': ['forbidden', 'secret love', 'star-crossed', 'illicit', 'taboo'],
-      'betrayal': ['betrayed', 'deceived', 'backstabbed', 'treachery', 'double-crossed'],
-      'revenge': ['revenge', 'vengeance', 'retribution', 'payback', 'avenge'],
-      'power_dynamics': ['power', 'control', 'dominance', 'authority', 'command'],
-      'obsession': ['obsessed', 'possessed', 'consumed', 'fixated', 'addicted'],
-      'dark_secrets': ['secret', 'hidden', 'mysterious', 'concealed', 'buried'],
-      'seduction': ['seduced', 'tempted', 'allured', 'enticed', 'charmed'],
-      'corruption': ['corrupted', 'tainted', 'fallen', 'darkness', 'evil'],
-      'jealousy': ['jealous', 'envious', 'possessive', 'resentful', 'covetous'],
-      'desire': ['desire', 'yearning', 'craving', 'longing', 'lust'],
-      'passion': ['passionate', 'intense', 'burning', 'fiery', 'ardent'],
-      'manipulation': ['manipulated', 'controlled', 'used', 'exploited', 'influenced']
+  /**
+   * Report which of the reader's themes the new chapters carried on.
+   *
+   * The result is returned to the caller as `themesContinued`, which the
+   * contract types as `ThemeType[]` — the same closed set of eighteen ids the
+   * form offers and `VALIDATION_RULES.themes.allowedValues` lists. Two things
+   * kept it from being one:
+   *
+   * - When nothing matched, the answer was `['romance', 'fantasy']`. Neither is
+   *   a theme: no chapter can be generated with either, no theme picker can
+   *   render either, and a caller mapping the ids back to labels gets nothing
+   *   for both. It is also not the honest answer — "no configured theme was
+   *   detected" is — and because a scan this coarse usually matches something,
+   *   the case it fired in was the one where the scan had found nothing to say.
+   * - Six of the eighteen themes had no keywords at all, so `dominance`,
+   *   `submission`, `temptation`, `sin`, `lust`, and `deceit` could never be
+   *   reported however plainly a chapter carried them: a scene naming all six
+   *   came back as `power_dynamics, desire`. `lust` was worse than absent — it
+   *   sat in `desire`'s keyword list, so the word was credited to a theme the
+   *   reader may not have chosen while its own theme stayed unreachable.
+   *
+   * Keying the table by `ThemeType` is what stops the second from returning: a
+   * theme added to the contract without keywords here is now a compile error
+   * rather than a silent blind spot. The declared return type does the same for
+   * the first.
+   *
+   * The scan reads the rendered text rather than the markup, like every other
+   * scanner here — the multi-word keywords (`secret love`, `star-crossed`,
+   * `false promise`) are the ones a welded `door.</p><p>Blood` boundary hides.
+   *
+   * Keywords are matched as whole words rather than as substrings, which is
+   * what makes the six new entries safe to state plainly: `sin` as a substring
+   * is in `rising`, `using`, and `singing`, and `lust` is in `lustre`, so under
+   * the old matching the only way to add those themes would have been to spell
+   * them as something other than their own names. The inflections the substring
+   * form used to pick up for free — `secrets` for `secret`, `powerful` for
+   * `power` — are listed instead. `used` is gone from `manipulation`: an
+   * ordinary "she used the key" is not a story about being used, and it was the
+   * loosest keyword in the table.
+   */
+  private extractThemesFromContent(content: string): ThemeType[] {
+    const lowerContent = this.stripHtml(content).toLowerCase();
+
+    // Ordered as `VALIDATION_RULES.themes.allowedValues` orders them, so the
+    // same chapter always reports the same list in the same order.
+    const themeKeywords: Record<ThemeType, readonly string[]> = {
+      betrayal: ['betrayed', 'betrayal', 'deceived', 'backstabbed', 'treachery', 'double-crossed'],
+      obsession: ['obsessed', 'obsession', 'possessed', 'consumed', 'fixated', 'addicted'],
+      power_dynamics: ['power', 'powers', 'powerful', 'control', 'authority', 'command', 'leverage'],
+      forbidden_love: ['forbidden', 'secret love', 'star-crossed', 'illicit', 'taboo'],
+      revenge: ['revenge', 'vengeance', 'retribution', 'payback', 'avenge', 'avenged'],
+      manipulation: ['manipulated', 'manipulation', 'controlled', 'exploited', 'influenced'],
+      seduction: ['seduced', 'seduction', 'allured', 'enticed', 'charmed', 'coaxed'],
+      dark_secrets: ['secret', 'secrets', 'hidden', 'mysterious', 'concealed', 'buried'],
+      corruption: ['corrupted', 'corruption', 'tainted', 'fallen', 'darkness', 'evil'],
+      dominance: ['dominance', 'dominant', 'dominated', 'dominion', 'mastery'],
+      submission: ['submission', 'submitted', 'submissive', 'yielded', 'knelt', 'obeyed'],
+      jealousy: ['jealous', 'jealousy', 'envious', 'possessive', 'resentful', 'covetous'],
+      temptation: ['tempted', 'temptation', 'tempting', 'lured', 'beckoned'],
+      sin: ['sin', 'sins', 'sinful', 'sinner', 'damnation', 'damned', 'penance'],
+      desire: ['desire', 'desires', 'yearning', 'craving', 'longing', 'wanting'],
+      passion: ['passionate', 'passion', 'intense', 'burning', 'fiery', 'ardent'],
+      lust: ['lust', 'lustful', 'lusted', 'carnal', 'ravenous'],
+      deceit: ['deceit', 'deceitful', 'lied', 'lying', 'false promise']
     };
-    
-    // Check for each theme
-    for (const [theme, keywords] of Object.entries(themeKeywords)) {
-      if (keywords.some(keyword => lowerContent.includes(keyword))) {
+
+    const detectedThemes: ThemeType[] = [];
+    for (const [theme, keywords] of Object.entries(themeKeywords) as Array<[ThemeType, readonly string[]]>) {
+      if (keywords.some(keyword => containsWholeWord(lowerContent, keyword))) {
         detectedThemes.push(theme);
       }
     }
-    
-    return detectedThemes.length > 0 ? detectedThemes : ['romance', 'fantasy'];
+
+    return detectedThemes;
   }
 
   private extractSpicyLevelFromContent(content: string): SpicyLevel {
@@ -1859,15 +1906,27 @@ ${renderBody()}`;
 
     // If no HTML formatting exists, apply smart formatting
     if (!content.includes('<h3>') && !content.includes('<p>')) {
-      // Extract title if present (first line typically)
-      const lines = content.split('\n').filter(line => line.trim());
-      const firstLine = lines[0]?.trim();
-      
+      // Extract title if present (first line typically).
+      //
+      // Only the blank lines *before* the title are dropped. Dropping all of
+      // them — `split('\n').filter(line => line.trim())` — took out the very
+      // separators the paragraph split below looks for, so rejoining the
+      // remainder produced a body with no blank line left anywhere in it and
+      // `split('\n\n')` returned the whole story as one block. Every paragraph
+      // the model wrote was then welded into a single `<p>`, and only for a
+      // story that opens with a title line: the same story without one kept its
+      // paragraphs, because that branch never touched the lines. This is the
+      // path a plain-text answer from the provider takes on its way to the
+      // reader, so what the reader saw was the chapter as one unbroken wall.
+      const lines = content.split('\n');
+      const titleIndex = lines.findIndex(line => line.trim());
+      const firstLine = titleIndex === -1 ? undefined : lines[titleIndex]?.trim();
+
       // Check if first line looks like a title (short, no punctuation except colon)
       const isTitle = firstLine && firstLine.length < 80 && !firstLine.endsWith('.') && !firstLine.startsWith('[');
-      
+
       if (isTitle) {
-        formatted = `<h3>${firstLine}</h3>\n\n` + lines.slice(1).join('\n');
+        formatted = `<h3>${firstLine}</h3>\n\n` + lines.slice(titleIndex + 1).join('\n');
       }
 
       // Split into paragraphs based on multiple newlines or speaker changes
@@ -2019,4 +2078,21 @@ ${renderBody()}`;
   private generateRequestId(): string {
     return `req_${randomUUID()}`;
   }
+}
+
+/**
+ * Whether `text` contains `keyword` as a whole word or whole phrase.
+ *
+ * Both sides are already lowercased by the caller. The `\b` at each end is what
+ * separates a theme keyword from the longer word it happens to sit inside, and
+ * a hyphenated keyword such as `star-crossed` is unaffected: `-` is a
+ * non-word character, so the boundaries fall at the ends of the phrase rather
+ * than around each half.
+ */
+function containsWholeWord(text: string, keyword: string): boolean {
+  return new RegExp(String.raw`\b${escapeRegExp(keyword)}\b`).test(text);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }

--- a/tests/story-lab-real-engine.test.ts
+++ b/tests/story-lab-real-engine.test.ts
@@ -8,7 +8,7 @@ import {
   shouldUseMockStoryLab,
   toClassicGenerationInput
 } from '../api/_lib/story-lab/storyLabEngine';
-import { getAuthorStylesForCreature } from '../api/_lib/config/authorStyles';
+import { getAuthorStylesForCreature, type AuthorStyle } from '../api/_lib/config/authorStyles';
 import type {
   StoryGenerationSeam as LabGenerationSeam,
   StoryStateSnapshot
@@ -149,7 +149,13 @@ for (const [creature, keywords] of Object.entries(creatureStyleKeywords) as [Cre
   assert(keywords.some(keyword => combinedText.includes(keyword)), `${creature} style bank should contain creature-specific language`);
 }
 
-for (const creature of ['witch', 'dragon', 'demon', 'angel', 'mermaid'] as CreatureType[]) {
+// Every creature the blueprint offers, other than the three whose banks the
+// others are measured against. `siren` and `djinn` used to be absent from this
+// list because both pointed at `FAIRY_STYLES`: a reader who chose either was
+// given the fae court's voices, and the keyword assertion above passed only
+// because `FAIRY_STYLES` ends on a Bargainer entry that says "siren",
+// "bargain", and "debts".
+for (const creature of ['siren', 'djinn', 'witch', 'dragon', 'demon', 'angel', 'mermaid'] as CreatureType[]) {
   const styles = getAuthorStylesForCreature(creature);
   const combinedText = styles
     .map(style => `${style.author} ${style.voiceSample} ${style.trait}`)
@@ -160,6 +166,17 @@ for (const creature of ['witch', 'dragon', 'demon', 'angel', 'mermaid'] as Creat
   assert(styles !== getAuthorStylesForCreature('vampire'), `${creature} should not reuse the vampire style bank object`);
   assert(styles !== getAuthorStylesForCreature('werewolf'), `${creature} should not reuse the werewolf style bank object`);
   assert(styles !== getAuthorStylesForCreature('fairy'), `${creature} should not reuse the fairy style bank object`);
+}
+
+// No two creatures share a bank at all: the reuse assertions above only ever
+// named three banks, so a new creature pointed at, say, `WITCH_STYLES` would
+// pass every one of them.
+const styleBanksByCreature = new Map<AuthorStyle[], CreatureType>();
+for (const creature of Object.keys(creatureStyleKeywords) as CreatureType[]) {
+  const styles = getAuthorStylesForCreature(creature);
+  const owner = styleBanksByCreature.get(styles);
+  assert(owner === undefined, `${creature} shares its style bank with ${owner}`);
+  styleBanksByCreature.set(styles, creature);
 }
 
 const classicStory: ClassicGenerationSeam['output'] = {

--- a/tests/story-service-improved.test.ts
+++ b/tests/story-service-improved.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { StoryService } from '../api/_lib/services/storyService';
-import { StoryGenerationSeam, ChapterContinuationSeam } from '../api/_lib/types/contracts';
+import { StoryGenerationSeam, ChapterContinuationSeam, VALIDATION_RULES } from '../api/_lib/types/contracts';
 
 // ==================== TEST UTILITIES ====================
 
@@ -707,6 +707,83 @@ const storyTextTests = {
     }
 
     console.log(`   ✓ Display content: ${JSON.stringify(display)}`);
+  }),
+
+  testTitledPlainTextKeepsParagraphs: test('Titled Plain Text Keeps Its Paragraphs', () => {
+    const service = new StoryService();
+    // A plain-text answer that opens with a title line. Dropping every blank
+    // line to find the title also removed the paragraph separators, so the
+    // whole body came back inside one `<p>`.
+    const raw = [
+      'Salt Vows',
+      '',
+      'She opened the door.',
+      '',
+      'Blood pooled where the light could not reach.',
+      '',
+      'He did not look away.'
+    ].join('\n');
+
+    const formatted: string = (service as any).formatStoryContent(raw);
+    const paragraphCount = formatted.split('<p>').length - 1;
+
+    if (!formatted.startsWith('<h3>Salt Vows</h3>')) {
+      throw new Error(`Expected the first line to become the heading: ${JSON.stringify(formatted)}`);
+    }
+    if (paragraphCount !== 3) {
+      throw new Error(`Expected 3 paragraphs below the title, got ${paragraphCount}: ${JSON.stringify(formatted)}`);
+    }
+
+    // The untitled form always kept its paragraphs; it must still.
+    const untitled: string = (service as any).formatStoryContent('She opened the door.\n\nBlood pooled.');
+    if (untitled.split('<p>').length - 1 !== 2) {
+      throw new Error(`Untitled plain text lost a paragraph: ${JSON.stringify(untitled)}`);
+    }
+
+    console.log(`   ✓ Titled plain text: ${JSON.stringify(formatted)}`);
+  }),
+
+  testContinuedThemesAreContractThemes: test('Continued Themes Stay Inside The Theme Contract', () => {
+    const service = new StoryService();
+    const allowedThemes: readonly string[] = VALIDATION_RULES.themes.allowedValues;
+
+    // Nothing to detect: the answer used to be `['romance', 'fantasy']`, two
+    // ids that are not themes at all.
+    const none: string[] = (service as any).extractThemesFromContent('<p>A quiet afternoon by the reef.</p>');
+    if (none.length !== 0) {
+      throw new Error(`Expected no themes for neutral prose, got ${JSON.stringify(none)}`);
+    }
+
+    // The six themes that had no keywords and so could never be reported.
+    const unreachable = ['dominance', 'submission', 'temptation', 'sin', 'lust', 'deceit'];
+    const detected: string[] = (service as any).extractThemesFromContent(
+      '<p>He knelt in submission to her dominance.</p>'
+      + '<p>Temptation was a sin, and her lust was built on deceit.</p>'
+    );
+    for (const theme of unreachable) {
+      if (!detected.includes(theme)) {
+        throw new Error(`Theme "${theme}" was named in the prose but not detected: ${JSON.stringify(detected)}`);
+      }
+    }
+
+    for (const theme of detected) {
+      if (!allowedThemes.includes(theme)) {
+        throw new Error(`Detected theme "${theme}" is not in VALIDATION_RULES.themes.allowedValues`);
+      }
+    }
+
+    // Whole-word matching: `sin` must not be read out of `rising`, nor `lust`
+    // out of `lustre`.
+    const substrings: string[] = (service as any).extractThemesFromContent(
+      '<p>The lustre of the rising tide was using the last of the light.</p>'
+    );
+    for (const theme of ['sin', 'lust', 'manipulation']) {
+      if (substrings.includes(theme)) {
+        throw new Error(`Theme "${theme}" was matched inside a longer word: ${JSON.stringify(substrings)}`);
+      }
+    }
+
+    console.log(`   ✓ Detected themes: ${JSON.stringify(detected)}`);
   })
 };
 


### PR DESCRIPTION
## A siren is no longer written by the fae court, and neither is a djinn

`AUTHOR_STYLE_MAP` gives every creature the voice bank its prompt is built from. `siren` and `djinn` both pointed at `FAIRY_STYLES`, so two of the ten choices the blueprint offers had the one setting that most decides how the prose sounds replaced by another creature's — Holly Black and Sarah J. Maas directing a story about neither — while the eight other creatures each had a bank of their own.

`SIREN_STYLES` and `DJINN_STYLES` are four voices each, in the same invented-house form the witch, dragon, demon, angel, and mermaid banks use. `getSecondaryAuthorStyles` gives each its own pairing too, rather than the fae court's.

The style-bank test passed straight through this. Its creature-language assertion looks for `siren`, `bargain`, and `debts` in the bank's combined text, and `FAIRY_STYLES` ends on a Bargainer entry that says all three, so both creatures were credited with creature-specific language they had borrowed; the stricter "must not reuse another creature's bank" loop beneath it named only the five creatures added last. Both are in that loop now, plus a new assertion that no two creatures share a bank object at all — which is what the three hard-coded comparisons were approximating.

## `themesContinued` reports themes

The contract types the field as `ThemeType[]`. `extractThemesFromContent` was declared `any[]`, which is what let two things through it:

- When nothing matched, the answer was `['romance', 'fantasy']`. Neither is a theme: no story can be generated with either, no picker can render either, and a caller mapping the ids back to labels gets nothing for both. The honest answer is the empty list.
- Six of the eighteen themes had no keywords at all, so `dominance`, `submission`, `temptation`, `sin`, `lust`, and `deceit` could never be reported however plainly a chapter carried them — a scene naming all six came back as `power_dynamics, desire`. `lust` was worse than absent: the word sat in `desire`'s keyword list, so it was credited to a theme the reader may not have chosen while its own theme stayed unreachable.

The table is keyed by `ThemeType`, so a theme added to the contract without keywords here is now a compile error rather than a silent blind spot. Keywords are matched as whole words, which is what makes the six new entries safe to spell as their own names — `sin` as a substring is inside `rising`, `using`, and `singing`, and `lust` is inside `lustre`; the inflections the substring form picked up for free are listed instead. `used` is gone from `manipulation`: "she used the key" is not a story about being used. The scan reads the rendered text rather than the markup, like the cliffhanger, image, and story-quality scanners — the multi-word keywords (`secret love`, `star-crossed`, `false promise`) are exactly the ones a welded `door.</p><p>Blood` boundary hides.

## A plain-text chapter that opens with a title keeps its paragraphs

`formatStoryContent` wraps a provider answer that arrived as plain text. To find the title it split on newlines and dropped every blank line — including the ones two lines below, which are the paragraph separators the very next step splits on. Rejoining what was left produced a body with no blank line anywhere in it, so `split('\n\n')` returned the whole story as a single block and every paragraph the model wrote was welded into one `<p>`.

It fired only for a story that opens with a title line; the same story without one kept its paragraphs, because that branch never touched the lines. Only the blank lines above the title are dropped now.

```
before: "<h3>Salt Vows</h3>\n\n<p>She opened the door.\nBlood pooled…\nHe did not look away.</p>"
after:  "<h3>Salt Vows</h3>\n\n<p>She opened the door.</p>\n\n<p>Blood pooled…</p>\n\n<p>He did not look away.</p>"
```

## Validation

- `npm run test:all` — all 47 suites pass (`tsx` is not in the tracked `node_modules`; it was installed for the run).
- New coverage: `tests/story-service-improved.test.ts` gains *Titled Plain Text Keeps Its Paragraphs* and *Continued Themes Stay Inside The Theme Contract*; `tests/story-lab-real-engine.test.ts` extends the bank-reuse loop to siren and djinn and adds the no-shared-bank assertion. Each fails on the pre-change code.
- `tsc --noEmit` over the two changed API files under the Angular app's strict flags (`strict`, `noPropertyAccessFromIndexSignature`, `noImplicitReturns`, `noFallthroughCasesInSwitch`), since the app type-checks this tree through the Node server.

## Not claimed

The theme scan is still keyword matching over the finished text, so it reports what a chapter *says* rather than what it is *about*. Nothing here changes that; it only stops the field carrying ids that are not themes and stops six themes being unreportable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gj5rCGJmuSK3LWX2x28Wg2)_

## Summary by Sourcery

Fix creature voice selection, theme continuation reporting, and paragraph formatting for titled plain-text chapters.

Bug Fixes:
- Give sirens and djinn dedicated author-style banks and secondary style pairings instead of reusing the fairy bank.
- Ensure continued-theme detection returns only valid configured themes, covers all contract themes, avoids substring false positives, and scans rendered content.
- Preserve paragraph breaks when formatting titled plain-text chapters.

Enhancements:
- Strengthen style-bank validation to ensure every creature has a distinct bank.

Tests:
- Add regression coverage for titled plain-text paragraph preservation, contract-valid theme detection, whole-word matching, and unique creature style banks.

Chores:
- Document the fixes in the unreleased changelog.