### PR TITLE
Three quick wins: an image style logged verbatim, the app's own themes reported as unrecognized, two creatures previewed as a third

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Three Quick Wins — an image style logged verbatim, the app's own themes reported as unrecognized, two creatures previewed as a third (August 26, 2026)
+
+#### `/api/image/generate` wrote the caller's `style` into the log as it arrived
+
+- The route's request line reports four caller-supplied fields. `storyId`,
+  `creature`, and `themes` each go through `loggableRequestParameters`, which
+  exists so that a value is repeated only when it is on the contract's own
+  allow-list. `style` did not: it was written as `style: input.style`.
+- Nothing before that line constrains it. The route's guard tests the field for
+  truthiness — `!input.style` — and the closed-set check lives in
+  `ImageService.validateImageInput`, which has not run yet. So a body of
+  `{"style": "Dana is in treatment at the clinic on Rosewood", …}` put that
+  sentence in the console and in the buffer the debug panel reads, verbatim,
+  under a log key that is deliberately kept. The token redaction every logged
+  string still passes through does not help: it removes credentials, addresses,
+  and URLs, not prose.
+- `ImageStyle` names five values, so there is a list to be recognised against.
+  `toLoggableImageStyle` joins its three siblings, reading
+  `VALIDATION_RULES.imageStyle.allowedValues` rather than restating them. A
+  request the app itself makes — which always sends one of the five — is logged
+  exactly as it was.
+
+#### The same line reported the app's own themes as unrecognized
+
+- `toLoggableThemes` filtered against `VALIDATION_RULES.themes.allowedValues`,
+  the eighteen classic `ThemeType`s. No screen in this repository sends those.
+  `app.ts` builds its picker from twelve Story Lab `ThemeSeed`s and passes
+  `theme.id` straight through, and seven of the twelve — `court_intrigue`,
+  `blood_oaths`, `slow_burn`, `enemies_to_lovers`, `magical_bargain`,
+  `secret_identity`, `forced_proximity` — are on no other list.
+- So the filter was rejecting the app's own traffic. A reader who picked "Court
+  Intrigue" and "Blood Oaths" and generated a chapter image produced the request
+  line `themes: [], unrecognizedThemeCount: 2` — the marker that means "the
+  caller sent something that is not a theme", written about the two themes the
+  picker itself offered. The diagnostic the module exists to preserve, *which
+  themes were asked for*, was blanked for exactly the requests that matter and
+  kept intact only for a vocabulary nothing sends.
+- This is the second time the same drift has been fixed in the same route:
+  `ImageService.mapThemeToVisualElement` described those seven seeds to the image
+  model as `mysterious elements` until it was taught both vocabularies. The list
+  had one copy, in `app.ts`, and no reader on the server side of the seam could
+  see it. It now lives in `shared/storyLabThemeSeeds.ts`, which the picker, the
+  log allow-list, and `tests/image-service.test.ts` all read — that test having
+  previously asserted against its own transcription of the list, so a seed added
+  to the picker and not to the test would have passed.
+- Widening the allow-list does not turn the filter off. A value from neither
+  picker is still reported by count rather than repeated.
+
+#### Proving Grounds showed a siren and a djinn the fairy author bank
+
+- `GenerationLogicService.getAllAuthorStyles` — the panel's preview of which
+  authors the API will be asked to write like — fell `siren` and `djinn` through
+  to `fairyStyles`. The API has had its own `SIREN_STYLES` and `DJINN_STYLES`
+  since that identical fallthrough was fixed in `api/_lib/config/authorStyles.ts`;
+  the browser-side copy was left behind.
+- For two of the ten creatures the screen therefore reported a bank of twelve fae
+  authors — Sarah J. Maas, Holly Black, Julie Kagawa — for a story the server
+  generated from four sea or wish voices. A prompt-comparison tool that shows a
+  prompt the run did not use is worse than one that shows nothing, because the
+  reader has no way to tell which they are looking at.
+- The spec was asserting the defect: `fairy, siren, and djinn share the same
+  fairy-styles pool` was a passing test over the drift. It is replaced by one
+  that requires every creature's bank to differ from every other's, and one that
+  names the siren and djinn authors the API actually uses — a borrowed bank is
+  still a non-empty, creature-shaped list, so only the contents catch it.
+
 ### 🐛 Three Quick Wins — every Story Lab refusal read as an outage, an adult gate that covered one chapter, a token count blanked from its own log (August 26, 2026)
 
 #### Every failure the story generator reported was served as HTTP 500 by the Story Lab routes

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -4,6 +4,30 @@ Created: 2026-05-26 00:12 EDT
 
 This is the chronological work log for the PR #70 recovery. It should capture commands, decisions, self-review notes, validation results, and anything that changes the plan.
 
+## 2026-08-26 UTC - An Image Style Logged Verbatim, The App's Own Themes Reported As Unrecognized, And Two Creatures Previewed As A Third
+
+Actions:
+
+- Put `/api/image/generate`'s `style` field through an allow-list. Its request line reported `storyId`, `creature`, and `themes` through `loggableRequestParameters` and `style` as `input.style`. Nothing before that line constrains the field — the route's guard tests it for truthiness and the closed-set check lives in `ImageService.validateImageInput`, which has not run yet — so a body carrying prose under that name put the prose in the console and the log buffer verbatim. Added `toLoggableImageStyle`, reading `VALIDATION_RULES.imageStyle.allowedValues` rather than restating the five.
+- Widened `toLoggableThemes`' allow-list to the vocabulary the app actually sends. It filtered against the eighteen classic `ThemeType`s; `app.ts` builds its picker from twelve Story Lab seeds and seven of them are on no other list, so an ordinary image generation logged `themes: []` beside an `unrecognizedThemeCount` — the caller-sent-garbage marker, written about the picker's own values. Both vocabularies are legitimate seam input and both are now recognised; a value from neither is still counted rather than repeated.
+- Created `shared/storyLabThemeSeeds.ts` and pointed `app.ts`, the log allow-list, and `tests/image-service.test.ts` at it. The list had one copy, in `app.ts`, invisible to the server side of the seam, and that has now cost the same bug twice — `mapThemeToVisualElement` described those same seven seeds to the image model as `mysterious elements` until PR #238. The image-service test held its own transcription of the list, so it was asserting against a copy rather than against the picker.
+- Ported `SIREN_STYLES` and `DJINN_STYLES` into `GenerationLogicService`. `getAllAuthorStyles` fell `siren` and `djinn` through to `fairyStyles`, so the Proving Grounds panel previewed twelve fae authors for two creatures the API generates from four sea or wish voices — the same fallthrough already fixed on the API side in `api/_lib/config/authorStyles.ts`, left behind in the browser copy.
+- Extended `tests/log-redaction.test.ts` and `tests/story-route-contracts.test.ts`, both registered in `test:all`, and replaced two specs in `generation-logic.service.spec.ts`.
+
+Self-review:
+
+- Good: every fix was reproduced against the old code by reverting one file at a time and re-running. `caller text sent as an image style must not reach the buffer`, `a request the app itself makes should have its themes logged intact (got …"themes":[],"unrecognizedThemeCount":2…)`, and two named Karma failures for the author banks.
+- The Angular spec was asserting the defect outright: `fairy, siren, and djinn share the same fairy-styles pool` was a green test over the drift. Replaced rather than deleted — one spec requires every creature's bank to differ from every other's, one names the siren and djinn authors — because a borrowed bank is still a non-empty, creature-shaped list and the existing shape check could not see it.
+- The theme fix needed both readings asserted. A filter that blanks everything satisfies "no caller text in the log" perfectly, which is how this defect survived: the route-contract test now checks that an ordinary request's themes arrive intact as well as that prose does not.
+- Non-claim: this slice changes no prompt, no generated story, and no route's status or payload. It changes what two log fields record, where the theme seed list lives, and which author bank one browser panel displays.
+
+Validation:
+
+- `npm run test:all`: passed (74 suites).
+- `cd story-generator && CHROME_BIN=/opt/pw-browsers/chromium npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox`: 176 of 176 passed.
+- `npm run build`: passed. The `proving-grounds.css` budget warning (68 bytes over 12 kB) predates this slice and is untouched by it.
+- `git diff --check`: passed.
+
 ## 2026-08-26 UTC - Every Story Lab Refusal Served As An Outage, An Adult Gate That Covered One Chapter, And A Token Count Blanked From Its Own Log
 
 Actions:

--- a/api/_lib/utils/loggableRequestParameters.ts
+++ b/api/_lib/utils/loggableRequestParameters.ts
@@ -1,8 +1,46 @@
 // Created: 2026-08-25 05:20 UTC
 
+import { STORY_LAB_THEME_SEED_IDS } from '../../../shared/storyLabThemeSeeds';
 import { VALIDATION_RULES } from '../types/contracts';
 
-const ALLOWED_THEMES: readonly string[] = VALIDATION_RULES.themes.allowedValues;
+/**
+ * The theme ids a log line may repeat, which is both vocabularies the seams
+ * accept — not just the classic one.
+ *
+ * `VALIDATION_RULES.themes.allowedValues` names the eighteen `ThemeType`s, and
+ * on its own that is the wrong list to filter a log against: no screen in this
+ * repository sends those. `app.ts` builds its picker from the twelve Story Lab
+ * seeds and passes `theme.id` through unchanged, and seven of the twelve —
+ * `court_intrigue`, `blood_oaths`, `slow_burn`, `enemies_to_lovers`,
+ * `magical_bargain`, `secret_identity`, and `forced_proximity` — are on neither
+ * the classic list nor any of its synonyms.
+ *
+ * So the filter below was rejecting the app's own traffic. A reader who picked
+ * "Court Intrigue" and "Blood Oaths" and generated a chapter image produced the
+ * request line `themes: [], unrecognizedThemeCount: 2` — the marker that exists
+ * to say "the caller sent something that is not a theme", written about the two
+ * themes the picker itself offered. The diagnostic this whole module exists to
+ * preserve, which themes were asked for, was blanked for exactly the requests
+ * that matter, and left intact only for a vocabulary nothing sends.
+ *
+ * Both are legitimate input — the seams type `themes` as `string[]`, and
+ * `ImageService.mapThemeToVisualElement` answers both for the same reason — so
+ * both are recognised here. `unrecognizedThemeCount` goes back to meaning what
+ * it says: a value that came from neither picker.
+ */
+const ALLOWED_THEMES: readonly string[] = [
+  ...VALIDATION_RULES.themes.allowedValues,
+  ...STORY_LAB_THEME_SEED_IDS
+];
+
+/**
+ * The image styles `ImageStyle` names, listed so a value can be checked at run
+ * time — the same arrangement as `ALLOWED_CREATURES`, and for the same reason.
+ * `ImageService.validateImageInput` holds its own copy and refuses anything
+ * outside it, but that runs after `/api/image/generate` has written its request
+ * line, and the route's own guard tests only that the field is present.
+ */
+const ALLOWED_IMAGE_STYLES: readonly string[] = VALIDATION_RULES.imageStyle.allowedValues;
 
 /**
  * The creatures `CreatureType` names, listed so a value can be checked at run
@@ -35,6 +73,31 @@ export const UNRECOGNIZED_PARAMETER = '[UNRECOGNIZED]';
 export function toLoggableCreature(creature: unknown): string {
   return typeof creature === 'string' && ALLOWED_CREATURES.includes(creature)
     ? creature
+    : UNRECOGNIZED_PARAMETER;
+}
+
+/**
+ * Log an image style only when it is one.
+ *
+ * `/api/image/generate` writes `style: input.style` on its request line, and
+ * `style` reaches that line as whatever JSON the caller wrote: the route's
+ * guard tests the field for truthiness, and the closed-set check lives in
+ * `ImageService`, which has not run yet. So a body of
+ * `{"style": "Dana is in treatment at the clinic on Rosewood", …}` put that
+ * sentence in the console and in the log buffer verbatim — the one field on
+ * that line still carrying caller text, beside `creature`, `themes`, and
+ * `storyId`, each of which is on this module precisely so it cannot.
+ *
+ * The redaction every logged string still passes through does not cover it:
+ * that removes credentials, addresses, and URLs, not prose.
+ *
+ * `ImageStyle` is five values, so there is a list to be recognised against, and
+ * a request the app itself makes — which always sends one of the five — is
+ * logged exactly as it was.
+ */
+export function toLoggableImageStyle(style: unknown): string {
+  return typeof style === 'string' && ALLOWED_IMAGE_STYLES.includes(style)
+    ? style
     : UNRECOGNIZED_PARAMETER;
 }
 

--- a/api/image/generate.ts
+++ b/api/image/generate.ts
@@ -9,6 +9,7 @@ import {
   IMAGE_GENERATION_REQUEST_FIELDS,
   toLoggableCreature,
   toLoggableFieldNames,
+  toLoggableImageStyle,
   toLoggableStoryId,
   toLoggableThemes
 } from '../_lib/utils/loggableRequestParameters';
@@ -72,7 +73,10 @@ export default async function handler(req: any, res: any) {
         storyId: toLoggableStoryId(input.storyId),
         creature: toLoggableCreature(input.creature),
         ...toLoggableThemes(input.themes),
-        style: input.style
+        // Through the allow-list like every other field on this line: the
+        // guard above accepted `style` for being present, not for being one of
+        // the five the contract names, so it is still caller text here.
+        style: toLoggableImageStyle(input.style)
       }
     });
 

--- a/shared/storyLabThemeSeeds.ts
+++ b/shared/storyLabThemeSeeds.ts
@@ -1,0 +1,55 @@
+// Created: 2026-08-26 07:10 UTC
+
+/**
+ * One thematic seed as the Story Lab picker offers it.
+ *
+ * Structurally the Angular `ThemeSeed` and the API's `GenerationThemeSeed`,
+ * restated here because this module sits below both trees and can import
+ * neither.
+ */
+export interface StoryLabThemeSeed {
+  id: string;
+  label: string;
+  description: string;
+}
+
+/**
+ * The thematic seeds the Story Lab picker offers, and therefore the theme ids
+ * every request the app makes actually carries.
+ *
+ * They are not `ThemeType`. The classic eighteen — `betrayal`, `power_dynamics`,
+ * and the rest — are a separate vocabulary that the seams still accept from a
+ * caller that sends them, but no screen in this repository offers them: `app.ts`
+ * builds its picker from these twelve and passes `theme.id` straight through to
+ * `/api/story-lab/*`, `/api/image/generate`, and `/api/export/save`.
+ *
+ * The list lived in `app.ts` alone, and the server-side tables that have to
+ * recognise these ids were each written against `ThemeType` instead. That has
+ * now cost the same bug twice: `ImageService.mapThemeToVisualElement` described
+ * seven of the twelve to the image model as `mysterious elements`, and
+ * `toLoggableThemes` counts those same seven as unrecognised, so the request
+ * line for an ordinary image generation reports no themes at all. Both were
+ * written correctly against the wrong vocabulary, which is what a list with one
+ * copy and several readers produces.
+ *
+ * Defining it here, where the API tree and the Angular tree can both read it,
+ * is what makes a seed added to the picker reach the code that has to know
+ * about it — rather than leaving the next reader to notice.
+ */
+export const STORY_LAB_THEME_SEEDS: readonly StoryLabThemeSeed[] = [
+  { id: 'forbidden_love', label: 'Forbidden Love', description: 'Desire has consequences.' },
+  { id: 'dark_secrets', label: 'Hidden Secrets', description: 'Someone is lying beautifully.' },
+  { id: 'court_intrigue', label: 'Court Intrigue', description: 'Power games under candlelight.' },
+  { id: 'blood_oaths', label: 'Blood Oaths', description: 'Promises that bite back.' },
+  { id: 'slow_burn', label: 'Slow Burn', description: 'Tension before surrender.' },
+  { id: 'enemies_to_lovers', label: 'Enemies to Lovers', description: 'Sparks from mutual danger.' },
+  { id: 'revenge', label: 'Revenge', description: 'A debt comes due.' },
+  { id: 'obsession', label: 'Obsession', description: 'Want sharp enough to wound.' },
+  { id: 'temptation', label: 'Temptation', description: 'The wrong door keeps opening.' },
+  { id: 'magical_bargain', label: 'Magical Bargain', description: 'Every wish has a price.' },
+  { id: 'secret_identity', label: 'Secret Identity', description: 'The lover is not who they seem.' },
+  { id: 'forced_proximity', label: 'Forced Proximity', description: 'No escape from chemistry.' }
+];
+
+/** Just the ids, for the allow-lists that only ever check membership. */
+export const STORY_LAB_THEME_SEED_IDS: readonly string[] = STORY_LAB_THEME_SEEDS.map(seed => seed.id);

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -12,6 +12,7 @@ import {
   downloadBlob,
   downloadHtmlDocument
 } from '../../../shared/htmlDocumentDownload';
+import { STORY_LAB_THEME_SEEDS } from '../../../shared/storyLabThemeSeeds';
 import { BlueprintValidationField, FormValidationService } from './form-validation.service';
 import {
   BatchProgressState,
@@ -272,20 +273,13 @@ export class App implements OnDestroy {
     { id: 'mermaid', label: 'Mermaid', description: 'Tides, curses, pearl-lit longing.' }
   ];
 
-  readonly availableThemes: ThemeSeed[] = [
-    { id: 'forbidden_love', label: 'Forbidden Love', description: 'Desire has consequences.' },
-    { id: 'dark_secrets', label: 'Hidden Secrets', description: 'Someone is lying beautifully.' },
-    { id: 'court_intrigue', label: 'Court Intrigue', description: 'Power games under candlelight.' },
-    { id: 'blood_oaths', label: 'Blood Oaths', description: 'Promises that bite back.' },
-    { id: 'slow_burn', label: 'Slow Burn', description: 'Tension before surrender.' },
-    { id: 'enemies_to_lovers', label: 'Enemies to Lovers', description: 'Sparks from mutual danger.' },
-    { id: 'revenge', label: 'Revenge', description: 'A debt comes due.' },
-    { id: 'obsession', label: 'Obsession', description: 'Want sharp enough to wound.' },
-    { id: 'temptation', label: 'Temptation', description: 'The wrong door keeps opening.' },
-    { id: 'magical_bargain', label: 'Magical Bargain', description: 'Every wish has a price.' },
-    { id: 'secret_identity', label: 'Secret Identity', description: 'The lover is not who they seem.' },
-    { id: 'forced_proximity', label: 'Forced Proximity', description: 'No escape from chemistry.' }
-  ];
+  // Read from the shared seed list rather than restated here. These ids do not
+  // stay in the browser: they travel to `/api/image/generate`, `/api/export/save`,
+  // and the Story Lab routes, where server-side tables have to recognise them —
+  // and every one of those tables was first written against the classic
+  // `ThemeType` vocabulary instead, because this list had one copy and no
+  // reader on the other side of the seam could see it.
+  readonly availableThemes: ThemeSeed[] = STORY_LAB_THEME_SEEDS.map(seed => ({ ...seed }));
 
   readonly spiceOptions: SpiceOption[] = [
     { level: 1, label: 'Storybook Romance', description: 'Longing, flirtation, no explicit detail.' },

--- a/story-generator/src/app/proving-grounds/generation-logic.service.spec.ts
+++ b/story-generator/src/app/proving-grounds/generation-logic.service.spec.ts
@@ -25,13 +25,37 @@ describe('GenerationLogicService', () => {
     }
   });
 
-  it('fairy, siren, and djinn share the same fairy-styles pool', () => {
-    const fairyStyles = service.getAllAuthorStyles('fairy');
-    const sirenStyles = service.getAllAuthorStyles('siren');
-    const djinnStyles = service.getAllAuthorStyles('djinn');
+  // This used to assert the opposite — that fairy, siren, and djinn share one
+  // pool — which is how the fallthrough survived: the panel showed a bank of
+  // fae authors for two creatures the API generates from `SIREN_STYLES` and
+  // `DJINN_STYLES`, and the suite called that the expected result.
+  it('gives every creature its own author bank rather than borrowing another creature\'s', () => {
+    const creatures: CreatureArchetype[] = [
+      'vampire', 'werewolf', 'fairy', 'siren', 'djinn', 'witch', 'dragon', 'demon', 'angel', 'mermaid'
+    ];
 
-    expect(sirenStyles).toEqual(fairyStyles);
-    expect(djinnStyles).toEqual(fairyStyles);
+    for (const creature of creatures) {
+      const ownAuthors = service.getAllAuthorStyles(creature).map(style => style.author).join('|');
+
+      for (const other of creatures) {
+        if (other === creature) {
+          continue;
+        }
+
+        expect(service.getAllAuthorStyles(other).map(style => style.author).join('|'))
+          .withContext(`${other} should not reuse the ${creature} bank`)
+          .not.toEqual(ownAuthors);
+      }
+    }
+  });
+
+  // Named rather than checked by shape: a bank borrowed from a neighbour is
+  // still a non-empty, creature-shaped list, so only the contents catch it.
+  it('reads the siren and djinn banks the API generates those creatures from', () => {
+    expect(service.getAllAuthorStyles('siren').map(style => style.author))
+      .toEqual(['Drowning-Song Gothic', 'Salt-Debt Bargainer', 'Storm-Voice Romance', 'Harbour-Watch Longing']);
+    expect(service.getAllAuthorStyles('djinn').map(style => style.author))
+      .toEqual(['Three-Wish Jurisprudence', 'Lamp-Bound Devotion', 'Smokeless-Fire Epic', 'Brass-Seal Bargain']);
   });
 
   it('selectRandomAuthors never returns more authors than exist for the creature, and never duplicates one', () => {

--- a/story-generator/src/app/proving-grounds/generation-logic.service.ts
+++ b/story-generator/src/app/proving-grounds/generation-logic.service.ts
@@ -220,6 +220,58 @@ export class GenerationLogicService {
     }
   ];
 
+  /**
+   * Ported from the API's `SIREN_STYLES`, which is the bank a siren story is
+   * actually generated from. See `getAllAuthorStyles` below for what reading
+   * the fairy bank instead was doing to this panel.
+   */
+  private readonly sirenStyles: AuthorStyle[] = [
+    {
+      author: 'Drowning-Song Gothic',
+      voiceSample: 'She sang one note and the helmsman turned the wheel toward the rocks, smiling the whole way, certain he had chosen it himself.',
+      trait: 'Siren song as consent stolen politely, and the guilt that follows it'
+    },
+    {
+      author: 'Salt-Debt Bargainer',
+      voiceSample: '"You called me across four hundred miles of black water," she said. "Debts like that are not settled in coin, sailor."',
+      trait: 'Siren bargains, owed favours, and payment demanded at the worst hour'
+    },
+    {
+      author: 'Storm-Voice Romance',
+      voiceSample: 'Her voice cracked the squall open like an egg, and for one impossible breath the sea held still to listen to her.',
+      trait: 'Weather-bending siren power set against unguarded tenderness'
+    },
+    {
+      author: 'Harbour-Watch Longing',
+      voiceSample: 'Every night he left a lamp burning on the pier, and every night she surfaced just past its light, unwilling to be saved and unwilling to leave.',
+      trait: 'Shoreline distance, a siren who will not come in, and a lover who will not go home'
+    }
+  ];
+
+  /** Ported from the API's `DJINN_STYLES`, for the same reason. */
+  private readonly djinnStyles: AuthorStyle[] = [
+    {
+      author: 'Three-Wish Jurisprudence',
+      voiceSample: '"Say it precisely," the djinn warned, delighted. "I am bound to give you exactly what you asked for, and nothing has ever hurt a mortal more."',
+      trait: 'Wish law read aloud like a contract, granted with ruinous precision'
+    },
+    {
+      author: 'Lamp-Bound Devotion',
+      voiceSample: 'Four hundred years of masters, and she was the first to ask what he wanted before she asked for anything at all.',
+      trait: 'Servitude, ownership, and the terror of being wished free'
+    },
+    {
+      author: 'Smokeless-Fire Epic',
+      voiceSample: 'He unfolded out of the brazier in a column of smokeless fire, and the desert night went to glass beneath him.',
+      trait: 'Elemental djinn grandeur, desert magic, and courts older than scripture'
+    },
+    {
+      author: 'Brass-Seal Bargain',
+      voiceSample: '"One wish left," she said, turning the brass seal over in her palm. "Spend it on me and you stay a slave. Spend it on you and I stay alone."',
+      trait: 'Bargains where the only winning move costs the romance itself'
+    }
+  ];
+
   private readonly witchStyles: AuthorStyle[] = [
     {
       author: 'Coven Hearth Gothic',
@@ -481,6 +533,23 @@ export class GenerationLogicService {
     "Scar that burns, old wound aches in presence of specific person, reveals hidden connection"
   ];
 
+  /**
+   * The author bank a creature's prompt is built from.
+   *
+   * The point of this panel is to show which authors the API will be asked to
+   * write like, so the answer has to be the API's answer. `siren` and `djinn`
+   * fell through to `fairyStyles`, and the API has had its own `SIREN_STYLES`
+   * and `DJINN_STYLES` since that same fallthrough was fixed in
+   * `api/_lib/config/authorStyles.ts` — so for two of the ten creatures this
+   * screen reported a bank of twelve fae authors (Sarah J. Maas, Holly Black,
+   * Julie Kagawa) for a story the server generated from four sea or wish
+   * voices. A prompt-comparison tool that shows a prompt the run did not use is
+   * worse than one that shows nothing, because the reader has no way to tell.
+   *
+   * The `default` stays for a creature that reaches here from outside
+   * `CreatureArchetype`; with every archetype now named it is unreachable from
+   * the type.
+   */
   getAllAuthorStyles(creature: CreatureArchetype): AuthorStyle[] {
     switch (creature) {
       case 'vampire':
@@ -488,9 +557,11 @@ export class GenerationLogicService {
       case 'werewolf':
         return this.werewolfStyles;
       case 'fairy':
-      case 'siren':
-      case 'djinn':
         return this.fairyStyles;
+      case 'siren':
+        return this.sirenStyles;
+      case 'djinn':
+        return this.djinnStyles;
       case 'witch':
         return this.witchStyles;
       case 'dragon':

--- a/tests/image-service.test.ts
+++ b/tests/image-service.test.ts
@@ -4,6 +4,7 @@
 import axios from 'axios';
 import { ImageService, readGeneratedImageUrl } from '../api/_lib/services/imageService';
 import { CreatureType, ImageGenerationSeam } from '../api/_lib/types/contracts';
+import { STORY_LAB_THEME_SEED_IDS } from '../shared/storyLabThemeSeeds';
 
 // The service reads `XAI_API_KEY` in its constructor and falls back to a mock
 // image URL when it is absent, so clearing it before the first `new
@@ -252,29 +253,19 @@ async function testEveryCreatureArchetypeReachesThePrompt(): Promise<void> {
   }
 }
 
-/**
- * The theme ids `app.ts` actually sends.
+/*
+ * The theme ids `app.ts` actually sends are read from `shared/`, not restated
+ * here.
  *
- * Not `ThemeType`. The image seam types `themes` as `string[]`, and the only
- * client this route has builds its picker from `availableThemes` — twelve Story
- * Lab `ThemeSeed`s — and passes `theme.id` straight through. Kept here as its
- * own list, alongside the creature list above, so a theme added to the picker
- * without a visual element is a failing case rather than a silent fallback.
+ * They are not `ThemeType`. The image seam types `themes` as `string[]`, and
+ * the only client this route has builds its picker from `availableThemes` —
+ * twelve Story Lab `ThemeSeed`s — and passes `theme.id` straight through. This
+ * file used to hold its own transcription of that list, which made the check
+ * below assert against a copy rather than against the picker: a seed added to
+ * the picker and not to this file would have passed. Importing the list the
+ * picker itself is built from is what makes a new seed with no visual element a
+ * failing case.
  */
-const STORY_LAB_THEME_SEED_IDS = [
-  'forbidden_love',
-  'dark_secrets',
-  'court_intrigue',
-  'blood_oaths',
-  'slow_burn',
-  'enemies_to_lovers',
-  'revenge',
-  'obsession',
-  'temptation',
-  'magical_bargain',
-  'secret_identity',
-  'forced_proximity'
-];
 
 /**
  * Seven of those twelve — `court_intrigue`, `blood_oaths`, `slow_burn`,

--- a/tests/log-redaction.test.ts
+++ b/tests/log-redaction.test.ts
@@ -4,10 +4,12 @@
 import { redactSensitiveLogData } from '../api/_lib/utils/logger';
 import {
   toLoggableBoolean,
+  toLoggableImageStyle,
   toLoggableStoryId,
   toLoggableNumber,
   toLoggableThemes
 } from '../api/_lib/utils/loggableRequestParameters';
+import { STORY_LAB_THEME_SEED_IDS } from '../shared/storyLabThemeSeeds';
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -245,6 +247,60 @@ assert(
 assert(
   toLoggableThemes(['betrayal', 'revenge']).unrecognizedThemeCount === undefined,
   'an ordinary request should log its themes with no unrecognized count beside them'
+);
+
+// The allow-list has to be the vocabulary the app actually sends, not only the
+// classic `ThemeType` one. Seven of the twelve seeds the picker offers —
+// `court_intrigue`, `blood_oaths`, `slow_burn`, `enemies_to_lovers`,
+// `magical_bargain`, `secret_identity`, `forced_proximity` — are on no other
+// list, so filtering against `ThemeType` alone reported the app's own themes as
+// unrecognised. Every real image generation then logged `themes: []` beside a
+// count, which is the marker for "the caller sent something that is not a
+// theme" written about the picker's own values.
+for (const seed of STORY_LAB_THEME_SEED_IDS) {
+  const loggable = toLoggableThemes([seed]);
+  assert(
+    loggable.themes.join(',') === seed && loggable.unrecognizedThemeCount === undefined,
+    `${seed} is on the app's own picker, so the request line should name it (got ${JSON.stringify(loggable)})`
+  );
+}
+
+const pickedFromTheUi = toLoggableThemes(['court_intrigue', 'blood_oaths']);
+assert(
+  pickedFromTheUi.themes.join(',') === 'court_intrigue,blood_oaths'
+    && pickedFromTheUi.unrecognizedThemeCount === undefined,
+  `a request the app itself makes should log its themes intact (got ${JSON.stringify(pickedFromTheUi)})`
+);
+
+// Widening the list must not turn the filter off: a value from neither picker
+// is still reported by count rather than repeated.
+const mixed = toLoggableThemes(['forced_proximity', privateProse]);
+assert(
+  mixed.themes.join(',') === 'forced_proximity' && mixed.unrecognizedThemeCount === 1,
+  `prose sent beside a real seed should still be counted, not repeated (got ${JSON.stringify(mixed)})`
+);
+
+// `style` reaches `/api/image/generate`'s request line as caller text: the
+// route's guard tests the field for truthiness, and the closed-set check lives
+// in `ImageService`, which has not run yet. It is the one field on that line
+// that was still being logged verbatim.
+assert(
+  toLoggableImageStyle('fantasy') === 'fantasy' && toLoggableImageStyle('artistic') === 'artistic',
+  'a style the contract names should be logged as it is'
+);
+assert(
+  toLoggableImageStyle(privateProse) === '[UNRECOGNIZED]',
+  `prose sent as an image style should be reported, not repeated (got ${toLoggableImageStyle(privateProse)})`
+);
+assert(
+  !JSON.stringify(redactSensitiveLogData({
+    requestParameters: { style: toLoggableImageStyle(privateProse) }
+  })).includes('Dana'),
+  'caller prose sent as an image style must not reach the log'
+);
+assert(
+  toLoggableImageStyle(42) === '[UNRECOGNIZED]' && toLoggableImageStyle(undefined) === '[UNRECOGNIZED]',
+  'a non-string style should be reported rather than stringified into the line'
 );
 
 // An identifier is filtered by its shape, not its length. A length cap alone

--- a/tests/story-route-contracts.test.ts
+++ b/tests/story-route-contracts.test.ts
@@ -538,11 +538,93 @@ async function captureConsole<T>(run: () => Promise<T>): Promise<{ response: T; 
   }
 }
 
+/**
+ * `/api/image/generate`'s request line must not repeat what the caller sent —
+ * and must still say what an ordinary request asked for.
+ *
+ * The line reports four caller-supplied fields. Three of them go through this
+ * repository's allow-lists; `style` did not. The route's own guard tests the
+ * field for truthiness and `ImageService.validateImageInput` holds the closed
+ * set, but that runs after the line is written, so `style` was caller text at
+ * the moment it was logged and a body carrying prose under that name put the
+ * prose in the console and in the buffer the debug panel reads.
+ *
+ * The other half of the same line was failing in the opposite direction:
+ * `themes` was filtered against the eighteen classic `ThemeType`s, and the only
+ * client this route has sends Story Lab seed ids. An ordinary request logged
+ * `themes: []` with an unrecognized count beside it — the caller-sent-garbage
+ * marker, written about the picker's own values. Both readings are asserted
+ * here, because a filter that blanks everything satisfies the first on its own.
+ */
+async function verifyImageRequestLineNeitherRepeatsNorBlanksItsParameters(): Promise<void> {
+  const prose = 'Dana is in treatment at the clinic on Rosewood';
+  const storyId = 'story_0f1c0e3a-2b44-4f2e-9c3d-6a7b8c9d0e1f';
+
+  logger.clearLogs();
+  const { consoleOutput } = await captureConsole(async () => {
+    const res = new FakeResponse();
+    await imageGenerateHandler({
+      method: 'POST',
+      headers: {},
+      body: { storyId, content: 'A chapter.', creature: 'vampire', themes: ['court_intrigue'], style: prose }
+    }, res);
+    return res;
+  });
+
+  const proseLine = logger.getRecentLogs(50, 'info')
+    .find(entry => entry.context?.endpoint === '/api/image/generate');
+  assert(proseLine, 'the route should log the request it was called with');
+
+  for (const [sink, written] of [
+    ['buffer', JSON.stringify(proseLine)],
+    ['console', consoleOutput]
+  ] as const) {
+    assert(
+      !written.includes('Dana') && !written.includes('Rosewood'),
+      `caller text sent as an image style must not reach the ${sink} (got ${written.slice(0, 300)})`
+    );
+  }
+
+  logger.clearLogs();
+  await captureConsole(async () => {
+    const res = new FakeResponse();
+    await imageGenerateHandler({
+      method: 'POST',
+      headers: {},
+      body: {
+        storyId,
+        content: 'A chapter.',
+        creature: 'siren',
+        // Two seeds straight off the picker `app.ts` builds.
+        themes: ['blood_oaths', 'forced_proximity'],
+        style: 'fantasy'
+      }
+    }, res);
+    return res;
+  });
+
+  const ordinaryLine = logger.getRecentLogs(50, 'info')
+    .find(entry => entry.context?.endpoint === '/api/image/generate');
+  assert(ordinaryLine, 'the route should log an ordinary request too');
+
+  const parameters = (ordinaryLine.context as any)?.requestParameters ?? {};
+  assert(
+    JSON.stringify(parameters.themes) === JSON.stringify(['blood_oaths', 'forced_proximity'])
+      && parameters.unrecognizedThemeCount === undefined,
+    `a request the app itself makes should have its themes logged intact (got ${JSON.stringify(parameters)})`
+  );
+  assert(
+    parameters.style === 'fantasy' && parameters.creature === 'siren' && parameters.storyId === storyId,
+    `the rest of the line should survive the allow-lists too (got ${JSON.stringify(parameters)})`
+  );
+}
+
 async function main(): Promise<void> {
   await verifyContinueDoesNotLogProseStoryIds();
   await verifyMalformedBodiesAreClientErrors();
   await verifyRejectedBodiesDoNotLogCallerFieldNames();
   await verifyRejectedStoryInputDoesNotRepeatCallerText();
+  await verifyImageRequestLineNeitherRepeatsNorBlanksItsParameters();
   await verifyExportMeasuresItsSizeCapInBytes();
 
   console.log('Story route contract tests passed');


### PR DESCRIPTION
## Scope

Three small, independent defects, each reproduced against the old code before the fix was written.

### 1. `/api/image/generate` wrote the caller's `style` into the log as it arrived

The route's request line reports four caller-supplied fields. `storyId`, `creature`, and `themes` each go through `loggableRequestParameters`, which exists so a value is repeated only when it is on the contract's own allow-list. `style` was written as `style: input.style`.

Nothing before that line constrains it. The route's guard tests the field for truthiness (`!input.style`), and the closed-set check lives in `ImageService.validateImageInput`, which has not run yet. So a body of `{"style": "Dana is in treatment at the clinic on Rosewood", …}` put that sentence in the console and in the buffer the debug panel reads, verbatim, under a log key that is deliberately kept. The token redaction every logged string passes through does not cover it — that removes credentials, addresses, and URLs, not prose.

`ImageStyle` names five values, so there is a list to be recognised against. `toLoggableImageStyle` joins its three siblings and reads `VALIDATION_RULES.imageStyle.allowedValues` rather than restating them.

### 2. The same line reported the app's own themes as unrecognized

`toLoggableThemes` filtered against `VALIDATION_RULES.themes.allowedValues` — the eighteen classic `ThemeType`s. No screen in this repository sends those. `app.ts` builds its picker from twelve Story Lab `ThemeSeed`s and passes `theme.id` straight through, and seven of the twelve (`court_intrigue`, `blood_oaths`, `slow_burn`, `enemies_to_lovers`, `magical_bargain`, `secret_identity`, `forced_proximity`) are on no other list.

So the filter was rejecting the app's own traffic. A reader who picked "Court Intrigue" and "Blood Oaths" and generated a chapter image produced the request line `themes: [], unrecognizedThemeCount: 2` — the marker that means *the caller sent something that is not a theme*, written about the two themes the picker itself offered. The diagnostic the module exists to preserve, which themes were asked for, was blanked for exactly the requests that matter and kept intact only for a vocabulary nothing sends.

This is the second time the same drift has been fixed in this route: `ImageService.mapThemeToVisualElement` described those seven seeds to the image model as `mysterious elements` until #238. The list had one copy, in `app.ts`, invisible to the server side of the seam. It now lives in `shared/storyLabThemeSeeds.ts`, which the picker, the log allow-list, and `tests/image-service.test.ts` all read — that test having previously held its own transcription, so a seed added to the picker and not to the test would have passed.

Widening the allow-list does not turn the filter off: a value from neither picker is still reported by count rather than repeated.

### 3. Proving Grounds showed a siren and a djinn the fairy author bank

`GenerationLogicService.getAllAuthorStyles` — the panel's preview of which authors the API will be asked to write like — fell `siren` and `djinn` through to `fairyStyles`. The API has had its own `SIREN_STYLES` and `DJINN_STYLES` since that identical fallthrough was fixed in `api/_lib/config/authorStyles.ts` (#237); the browser-side copy was left behind.

For two of the ten creatures the screen therefore reported twelve fae authors — Sarah J. Maas, Holly Black, Julie Kagawa — for a story the server generated from four sea or wish voices. A prompt-comparison tool that shows a prompt the run did not use is worse than one that shows nothing, because the reader has no way to tell.

The spec was asserting the defect outright: `fairy, siren, and djinn share the same fairy-styles pool` was a green test over the drift. It is replaced by one requiring every creature's bank to differ from every other's, and one naming the siren and djinn authors the API actually uses — a borrowed bank is still a non-empty, creature-shaped list, so only the contents catch it.

## Validation

| Command | Result |
|---|---|
| `npm run test:all` | passed (74 suites) |
| `cd story-generator && ng test --watch=false --browsers=ChromeHeadlessNoSandbox` | 176 of 176 passed |
| `npm run build` | passed |
| `npx tsc --noEmit --strict` over the new/changed shared + util files | passed |
| `git diff --check` | passed |

Each fix was reproduced by reverting one file at a time and re-running, so no assertion is passing for another's reason:

- `caller text sent as an image style must not reach the buffer`
- `a request the app itself makes should have its themes logged intact (got …"themes":[],"unrecognizedThemeCount":2…)`
- two named Karma failures for the siren and djinn author banks

The theme fix needed both readings asserted, because a filter that blanks everything satisfies "no caller text in the log" perfectly — which is how this defect survived. The route-contract test now checks that an ordinary request's themes arrive intact as well as that prose does not.

## Non-claims

This slice changes no prompt, no generated story, and no route's status or payload. It changes what two log fields record, where the theme seed list lives, and which author bank one browser panel displays.

The `proving-grounds.css` budget warning during `npm run build` (68 bytes over 12 kB) predates this slice and is untouched by it.

## Next-slice notes

`tests/story-quality-evals.test.ts` and `api/_lib/story-lab/evaluation/storyQualityHeuristics.ts` still hold their own theme handling; `scoreContinuity` filters theme words by `length > 3`, which drops the `sin` theme entirely. Not touched here — it is an advisory heuristic, not a seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GH1kCZtZ8s6gytSs7pV7gh

---
_Generated by [Claude Code](https://claude.ai/code/session_01GH1kCZtZ8s6gytSs7pV7gh)_

## Summary by Sourcery

Correct image request diagnostics and creature author previews so they reflect validated caller input and the server's actual configuration.

Bug Fixes:
- Prevent arbitrary caller text from being written to image-generation request logs by validating image styles before recording them.
- Preserve Story Lab theme selections in request logs while continuing to flag values outside the supported theme vocabularies.
- Show the correct siren and djinn author banks in the Proving Grounds preview.

Enhancements:
- Centralize Story Lab theme seed definitions for reuse by the picker, server-side logging, and image-service tests.

Documentation:
- Document the three fixes in the unreleased changelog and PR recovery work log.

Tests:
- Add coverage ensuring image styles are safely logged, app-provided themes remain intact, and invalid themes are still counted.
- Replace the author-bank regression test with coverage requiring distinct creature banks and verifying the siren and djinn authors.