### PR TITLE
Three quick wins: a blend voice missing from every prompt preview, a theme picker no reader can reach, a form refusing what the API accepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   coin flip. The spec that accepted "anything from two authors up to the size of
   the bank" was accepting the defect exactly; it is replaced by one asserting the
   two-plus-one shape for every creature and one naming the pairings.
+- Porting the pairings surfaced that the panel's `werewolfStyles` and `fairyStyles`
+  were not the API's banks either — six of the twelve werewolf voices and three of
+  the twelve fae ones were names `WEREWOLF_STYLES` and `FAIRY_STYLES` have never
+  held, in a different order and with different voice samples and traits, and
+  `Nalini Singh` appeared twice inside the panel's own werewolf bank. Every
+  creature except siren borrows werewolf or fae for its blend voice, so pointing
+  the selection at the right banks while the banks themselves were wrong would
+  have left almost every preview still able to name an author the server could not
+  pick. Both are now the API's, transplanted rather than retyped, and pinned by
+  name the way the siren and djinn banks already were.
+- The two banks were also what made a preview able to name the *same* author
+  twice. `Kresley Cole` and `Laurell K. Hamilton` sat in both the panel's vampire
+  and werewolf banks, and `Nalini Singh` and `Jennifer L. Armentrout` in both its
+  werewolf and fae ones, so a vampire or fae draw could take one voice from each
+  bank and get one author — losing the variety the third voice exists for, and
+  handing two identical keys to a template that tracked by author name, which
+  Angular answers with an NG0955 runtime error rather than a render. The API's ten
+  banks share no name at all, within a bank or between any creature's two pools,
+  so the port removes the collision; a spec now states that property so a later
+  bank edit fails a test instead of a reader's screen, and the template tracks the
+  draw by position, which is the only identity a freshly-shuffled list has.
 
 #### Proving Grounds offered ten themes, five of which no reader can send
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,78 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Three Quick Wins — a blend voice missing from every prompt preview, a theme picker no reader can reach, a form refusing what the API accepts (August 26, 2026)
+
+#### Proving Grounds never showed the third author the API actually blends in
+
+- `selectRandomAuthorStyles` in `api/_lib/config/authorStyles.ts` builds every
+  story's prompt from **two** voices out of the creature's own bank and **one**
+  out of a second bank belonging to other creatures — a werewolf story is written
+  by two werewolf voices and one vampire or fae one. That third voice is the
+  entire reason the API keeps a `getSecondaryAuthorStyles` table.
+- `GenerationLogicService.selectRandomAuthors`, whose stated job is to "simulate
+  the random selection logic from storyService", drew `2 + randomInt(2)` voices
+  and took all of them from the primary bank. So the panel disagreed with the run
+  twice over: the blend voice was absent from every preview for every one of the
+  ten creatures, and a preview that happened to roll three named three
+  same-creature voices where the generator had used two.
+- This is the second half of the fallthrough fixed in the previous slice. That
+  one made the panel read the right *primary* bank for `siren` and `djinn`; the
+  secondary bank had never been ported at all, so the panel was still describing
+  a prompt the run did not use — the failure a prompt-comparison tool cannot
+  afford, because the reader has no way to tell.
+- `getSecondaryAuthorStyles` is ported with the API's pairings, and the counts are
+  named (`PRIMARY_AUTHOR_COUNT`, `SECONDARY_AUTHOR_COUNT`) rather than left as a
+  coin flip. The spec that accepted "anything from two authors up to the size of
+  the bank" was accepting the defect exactly; it is replaced by one asserting the
+  two-plus-one shape for every creature and one naming the pairings.
+
+#### Proving Grounds offered ten themes, five of which no reader can send
+
+- Its `themeOptions` was a thirteenth copy of the theme vocabulary and it was the
+  other one: ten classic `ThemeType` ids with descriptions written for that page.
+  `app.ts` builds its picker from `STORY_LAB_THEME_SEEDS`, so those twelve seeds
+  are the only themes any request the app makes actually carries. The two lists
+  overlap on five ids.
+- Seven of the app's themes — `court_intrigue`, `blood_oaths`, `slow_burn`,
+  `enemies_to_lovers`, `magical_bargain`, `secret_identity`, `forced_proximity` —
+  could not be tested at all in the one screen built for testing prompts, and five
+  of the ids on offer (`betrayal`, `power_dynamics`, `manipulation`, `seduction`,
+  `desire`) are ones no reader can pick.
+- The five shared ids were the worse half, because they looked right. A seed's
+  `label` and `description` are carried into the generation prompt, not merely
+  printed beside a checkbox, so `Dark Secrets / Hidden history threatens the bond.`
+  here and `Hidden Secrets / Someone is lying beautifully.` in the app are two
+  different prompts under one id — a comparison tool reporting on prose the app
+  would never have asked for, with nothing in the output to say so.
+- The picker now reads `shared/storyLabThemeSeeds.ts`, the module the previous
+  slice created for exactly this class of drift, and its selection cap moves from
+  a hard-coded three to `STORY_BLUEPRINT_LIMITS.maxThemes` — the five the route
+  accepts and `FormValidationService` enforces. The label states that number
+  rather than restating it.
+
+#### The blueprint form refused loglines the API would have accepted
+
+- `parseStoryLabBlueprint` reads `logline` through `.trim()`, and `worldDetails`
+  and `narrativeDirectives` through `optionalString`, which trims too — and only
+  then compares against `STORY_BLUEPRINT_LIMITS`. `FormValidationService` measured
+  the raw value.
+- So surrounding whitespace counted on one side of the seam and not the other. A
+  logline pasted with a trailing newline — the ordinary result of copying a
+  paragraph out of a document — was refused by the form at exactly the cap the
+  route accepts it under, with a message telling the reader to shorten prose that
+  was already short enough.
+- `describeNarrativeDirectivesOverflow` in the shared limits module was written to
+  avoid this and says so in its own comment: measuring the field any other way
+  "would refuse a request the route would have taken". Both readers of the shared
+  numbers now measure it the same way the route does.
+- `heatContract.noGoContent` is deliberately left as it was: the parser checks that
+  field's length *without* trimming, so trimming it in the form would accept a
+  contract the route refuses — the drift running the more expensive way.
+- The parser's own trimming of `logline` and `worldDetails` was stated nowhere,
+  which is how the form came to disagree with it. `tests/story-lab-blueprint-parser.test.ts`
+  now pins it, beside the `narrativeDirectives` case that was already covered.
+
 ### 🐛 Three Quick Wins — an image style logged verbatim, the app's own themes reported as unrecognized, two creatures previewed as a third (August 26, 2026)
 
 #### `/api/image/generate` wrote the caller's `style` into the log as it arrived

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -4,6 +4,30 @@ Created: 2026-05-26 00:12 EDT
 
 This is the chronological work log for the PR #70 recovery. It should capture commands, decisions, self-review notes, validation results, and anything that changes the plan.
 
+## 2026-08-26 UTC - A Blend Voice Missing From Every Prompt Preview, A Theme Picker No Reader Can Reach, And A Form Refusing What The API Accepts
+
+Actions:
+
+- Ported `getSecondaryAuthorStyles` into `GenerationLogicService` and rebuilt `selectRandomAuthors` on the API's two-plus-one shape. `selectRandomAuthorStyles` takes two voices from the creature's own bank and one from a second bank belonging to other creatures; the panel drew `2 + randomInt(2)` voices, all primary. So the blend voice was missing from every preview for all ten creatures, and a preview that rolled three named three same-creature voices where the generator had used two. This is the other half of the fallthrough PR #240 fixed: that slice gave `siren` and `djinn` the right primary bank, but the secondary table had never been ported at all.
+- Pointed the Proving Grounds theme picker at `shared/storyLabThemeSeeds.ts`. `themeOptions` was a thirteenth copy of the vocabulary and the wrong one — ten classic `ThemeType` ids with descriptions written for that page — so seven of the app's twelve seeds could not be tested at all and five of the ids on offer are ones no reader can send. The five shared ids were worse: a seed's `label` and `description` reach the generation prompt, so matching ids carrying different wording had the panel reporting on prose the app would never have asked for.
+- Moved that picker's selection cap from a hard-coded three to `STORY_BLUEPRINT_LIMITS.maxThemes`, and made the label state the number instead of restating it.
+- Made `FormValidationService` measure `logline`, `worldDetails`, and `narrativeDirectives` the way the parser does. `parseStoryLabBlueprint` trims all three before comparing against the shared caps; the form counted the raw value, so a logline pasted with a trailing newline was refused at exactly the cap the route accepts it under. `heatContract.noGoContent` is left untrimmed on purpose — the parser does not trim that one, so trimming it here would accept a contract the route refuses.
+- Extended `tests/story-lab-blueprint-parser.test.ts` (registered in `test:all`) to pin the parser's trimming of `logline` and `worldDetails`, which was stated nowhere and is what the form has to mirror. Added and replaced specs in `generation-logic.service.spec.ts`, `proving-grounds.spec.ts`, and `form-validation.service.spec.ts`.
+
+Self-review:
+
+- Good: every fix was reproduced against the old behaviour before being kept. Reverting the three source files while leaving the specs in place produced four named Karma failures — `selectRandomAuthors draws two voices from the primary bank and one from the secondary bank`, `offers exactly the thematic seeds the app picker offers`, `lets a test carry as many seeds as the blueprint route accepts`, `accepts free text that only exceeds a cap through surrounding whitespace` — and no others.
+- Two existing specs were asserting the defect and were replaced rather than deleted. `selectRandomAuthors never returns more authors than exist for the creature` accepted anything from two authors up to the size of the bank, which is precisely the range the defect produced; `generateRandomLogic` required every selected author to be in the primary bank, which a selection that never reaches the secondary bank satisfies by construction.
+- The secondary-bank assertion had to be written as the API's pairings rather than as "borrows another creature". Several author names appear in two banks — `Kresley Cole` and `Laurell K. Hamilton` in both vampire and werewolf, `Nalini Singh` in both werewolf and fairy — so a disjointness check would have failed on correct data.
+- Non-claim: this slice changes no API route, no prompt the server builds, and no generated story. It changes which authors one browser panel previews, which themes that panel offers, and where the Angular form draws the line on three free-text fields.
+
+Validation:
+
+- `npm test`: passed (all suites).
+- `cd story-generator && CHROME_BIN=/opt/pw-browsers/chromium-1194/chrome-linux/chrome npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox`: 182 of 182 passed.
+- `tsc -p tsconfig.app.json --noEmit`, `tsc -p tsconfig.spec.json --noEmit`, and the Vercel API function typecheck: passed.
+- `git diff --check`: passed.
+
 ## 2026-08-26 UTC - An Image Style Logged Verbatim, The App's Own Themes Reported As Unrecognized, And Two Creatures Previewed As A Third
 
 Actions:

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -21,11 +21,24 @@ Self-review:
 - The secondary-bank assertion had to be written as the API's pairings rather than as "borrows another creature". Several author names appear in two banks — `Kresley Cole` and `Laurell K. Hamilton` in both vampire and werewolf, `Nalini Singh` in both werewolf and fairy — so a disjointness check would have failed on correct data.
 - Non-claim: this slice changes no API route, no prompt the server builds, and no generated story. It changes which authors one browser panel previews, which themes that panel offers, and where the Angular form draws the line on three free-text fields.
 
+Review follow-up (same slice, after Codex flagged two P2s on the first push):
+
+- Transplanted the API's `WEREWOLF_STYLES` and `FAIRY_STYLES` over the panel's own copies. Codex was right and the divergence was larger than the pairings: six of the twelve werewolf voices and three of the twelve fae ones were authors the API has never generated from, in a different order and with different voice samples and traits, and `Nalini Singh` was listed twice in the panel's werewolf bank. Nine of the ten creatures borrow werewolf or fae for their blend voice, so fixing the selection while the banks stayed wrong would have left almost every preview still naming authors the server could not pick — the parity this slice claims. The banks were extracted from `api/_lib/config/authorStyles.ts` by script and diffed back rather than retyped; `VAMPIRE_STYLES` already matched byte for byte.
+- Changed the author list's `@for` from `track author.author` to `track $index`, and added a spec asserting that no creature can draw one author from both its banks. Codex's other P2 was the same defect seen from the template: the panel's banks put `Kresley Cole` and `Laurell K. Hamilton` in both vampire and werewolf, and `Nalini Singh` and `Jennifer L. Armentrout` in both werewolf and fae, so a vampire or fae draw could return the same author twice and hand Angular two identical keys, which is an NG0955 runtime error rather than a render. The API's ten banks share no name anywhere, so the port removes the collision; the spec keeps a later bank edit from reintroducing it silently, and position is the only identity a freshly-shuffled draw of three has.
+
+Self-review (follow-up):
+
+- Both findings were verified against the code before either was acted on, not taken on the bot's word: a script extracted the three shared banks from both trees and compared author lists, and a second one checked every creature's primary bank against its secondary pool for overlap across all ten of the API's banks.
+- The two findings turned out to be one cause. The duplicate-key error was reachable only because the panel's werewolf and fae banks were the wrong lists; deduplicating the selection instead — the fix the comment proposed first — would have made the panel diverge from the API in a new way, since `selectRandomAuthorStyles` does not deduplicate and does not need to.
+- Both new specs were confirmed to fail against the pre-port banks (`reads the werewolf and fae banks the API generates those creatures from`, `never lets a creature draw the same author from both of its banks`) and to pass after.
+- Known and not addressed here: the ten author banks now exist in full in two trees, which is the same one-copy-per-reader shape `shared/storyLabThemeSeeds.ts` was created to end. Moving them under `shared/` is the durable fix and is a change to the API tree as well, so it is worth its own slice rather than being folded into this one.
+
 Validation:
 
 - `npm test`: passed (all suites).
-- `cd story-generator && CHROME_BIN=/opt/pw-browsers/chromium-1194/chrome-linux/chrome npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox`: 182 of 182 passed.
+- `cd story-generator && CHROME_BIN=/opt/pw-browsers/chromium-1194/chrome-linux/chrome npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox`: 184 of 184 passed (182 before the follow-up specs).
 - `tsc -p tsconfig.app.json --noEmit`, `tsc -p tsconfig.spec.json --noEmit`, and the Vercel API function typecheck: passed.
+- `npm run build`: passed.
 - `git diff --check`: passed.
 
 ## 2026-08-26 UTC - An Image Style Logged Verbatim, The App's Own Themes Reported As Unrecognized, And Two Creatures Previewed As A Third

--- a/story-generator/src/app/form-validation.service.spec.ts
+++ b/story-generator/src/app/form-validation.service.spec.ts
@@ -93,6 +93,32 @@ describe('FormValidationService', () => {
     expect(errors.heatContract).toContain('supported Heat Contract settings');
   });
 
+  // The three free-text caps the blueprint parser measures after trimming. A
+  // value that is exactly the cap once trimmed is one the route accepts, so
+  // refusing it here is the form disagreeing with the API about a blueprint that
+  // is fine — the failure the shared limits module exists to prevent.
+  it('accepts free text that only exceeds a cap through surrounding whitespace', () => {
+    const errors = service.validateBlueprint(createBlueprint({
+      logline: `${'l'.repeat(service.maxLoglineLength)}\n`,
+      worldDetails: `  ${'w'.repeat(service.maxWorldDetailsLength)}  `,
+      narrativeDirectives: `${'d'.repeat(service.maxNarrativeDirectivesLength)}\n\n`
+    }));
+
+    expect(service.isValid(errors)).withContext(service.getFirstError(errors) ?? '').toBeTrue();
+  });
+
+  it('still rejects free text past a cap once the surrounding whitespace is gone', () => {
+    const errors = service.validateBlueprint(createBlueprint({
+      logline: ` ${'l'.repeat(service.maxLoglineLength + 1)} `,
+      worldDetails: ` ${'w'.repeat(service.maxWorldDetailsLength + 1)} `,
+      narrativeDirectives: ` ${'d'.repeat(service.maxNarrativeDirectivesLength + 1)} `
+    }));
+
+    expect(errors.logline).toContain('logline');
+    expect(errors.worldDetails).toContain('world details');
+    expect(errors.narrativeDirectives).toContain('narrative directives');
+  });
+
   it('rejects unsupported Heat Contract intimacy boundary', () => {
     const errors = service.validateBlueprint(createBlueprint({
       heatContract: {

--- a/story-generator/src/app/form-validation.service.ts
+++ b/story-generator/src/app/form-validation.service.ts
@@ -47,6 +47,32 @@ const VALID_BATCH_SIZES = new Set<ChapterBatchSize>([1, 2, 3]);
 const VALID_HEAT_TENSION_MODES = new Set<HeatTensionMode>(['slow_burn', 'dangerous_proximity', 'playful_banter', 'devotional_longing']);
 const VALID_HEAT_BOUNDARIES = new Set<HeatIntimacyBoundary>(['fade_to_black', 'closed_door', 'literary_on_page']);
 
+/**
+ * The length the API will measure this free-text field at.
+ *
+ * `parseStoryLabBlueprint` reads `logline` through `.trim()` and `worldDetails`
+ * and `narrativeDirectives` through `optionalString`, which trims too, and only
+ * then compares against `STORY_BLUEPRINT_LIMITS`. This service read the raw
+ * value, so surrounding whitespace counted here and not there: a logline pasted
+ * with a trailing newline — the ordinary result of copying a paragraph out of a
+ * document — was refused by the form at exactly the cap the route would have
+ * accepted it under, with a message telling the reader to shorten prose that was
+ * already short enough.
+ *
+ * That is the mirror of the failure `describeNarrativeDirectivesOverflow` in the
+ * shared limits module was written to avoid, and it says so: measuring this any
+ * other way "would refuse a request the route would have taken". Both readers of
+ * the shared numbers now measure the field the same way the route does.
+ *
+ * `heatContract.noGoContent` is deliberately not routed through here. The parser
+ * checks that field's length as sent, without trimming, so trimming it here
+ * would accept a contract the route refuses — the drift running the other way,
+ * which is the more expensive direction.
+ */
+function measuredLength(value: string | undefined): number {
+  return value?.trim().length ?? 0;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -83,7 +109,7 @@ export class FormValidationService {
 
     if (!input.logline?.trim()) {
       errors.logline = 'Add a logline so the story has a clear hook.';
-    } else if (input.logline.length > this.maxLoglineLength) {
+    } else if (measuredLength(input.logline) > this.maxLoglineLength) {
       errors.logline = `Keep the logline under ${this.maxLoglineLength} characters.`;
     }
 
@@ -110,11 +136,11 @@ export class FormValidationService {
       errors.chapterBatchSize = 'Choose 1, 2, or 3 chapters per batch.';
     }
 
-    if ((input.worldDetails?.length ?? 0) > this.maxWorldDetailsLength) {
+    if (measuredLength(input.worldDetails) > this.maxWorldDetailsLength) {
       errors.worldDetails = `Keep world details under ${this.maxWorldDetailsLength} characters.`;
     }
 
-    if ((input.narrativeDirectives?.length ?? 0) > this.maxNarrativeDirectivesLength) {
+    if (measuredLength(input.narrativeDirectives) > this.maxNarrativeDirectivesLength) {
       errors.narrativeDirectives = `Keep narrative directives under ${this.maxNarrativeDirectivesLength} characters.`;
     }
 

--- a/story-generator/src/app/proving-grounds/generation-logic.service.spec.ts
+++ b/story-generator/src/app/proving-grounds/generation-logic.service.spec.ts
@@ -51,6 +51,51 @@ describe('GenerationLogicService', () => {
 
   // Named rather than checked by shape: a bank borrowed from a neighbour is
   // still a non-empty, creature-shaped list, so only the contents catch it.
+  // Named for the same reason the siren and djinn banks are named below. These
+  // two were the last banks still carrying the panel's own authors: six of the
+  // twelve werewolf voices and three of the twelve fae ones were names the API
+  // has never generated from — and `Nalini Singh` appeared twice in the same
+  // werewolf bank. Every creature borrows werewolf or fae for its blend voice
+  // except siren, so a preview of almost any creature could name an author the
+  // server could not have picked.
+  it('reads the werewolf and fae banks the API generates those creatures from', () => {
+    expect(service.getAllAuthorStyles('werewolf').map(style => style.author))
+      .toEqual([
+        'Patricia Briggs', 'Ilona Andrews', 'Nalini Singh', 'Kelley Armstrong',
+        'Jennifer Ashley', 'Carrie Ann Ryan', 'Shelly Laurenston', 'Suzanne Wright',
+        'Faith Hunter', 'Keri Arthur', 'Rachel Vincent', 'Chloe Neill'
+      ]);
+    expect(service.getAllAuthorStyles('fairy').map(style => style.author))
+      .toEqual([
+        'Holly Black', 'Sarah J. Maas', 'Melissa Marr', 'Grace Draven',
+        'Julie Kagawa', 'Karen Marie Moning', 'Elise Kova', 'Jennifer Estep',
+        'Cassandra Clare', 'Sylvia Mercedes', 'Roshani Chokshi', 'Laura Thalassa'
+      ]);
+  });
+
+  // The property that keeps a three-voice draw three distinct voices. It holds
+  // across the API's banks today, and it is not a coincidence worth relying on
+  // silently: while the panel carried its own werewolf and fae lists, `Kresley
+  // Cole` and `Laurell K. Hamilton` sat in both the vampire and werewolf banks,
+  // so a vampire preview could draw the same author twice — reducing the variety
+  // the third voice exists for, and feeding two identical keys to a template
+  // that tracked by author name.
+  it('never lets a creature draw the same author from both of its banks', () => {
+    const creatures: CreatureArchetype[] = [
+      'vampire', 'werewolf', 'fairy', 'siren', 'djinn', 'witch', 'dragon', 'demon', 'angel', 'mermaid'
+    ];
+
+    for (const creature of creatures) {
+      const primary = service.getAllAuthorStyles(creature).map(style => style.author);
+      const secondary = service.getSecondaryAuthorStyles(creature).map(style => style.author);
+
+      expect(new Set(primary).size).withContext(`${creature} primary bank`).toBe(primary.length);
+      expect(primary.filter(author => secondary.includes(author)))
+        .withContext(`${creature} draws these from both banks`)
+        .toEqual([]);
+    }
+  });
+
   it('reads the siren and djinn banks the API generates those creatures from', () => {
     expect(service.getAllAuthorStyles('siren').map(style => style.author))
       .toEqual(['Drowning-Song Gothic', 'Salt-Debt Bargainer', 'Storm-Voice Romance', 'Harbour-Watch Longing']);

--- a/story-generator/src/app/proving-grounds/generation-logic.service.spec.ts
+++ b/story-generator/src/app/proving-grounds/generation-logic.service.spec.ts
@@ -58,14 +58,71 @@ describe('GenerationLogicService', () => {
       .toEqual(['Three-Wish Jurisprudence', 'Lamp-Bound Devotion', 'Smokeless-Fire Epic', 'Brass-Seal Bargain']);
   });
 
-  it('selectRandomAuthors never returns more authors than exist for the creature, and never duplicates one', () => {
+  it('selectRandomAuthors never duplicates a voice within one selection', () => {
     for (let i = 0; i < 20; i++) {
       const authors = service.selectRandomAuthors('witch');
-      expect(authors.length).toBeGreaterThanOrEqual(2);
-      expect(authors.length).toBeLessThanOrEqual(service.getAllAuthorStyles('witch').length);
 
       const uniqueNames = new Set(authors.map(author => author.author));
       expect(uniqueNames.size).toBe(authors.length);
+    }
+  });
+
+  // The shape the API builds, asserted as a shape rather than as a range: the
+  // previous version accepted anything from two authors up to the size of the
+  // primary bank, which is exactly what the defect produced. `selectRandomAuthors`
+  // drew two or three voices from the creature's own bank and never touched the
+  // secondary one, so the blend voice `selectRandomAuthorStyles` puts in every
+  // real prompt was missing from every preview.
+  it('selectRandomAuthors draws two voices from the primary bank and one from the secondary bank', () => {
+    const creatures: CreatureArchetype[] = [
+      'vampire', 'werewolf', 'fairy', 'siren', 'djinn', 'witch', 'dragon', 'demon', 'angel', 'mermaid'
+    ];
+
+    for (const creature of creatures) {
+      const primaryNames = new Set(service.getAllAuthorStyles(creature).map(style => style.author));
+      const secondaryNames = new Set(service.getSecondaryAuthorStyles(creature).map(style => style.author));
+
+      for (let i = 0; i < 10; i++) {
+        const authors = service.selectRandomAuthors(creature);
+
+        expect(authors.length).withContext(creature).toBe(3);
+        expect(authors.slice(0, 2).every(author => primaryNames.has(author.author)))
+          .withContext(`${creature} primary voices`)
+          .toBeTrue();
+        expect(secondaryNames.has(authors[2].author))
+          .withContext(`${creature} blend voice`)
+          .toBeTrue();
+      }
+    }
+  });
+
+  // The pairings themselves, spelled out the way `getSecondaryAuthorStyles` in
+  // `api/_lib/config/authorStyles.ts` spells them. Checked by name rather than
+  // by shape because a secondary bank pointing at the wrong creature is still a
+  // non-empty list of other creatures' voices, and the panel would still show
+  // three authors — the failure this exists to catch is a preview that names a
+  // blend the run never used.
+  it('pairs every creature with the two banks the API blends it with', () => {
+    const expectedPairings: ReadonlyArray<readonly [CreatureArchetype, CreatureArchetype, CreatureArchetype]> = [
+      ['vampire', 'werewolf', 'fairy'],
+      ['werewolf', 'vampire', 'fairy'],
+      ['fairy', 'vampire', 'werewolf'],
+      ['siren', 'mermaid', 'fairy'],
+      ['djinn', 'fairy', 'demon'],
+      ['witch', 'fairy', 'vampire'],
+      ['dragon', 'werewolf', 'fairy'],
+      ['demon', 'vampire', 'fairy'],
+      ['angel', 'fairy', 'witch'],
+      ['mermaid', 'fairy', 'werewolf']
+    ];
+
+    for (const [creature, first, second] of expectedPairings) {
+      expect(service.getSecondaryAuthorStyles(creature).map(style => style.author))
+        .withContext(`${creature} blends ${first} and ${second}`)
+        .toEqual([
+          ...service.getAllAuthorStyles(first).map(style => style.author),
+          ...service.getAllAuthorStyles(second).map(style => style.author)
+        ]);
     }
   });
 
@@ -92,10 +149,17 @@ describe('GenerationLogicService', () => {
 
   it('generateRandomLogic assembles authors, a beat structure, and Chekov elements for the requested creature', () => {
     const logic = service.generateRandomLogic('dragon');
+    // Both banks, because the third voice comes from the secondary one. Asserting
+    // membership of the primary bank alone is how the missing blend voice went
+    // unnoticed: a selection that never left the primary bank passed it.
+    const drawableStyles = [
+      ...service.getAllAuthorStyles('dragon'),
+      ...service.getSecondaryAuthorStyles('dragon')
+    ];
 
-    expect(logic.selectedAuthors.length).toBeGreaterThan(0);
+    expect(logic.selectedAuthors.length).toBe(3);
     for (const author of logic.selectedAuthors) {
-      expect(service.getAllAuthorStyles('dragon')).toContain(author);
+      expect(drawableStyles).toContain(author);
     }
     expect(logic.selectedBeatStructure).toBeTruthy();
     expect(logic.chekovElements.length).toBe(2);

--- a/story-generator/src/app/proving-grounds/generation-logic.service.ts
+++ b/story-generator/src/app/proving-grounds/generation-logic.service.ts
@@ -132,125 +132,125 @@ export class GenerationLogicService {
     {
       author: 'Patricia Briggs',
       voiceSample: '"Pack means family. And family means I\'ll tear apart anyone who threatens what\'s mine."',
-      trait: 'Loyal pack dynamics with mechanical expertise'
-    },
-    {
-      author: 'Kelley Armstrong',
-      voiceSample: 'The wolf inside her stirred, recognizing the alpha in him even as her human side refused to submit.',
-      trait: 'Bitten werewolf discovering pack culture'
-    },
-    {
-      author: 'Nalini Singh',
-      voiceSample: 'His changeling leopard purred at her scent—wild forest and untamed woman, a combination that made his animal half want to chase.',
-      trait: 'Psy-Changeling world with mate bonds'
+      trait: 'Grounded pragmatism with fierce loyalty'
     },
     {
       author: 'Ilona Andrews',
-      voiceSample: '"You smell like mine," he growled, the beast in his voice making it clear this wasn\'t a request.',
-      trait: 'Kate Daniels urban fantasy with shapeshifter politics'
-    },
-    {
-      author: 'Jennifer L. Armentrout',
-      voiceSample: 'The connection between them snapped into place like a rubber band pulled too tight, inevitable and impossible to ignore.',
-      trait: 'New adult paranormal with fated mates'
-    },
-    {
-      author: 'Laurell K. Hamilton',
-      voiceSample: 'His beast rode too close to the surface, fur rippling beneath skin, amber bleeding into human eyes.',
-      trait: 'Anita Blake\'s complex werewolf power structure'
-    },
-    {
-      author: 'Yasmine Galenorn',
-      voiceSample: 'Moon magic sang in her blood, calling to the predator that lived beneath her skin, wild and free.',
-      trait: 'Sisters of the Moon goddess-touched werewolves'
-    },
-    {
-      author: 'Kresley Cole',
-      voiceSample: 'He\'d waited centuries for his mate. Now that he\'d found her, nothing—not even her terror—would keep him away.',
-      trait: 'Immortals After Dark fated mates and warrior culture'
-    },
-    {
-      author: 'Carrie Ann Ryan',
-      voiceSample: 'The mating bond thrummed between them, pack magic recognizing what their human halves still denied.',
-      trait: 'Redwood Pack family saga with pack bonds'
-    },
-    {
-      author: 'Lora Leigh',
-      voiceSample: 'Feline genetics mixed with human desire created something new, something the world wasn\'t ready for.',
-      trait: 'Breeds series genetic manipulation themes'
+      voiceSample: '"Great. Magical politics, ancient curses, and now this. Tuesday just keeps getting better."',
+      trait: 'Urban grit balanced with unexpected humor'
     },
     {
       author: 'Nalini Singh',
-      voiceSample: 'His wolf wanted to mark her, claim her, make it impossible for any other male to even look at her.',
-      trait: 'Guild Hunter world alpha dominance'
+      voiceSample: 'His wolf pressed against his skin, demanding he claim what was his, mark her, make her understand she belonged to the pack-to him.',
+      trait: 'Primal sensuality overwhelming rational thought'
+    },
+    {
+      author: 'Kelley Armstrong',
+      voiceSample: 'The change rippled through her bones like electricity, wild and barely contained, a storm waiting to break.',
+      trait: 'Suspenseful tension building like a storm'
+    },
+    {
+      author: 'Jennifer Ashley',
+      voiceSample: '"The pack protects its own. Always. Even when \'its own\' is too stubborn to ask for help."',
+      trait: 'Found family bonds stronger than blood'
+    },
+    {
+      author: 'Carrie Ann Ryan',
+      voiceSample: 'The mating bond snapped into place like fate clicking its final lock, and suddenly "mine" wasn\'t just a word-it was a destiny.',
+      trait: 'Fated mates with pack loyalty and emotional werewolf bonds'
     },
     {
       author: 'Shelly Laurenston',
-      voiceSample: '"Honey badger don\'t care," she said, right before she proved exactly how much damage a small woman with claws could do.',
-      trait: 'Pride series humor with fierce heroines'
+      voiceSample: '"Did you just challenge me to an alpha battle in the middle of brunch? Honey, I haven\'t even had my coffee yet."',
+      trait: 'Comedic werewolf chaos with irreverent alpha battles'
+    },
+    {
+      author: 'Suzanne Wright',
+      voiceSample: 'Possessive didn\'t begin to cover it. His wolf wanted to wrap around her, claim her, make sure every shifter within a hundred miles knew she was his.',
+      trait: 'Possessive alpha wolves with pack mentality and steamy romance'
+    },
+    {
+      author: 'Faith Hunter',
+      voiceSample: 'The skinwalker magic crawled across her skin, werewolf and vampire scents mixing in the humid Southern night like a supernatural storm brewing.',
+      trait: 'Southern Gothic werewolves with vampire-werewolf tension and skinwalker magic'
+    },
+    {
+      author: 'Keri Arthur',
+      voiceSample: 'Werewolf detective, vampire lover, and a murder case that smelled like death and dark magic. Just another night in the Riley Jenson universe.',
+      trait: 'Werewolf detective noir with Riley Jenson vibes and hybrid powers'
+    },
+    {
+      author: 'Rachel Vincent',
+      voiceSample: 'Territory. Dominance. Pride. The werecat politics translated perfectly to werewolf pack law-fight for your place or lose everything.',
+      trait: 'Werecats/shifter politics crossover with territorial dominance and family saga'
+    },
+    {
+      author: 'Chloe Neill',
+      voiceSample: '"Chicago werewolf packs play by different rules. Less howling at the moon, more political maneuvering with a side of violence."',
+      trait: 'Chicago werewolf packs with urban fantasy setting and political intrigue'
     }
   ];
 
   private readonly fairyStyles: AuthorStyle[] = [
     {
-      author: 'Sarah J. Maas',
-      voiceSample: 'High Fae beauty masked centuries of cunning and cruelty, but his smile promised things far more dangerous than death.',
-      trait: 'ACOTAR dark fae romance with mate bonds'
+      author: 'Holly Black',
+      voiceSample: '"I could give you what you desire most," she said, and her smile was sharp as winter. "The question is: what are you willing to lose for it?"',
+      trait: 'Court intrigue where every smile hides daggers'
     },
     {
-      author: 'Holly Black',
-      voiceSample: 'The Folk never lie, but truth can be shaped into weapons sharper than any blade forged in their realm.',
-      trait: 'Cruel Prince political intrigue and deception'
+      author: 'Sarah J. Maas',
+      voiceSample: 'Power thrummed beneath her skin like a living thing, ancient and terrible and beautiful enough to bring kingdoms to their knees.',
+      trait: 'Epic romance with world-shattering consequences'
+    },
+    {
+      author: 'Melissa Marr',
+      voiceSample: 'The mortal world blurred at the edges when he looked at her, reality bending around the impossible pull of fae magic.',
+      trait: 'Dangerous beauty drawing moths to flame'
+    },
+    {
+      author: 'Grace Draven',
+      voiceSample: '"In my realm, we have a saying: \'Love is the cruelest magic, for it makes even immortals mortal.\'"',
+      trait: 'Slow-burn intimacy across cultural impossibilities'
     },
     {
       author: 'Julie Kagawa',
-      voiceSample: 'Summer and Winter courts circled each other like predators, and she stood in the middle, desired by both.',
-      trait: 'Iron Fey world with court politics'
-    },
-    {
-      author: 'Jennifer L. Armentrout',
-      voiceSample: 'Fae glamour couldn\'t hide the wildness in his eyes, the barely leashed power that promised pleasure and pain in equal measure.',
-      trait: 'Dark Elements series fae warriors'
+      voiceSample: 'Honor and desire warred in his expression, duty and longing locked in a battle that would determine both their fates.',
+      trait: 'Hybrid honor versus desire in heart-wrenching choices'
     },
     {
       author: 'Karen Marie Moning',
-      voiceSample: 'Unseelie princes played with humans like toys, but she\'d learned their games and was playing to win.',
-      trait: 'Fever series dark fae mythology'
-    },
-    {
-      author: 'Cassandra Clare',
-      voiceSample: 'Seelie beauty hid seelie cruelty, and she\'d fallen for both—hook, line, and sinker.',
-      trait: 'Shadowhunter world fae courts'
+      voiceSample: '"Welcome to Dublin, where the Unseelie princes play and humans are just pretty toys to break." She should run. She should definitely run.',
+      trait: 'Fever series Fae with dark Unseelie princes and Dublin setting'
     },
     {
       author: 'Elise Kova',
-      voiceSample: 'Wings of starlight and eyes of eternal night—he was everything the stories warned about and everything she wanted.',
-      trait: 'Air Awakens elemental magic and fae romance'
-    },
-    {
-      author: 'Roshani Chokshi',
-      voiceSample: 'The bargain tasted of midnight and promises, sweet poison that would bind her to him until the stars fell.',
-      trait: 'Gilded Wolves mythology-rich fae bargains'
-    },
-    {
-      author: 'Nalini Singh',
-      voiceSample: 'Guild Hunter angels might not be fae, but they shared the same terrible beauty and ageless hunger.',
-      trait: 'Archangel-level power and immortal romance'
+      voiceSample: 'Air magic sang through her veins, elemental power awakening with each breath, the fairy prince watching like he knew exactly what she was becoming.',
+      trait: 'Air Awakens fairy magic with elemental powers and fantasy romance'
     },
     {
       author: 'Jennifer Estep',
-      voiceSample: 'Black Blade Academy taught her to fight monsters. No one warned her she\'d fall for one.',
-      trait: 'Academy setting with fae warrior training'
+      voiceSample: '"Mythos Academy Rule #1: Never trust a fairy. Rule #2: Especially not one who offers to teach you assassination techniques."',
+      trait: 'Mythos Academy fae with assassin protagonist and snarky tone'
     },
     {
-      author: 'Annette Marie',
-      voiceSample: 'Yokai and fae shared one thing: mortals were playthings. She\'d just have to play harder.',
-      trait: 'Guild Codex world with fae trickster energy'
+      author: 'Cassandra Clare',
+      voiceSample: 'Shadowhunter meets Seelie Court, and the lines between ally and enemy blur like glamour in moonlight-forbidden and intoxicating.',
+      trait: 'Shadowhunter fae crossover with Seelie/Unseelie courts and forbidden romance'
+    },
+    {
+      author: 'Sylvia Mercedes',
+      voiceSample: 'Bride of the Shadow King-the bargain was simple: her life for her kingdom. What she didn\'t expect was wanting to stay in the darkness.',
+      trait: 'Bride of the Shadow King vibes with dark fairy bargains and enemies-to-lovers'
+    },
+    {
+      author: 'Roshani Chokshi',
+      voiceSample: 'Indian mythology wove through the fairy realm like silk and starlight, lush magic painting the air in colors that had no earthly names.',
+      trait: 'Indian mythology fae with lush descriptions and magical realism'
     },
     {
       author: 'Laura Thalassa',
-      voiceSample: 'The Bargainer collected debts with a smile that could charm angels and destroy mortals.',
-      trait: 'Bargainer series dark fae debt collector'
+      voiceSample: '"The Bargainer collects debts, siren. And you\'ve owed me for a very long time." His smile promised wicked payments and dangerous pleasures.',
+      trait: 'Bargainer series vibes with siren fae, debts and deals'
     }
   ];
 

--- a/story-generator/src/app/proving-grounds/generation-logic.service.ts
+++ b/story-generator/src/app/proving-grounds/generation-logic.service.ts
@@ -34,6 +34,31 @@ export interface GenerationLogic {
 const PRIMARY_AUTHOR_COUNT = 2;
 const SECONDARY_AUTHOR_COUNT = 1;
 
+/**
+ * Which two banks each creature's blend voice is drawn from, as
+ * `getSecondaryAuthorStyles` in `api/_lib/config/authorStyles.ts` pairs them.
+ *
+ * A table rather than a switch, because the pairings are a table: four of the ten
+ * creatures share a pair with another one — `vampire` and `dragon` both borrow
+ * werewolf and fae, `werewolf` and `demon` both borrow vampire and fae — so a
+ * switch states two of its arms twice and a reader has to compare bodies to see
+ * that they agree. Here each creature is one line naming the banks by the same
+ * names `getAllAuthorStyles` answers to, and the repetition is visible instead of
+ * duplicated.
+ */
+const SECONDARY_AUTHOR_BANKS: Record<CreatureArchetype, readonly [CreatureArchetype, CreatureArchetype]> = {
+  vampire: ['werewolf', 'fairy'],
+  werewolf: ['vampire', 'fairy'],
+  fairy: ['vampire', 'werewolf'],
+  siren: ['mermaid', 'fairy'],
+  djinn: ['fairy', 'demon'],
+  witch: ['fairy', 'vampire'],
+  dragon: ['werewolf', 'fairy'],
+  demon: ['vampire', 'fairy'],
+  angel: ['fairy', 'witch'],
+  mermaid: ['fairy', 'werewolf']
+};
+
 @Injectable({
   providedIn: 'root'
 })
@@ -595,35 +620,14 @@ export class GenerationLogicService {
    * reconstruction: each creature borrows the two banks named there, in that
    * order, so the pool a voice is drawn from is the same pool on both sides.
    *
-   * The `default` stays for a creature that reaches here from outside
-   * `CreatureArchetype`; with every archetype named it is unreachable from the
-   * type, exactly as in `getAllAuthorStyles`.
+   * The lookup answers `[]` for a creature that reaches here from outside
+   * `CreatureArchetype`, which is what the `default` of `getAllAuthorStyles`
+   * does and is unreachable from the type for the same reason.
    */
   getSecondaryAuthorStyles(creature: CreatureArchetype): AuthorStyle[] {
-    switch (creature) {
-      case 'vampire':
-        return [...this.werewolfStyles, ...this.fairyStyles];
-      case 'werewolf':
-        return [...this.vampireStyles, ...this.fairyStyles];
-      case 'fairy':
-        return [...this.vampireStyles, ...this.werewolfStyles];
-      case 'siren':
-        return [...this.mermaidStyles, ...this.fairyStyles];
-      case 'djinn':
-        return [...this.fairyStyles, ...this.demonStyles];
-      case 'witch':
-        return [...this.fairyStyles, ...this.vampireStyles];
-      case 'dragon':
-        return [...this.werewolfStyles, ...this.fairyStyles];
-      case 'demon':
-        return [...this.vampireStyles, ...this.fairyStyles];
-      case 'angel':
-        return [...this.fairyStyles, ...this.witchStyles];
-      case 'mermaid':
-        return [...this.fairyStyles, ...this.werewolfStyles];
-      default:
-        return [];
-    }
+    const pairing = SECONDARY_AUTHOR_BANKS[creature];
+
+    return pairing ? pairing.flatMap(bank => this.getAllAuthorStyles(bank)) : [];
   }
 
   getAllBeatStructures(): BeatStructure[] {

--- a/story-generator/src/app/proving-grounds/generation-logic.service.ts
+++ b/story-generator/src/app/proving-grounds/generation-logic.service.ts
@@ -25,6 +25,15 @@ export interface GenerationLogic {
   chekovElements: ChekovElement[];
 }
 
+/**
+ * How many voices a generation draws from each bank, as
+ * `selectRandomAuthorStyles` in `api/_lib/config/authorStyles.ts` draws them.
+ * Named rather than inlined so the two slices below read as the API's shape
+ * rather than as two unrelated magic numbers.
+ */
+const PRIMARY_AUTHOR_COUNT = 2;
+const SECONDARY_AUTHOR_COUNT = 1;
+
 @Injectable({
   providedIn: 'root'
 })
@@ -577,6 +586,46 @@ export class GenerationLogicService {
     }
   }
 
+  /**
+   * The second bank a creature's prompt draws its blend voice from.
+   *
+   * Ported from `getSecondaryAuthorStyles` in `api/_lib/config/authorStyles.ts`,
+   * which is where the API decides it — see `selectRandomAuthors` below for what
+   * leaving it out was doing to this panel. The pairings are the API's, not a
+   * reconstruction: each creature borrows the two banks named there, in that
+   * order, so the pool a voice is drawn from is the same pool on both sides.
+   *
+   * The `default` stays for a creature that reaches here from outside
+   * `CreatureArchetype`; with every archetype named it is unreachable from the
+   * type, exactly as in `getAllAuthorStyles`.
+   */
+  getSecondaryAuthorStyles(creature: CreatureArchetype): AuthorStyle[] {
+    switch (creature) {
+      case 'vampire':
+        return [...this.werewolfStyles, ...this.fairyStyles];
+      case 'werewolf':
+        return [...this.vampireStyles, ...this.fairyStyles];
+      case 'fairy':
+        return [...this.vampireStyles, ...this.werewolfStyles];
+      case 'siren':
+        return [...this.mermaidStyles, ...this.fairyStyles];
+      case 'djinn':
+        return [...this.fairyStyles, ...this.demonStyles];
+      case 'witch':
+        return [...this.fairyStyles, ...this.vampireStyles];
+      case 'dragon':
+        return [...this.werewolfStyles, ...this.fairyStyles];
+      case 'demon':
+        return [...this.vampireStyles, ...this.fairyStyles];
+      case 'angel':
+        return [...this.fairyStyles, ...this.witchStyles];
+      case 'mermaid':
+        return [...this.fairyStyles, ...this.werewolfStyles];
+      default:
+        return [];
+    }
+  }
+
   getAllBeatStructures(): BeatStructure[] {
     return this.beatStructures;
   }
@@ -585,11 +634,38 @@ export class GenerationLogicService {
     return this.chekovElements;
   }
 
-  // Simulate the random selection logic from storyService
+  /**
+   * The author styles a generation would actually be prompted with.
+   *
+   * `selectRandomAuthorStyles` in `api/_lib/config/authorStyles.ts` takes two
+   * voices from the creature's own bank and one from a *second* bank belonging
+   * to other creatures — a werewolf story is written by two werewolf voices and
+   * one vampire or fae one, and that third voice is the whole reason the API
+   * keeps a `getSecondaryAuthorStyles` table at all. This panel drew two or
+   * three, all from the primary bank, so it disagreed with the run twice over:
+   * the blend voice never appeared in the preview for any creature, and a
+   * three-author preview named three primary voices where the API had used two.
+   *
+   * The count is what makes the second half wrong rather than merely incomplete.
+   * `2 + randomInt(2)` is a coin flip between two and three, so the panel that
+   * happened to roll three showed a prompt with one more same-creature voice
+   * than the generator ever builds. The API's shape is fixed — two plus one, in
+   * that order — so there is nothing to randomise here beyond which voices are
+   * drawn.
+   *
+   * `Math.min` still guards each slice, because a bank shorter than the slice it
+   * is asked for should hand back what it has rather than a padded list; the
+   * shipped banks are all at least four deep, so this is about the next one
+   * added rather than about any creature today.
+   */
   selectRandomAuthors(creature: CreatureArchetype): AuthorStyle[] {
-    const styles = this.getAllAuthorStyles(creature);
-    const count = Math.min(styles.length, 2 + this.randomInt(2));
-    return this.shuffle(styles).slice(0, count);
+    const primaryStyles = this.getAllAuthorStyles(creature);
+    const secondaryStyles = this.getSecondaryAuthorStyles(creature);
+
+    return [
+      ...this.shuffle(primaryStyles).slice(0, Math.min(PRIMARY_AUTHOR_COUNT, primaryStyles.length)),
+      ...this.shuffle(secondaryStyles).slice(0, Math.min(SECONDARY_AUTHOR_COUNT, secondaryStyles.length))
+    ];
   }
 
   selectRandomBeatStructure(): BeatStructure {

--- a/story-generator/src/app/proving-grounds/proving-grounds.html
+++ b/story-generator/src/app/proving-grounds/proving-grounds.html
@@ -174,7 +174,14 @@
             <!-- Selected Authors -->
             <div class="logic-section">
               <h4>📚 Author Styles ({{ currentGenerationLogic()!.selectedAuthors.length }}/3)</h4>
-              @for (author of currentGenerationLogic()!.selectedAuthors; track author.author) {
+              <!--
+                Tracked by position, not by name. This list is one random draw of
+                three voices, rebuilt whole every time the reader regenerates, so
+                there is no identity across renders for a key to preserve — and a
+                name is not one anyway: two banks may hold the same author, and
+                Angular throws NG0955 on a duplicate key rather than rendering.
+              -->
+              @for (author of currentGenerationLogic()!.selectedAuthors; track $index) {
                 <div class="author-card">
                   <div class="author-name">{{ author.author }}</div>
                   <div class="author-trait">{{ author.trait }}</div>

--- a/story-generator/src/app/proving-grounds/proving-grounds.html
+++ b/story-generator/src/app/proving-grounds/proving-grounds.html
@@ -99,7 +99,7 @@
 
         <!-- Themes -->
         <div class="form-group">
-          <label id="pg-themes-label">Themes (Select 1-3)</label>
+          <label id="pg-themes-label">Themes (Select 1-{{ maxThemes }})</label>
           <div class="theme-grid" role="group" aria-labelledby="pg-themes-label">
             @for (theme of themeOptions; track theme.id) {
               <button

--- a/story-generator/src/app/proving-grounds/proving-grounds.spec.ts
+++ b/story-generator/src/app/proving-grounds/proving-grounds.spec.ts
@@ -4,6 +4,8 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { ProvingGroundsTestResult } from '../contracts';
 import { ProvingGroundsComponent } from './proving-grounds';
+import { STORY_BLUEPRINT_LIMITS } from '../../../../shared/storyBlueprintLimits';
+import { STORY_LAB_THEME_SEEDS } from '../../../../shared/storyLabThemeSeeds';
 
 function createEvaluatedResult(): ProvingGroundsTestResult {
   return {
@@ -232,6 +234,30 @@ describe('ProvingGroundsComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('[data-testid="mock-evaluation-badge"]')).toBeNull();
+  });
+
+  // The picker used to be its own list of ten classic `ThemeType` ids, so seven
+  // of the app's twelve seeds could not be tested at all and five of the ids on
+  // offer were ones no reader can send. Compared field by field rather than by
+  // id, because a seed's `label` and `description` reach the generation prompt:
+  // matching ids carrying this page's own wording would still test a prompt the
+  // app never builds.
+  it('offers exactly the thematic seeds the app picker offers', () => {
+    expect(component.themeOptions).toEqual(STORY_LAB_THEME_SEEDS.map(seed => ({ ...seed })));
+  });
+
+  it('lets a test carry as many seeds as the blueprint route accepts', () => {
+    component.selectedThemeIds = [];
+
+    for (const theme of component.themeOptions) {
+      component.toggleTheme(theme);
+    }
+
+    expect(component.selectedThemeIds.length).toBe(STORY_BLUEPRINT_LIMITS.maxThemes);
+    // The most recent choices, since selecting past the cap drops the oldest.
+    expect(component.selectedThemeIds).toEqual(
+      component.themeOptions.slice(-STORY_BLUEPRINT_LIMITS.maxThemes).map(theme => theme.id)
+    );
   });
 
   it('deletes the current history item when its delete action is clicked', () => {

--- a/story-generator/src/app/proving-grounds/proving-grounds.ts
+++ b/story-generator/src/app/proving-grounds/proving-grounds.ts
@@ -25,7 +25,11 @@ import {
   createBrowserHtmlDownloadHost,
   downloadTextDocument
 } from '../../../../shared/htmlDocumentDownload';
-import { describeNarrativeDirectivesOverflow } from '../../../../shared/storyBlueprintLimits';
+import {
+  STORY_BLUEPRINT_LIMITS,
+  describeNarrativeDirectivesOverflow
+} from '../../../../shared/storyBlueprintLimits';
+import { STORY_LAB_THEME_SEEDS } from '../../../../shared/storyLabThemeSeeds';
 
 type TestResult = ProvingGroundsTestResult;
 type StoredTestResult = StoredProvingGroundsTestResult;
@@ -80,18 +84,32 @@ export class ProvingGroundsComponent implements OnInit {
     'angel',
     'mermaid'
   ];
-  readonly themeOptions: ThemeSeed[] = [
-    { id: 'betrayal', label: 'Betrayal', description: 'Trust becomes leverage.' },
-    { id: 'obsession', label: 'Obsession', description: 'Desire narrows into fixation.' },
-    { id: 'power_dynamics', label: 'Power Dynamics', description: 'Control shifts between rivals.' },
-    { id: 'forbidden_love', label: 'Forbidden Love', description: 'Rules make romance dangerous.' },
-    { id: 'revenge', label: 'Revenge', description: 'Old wounds drive present choices.' },
-    { id: 'manipulation', label: 'Manipulation', description: 'Truth is shaped as a weapon.' },
-    { id: 'seduction', label: 'Seduction', description: 'Attraction becomes strategy.' },
-    { id: 'dark_secrets', label: 'Dark Secrets', description: 'Hidden history threatens the bond.' },
-    { id: 'temptation', label: 'Temptation', description: 'The wrong choice feels inevitable.' },
-    { id: 'desire', label: 'Desire', description: 'Longing pushes the scene forward.' }
-  ];
+  /**
+   * The thematic seeds the app's own picker offers, so a test here is a test of
+   * something a reader can actually generate.
+   *
+   * This was a thirteenth copy of the theme vocabulary, and it was the other
+   * one: ten classic `ThemeType` ids with descriptions written for this page.
+   * `app.ts` builds its picker from `STORY_LAB_THEME_SEEDS`, so those twelve
+   * seeds are the only themes any request the app makes actually carries, and
+   * the two lists overlap on five ids. That left seven of the app's themes —
+   * `court_intrigue`, `blood_oaths`, `slow_burn`, `enemies_to_lovers`,
+   * `magical_bargain`, `secret_identity`, `forced_proximity` — untestable in the
+   * one screen built for testing prompts, while five of the ids this page did
+   * offer (`betrayal`, `power_dynamics`, `manipulation`, `seduction`, `desire`)
+   * are ones no reader can pick.
+   *
+   * The five shared ids were the worse half, because they looked right. A seed's
+   * `label` and `description` are carried into the generation prompt, not just
+   * printed beside a checkbox, so "Dark Secrets / Hidden history threatens the
+   * bond." here and "Hidden Secrets / Someone is lying beautifully." in the app
+   * are two different prompts under one id — a comparison tool reporting on
+   * prose the app would never have asked for, with nothing in the output to say
+   * so.
+   */
+  readonly themeOptions: ThemeSeed[] = STORY_LAB_THEME_SEEDS.map(seed => ({ ...seed }));
+  /** The cap the picker enforces, so its label cannot state a different number. */
+  readonly maxThemes = STORY_BLUEPRINT_LIMITS.maxThemes;
   readonly spicyLevelOptions: SpicyLevel[] = [1, 2, 3, 4, 5];
   readonly wordCountOptions: WordBudget[] = [600, 900, 1200, 1500];
   readonly chapterBatchOptions: ChapterBatchSize[] = [1, 2, 3];
@@ -111,13 +129,20 @@ export class ProvingGroundsComponent implements OnInit {
     return this.themeOptions.filter(theme => this.selectedThemeIds.includes(theme.id));
   }
 
+  /**
+   * Selecting past the cap drops the oldest choice rather than refusing the new
+   * one, which is this page's own behaviour and stays. The cap itself is the
+   * blueprint's, read from the shared limits: it was three, against the five the
+   * route accepts and `FormValidationService` enforces, so a prompt could not be
+   * tested against as many seeds as a reader can send it.
+   */
   toggleTheme(theme: ThemeSeed): void {
     if (this.selectedThemeIds.includes(theme.id)) {
       this.selectedThemeIds = this.selectedThemeIds.filter(id => id !== theme.id);
       return;
     }
 
-    this.selectedThemeIds = [...this.selectedThemeIds, theme.id].slice(-3);
+    this.selectedThemeIds = [...this.selectedThemeIds, theme.id].slice(-this.maxThemes);
   }
 
   isThemeSelected(theme: ThemeSeed): boolean {

--- a/tests/story-lab-blueprint-parser.test.ts
+++ b/tests/story-lab-blueprint-parser.test.ts
@@ -212,4 +212,24 @@ assert(
   'whitespace around directives at the cap should not be refused by the parser'
 );
 
+// `logline` and `worldDetails` are read through the same trimming helpers and
+// were not stated anywhere, which is how the Angular `FormValidationService`
+// came to measure all three untrimmed: it refused a logline pasted with a
+// trailing newline at exactly the cap the route accepts it under. The parser's
+// reading is the one the form has to mirror, so it is written down here.
+const paddedFreeText = parseStoryLabBlueprintFromBody({
+  ...bodyForCreature('dragon'),
+  logline: `\n  ${longText(STORY_BLUEPRINT_LIMITS.maxLoglineLength)}  \n`,
+  worldDetails: `  ${longText(STORY_BLUEPRINT_LIMITS.maxWorldDetailsLength)}\n`
+});
+assert(
+  !paddedFreeText.error,
+  'whitespace around a logline or world details at the cap should not be refused by the parser'
+);
+assert(
+  paddedFreeText.blueprint.logline.length === STORY_BLUEPRINT_LIMITS.maxLoglineLength
+    && paddedFreeText.blueprint.worldDetails?.length === STORY_BLUEPRINT_LIMITS.maxWorldDetailsLength,
+  'the parsed blueprint should carry the trimmed value it was measured as'
+);
+
 console.log('Story Lab shared blueprint parser tests passed');


### PR DESCRIPTION
## Proving Grounds never showed the third author the API actually blends in

`selectRandomAuthorStyles` in `api/_lib/config/authorStyles.ts` builds every story's prompt from **two** voices out of the creature's own bank and **one** out of a second bank belonging to other creatures — a werewolf story is written by two werewolf voices and one vampire or fae one. That third voice is the entire reason the API keeps a `getSecondaryAuthorStyles` table.

`GenerationLogicService.selectRandomAuthors`, whose stated job is to "simulate the random selection logic from storyService", drew `2 + randomInt(2)` voices and took all of them from the primary bank. So the panel disagreed with the run twice over: the blend voice was absent from every preview for every one of the ten creatures, and a preview that happened to roll three named three same-creature voices where the generator had used two.

This is the other half of the fallthrough #240 fixed. That slice made the panel read the right *primary* bank for `siren` and `djinn`; the secondary table had never been ported at all, so the panel was still describing a prompt the run did not use — the failure a prompt-comparison tool cannot afford, because the reader has no way to tell.

`getSecondaryAuthorStyles` is ported with the API's pairings, and the counts are named (`PRIMARY_AUTHOR_COUNT`, `SECONDARY_AUTHOR_COUNT`) rather than left as a coin flip.

Two specs were asserting the defect and are replaced rather than deleted:
- `selectRandomAuthors never returns more authors than exist for the creature` accepted anything from two authors up to the size of the bank — precisely the range the defect produced.
- `generateRandomLogic` required every selected author to be in the primary bank, which a selection that never reaches the secondary bank satisfies by construction.

### The banks themselves were wrong too (found in review)

Porting the pairings was not enough, and Codex was right to say so. Extracting the three shared banks from both trees and comparing them field by field:

- `VAMPIRE_STYLES` already matched the panel's copy byte for byte.
- `WEREWOLF_STYLES`: **six of twelve differ.** The API has Jennifer Ashley, Suzanne Wright, Faith Hunter, Keri Arthur, Rachel Vincent, Chloe Neill where the panel had Jennifer L. Armentrout, Laurell K. Hamilton, Yasmine Galenorn, Kresley Cole, Lora Leigh — and a second copy of Nalini Singh. Different order, and different voice samples and traits for the shared names.
- `FAIRY_STYLES`: **three of twelve differ** — Melissa Marr, Grace Draven, Sylvia Mercedes against Jennifer L. Armentrout, Nalini Singh, Annette Marie.

Nine of the ten creatures borrow werewolf or fae for their blend voice (siren is the exception), so fixing the selection while the banks stayed wrong would have left almost every preview still able to name an author the server could not pick — the parity this branch exists for. Both banks are now transplanted from `api/_lib/config/authorStyles.ts` by script and diffed back rather than retyped, and pinned by name in a spec the way the siren and djinn banks already were.

Those divergent banks were also what let a preview name the **same author twice**: `Kresley Cole` and `Laurell K. Hamilton` sat in both the panel's vampire and werewolf lists, `Nalini Singh` and `Jennifer L. Armentrout` in both its werewolf and fae ones. A vampire or fae draw could take one voice from each bank and get one author — losing the variety the third voice exists for, and handing two identical keys to a `@for` that tracked by author name, which Angular answers with NG0955 rather than a render. Checked across all ten of the API's banks: no name is shared within a bank or between any creature's two pools, so the port removes the collision at the root. Deduplicating the selection instead would have introduced a fresh divergence, since `selectRandomAuthorStyles` does not deduplicate. A spec now states the no-overlap property so a later bank edit fails a test rather than a reader's screen, and the list tracks by position — the only identity a freshly-shuffled draw of three has.

## Proving Grounds offered ten themes, five of which no reader can send

Its `themeOptions` was a thirteenth copy of the theme vocabulary and it was the other one: ten classic `ThemeType` ids with descriptions written for that page. `app.ts` builds its picker from `STORY_LAB_THEME_SEEDS`, so those twelve seeds are the only themes any request the app makes actually carries. The two lists overlap on five ids.

- Seven of the app's themes — `court_intrigue`, `blood_oaths`, `slow_burn`, `enemies_to_lovers`, `magical_bargain`, `secret_identity`, `forced_proximity` — could not be tested at all in the one screen built for testing prompts.
- Five of the ids on offer (`betrayal`, `power_dynamics`, `manipulation`, `seduction`, `desire`) are ones no reader can pick.
- The five shared ids were the worse half, because they looked right. A seed's `label` and `description` are carried into the generation prompt, not merely printed beside a checkbox, so `Dark Secrets / Hidden history threatens the bond.` here and `Hidden Secrets / Someone is lying beautifully.` in the app are two different prompts under one id — a comparison tool reporting on prose the app would never have asked for, with nothing in the output to say so.

The picker now reads `shared/storyLabThemeSeeds.ts`, the module #240 created for exactly this class of drift, and its selection cap moves from a hard-coded three to `STORY_BLUEPRINT_LIMITS.maxThemes` — the five the route accepts and `FormValidationService` enforces. The label states that number rather than restating it.

## The blueprint form refused loglines the API would have accepted

`parseStoryLabBlueprint` reads `logline` through `.trim()`, and `worldDetails` and `narrativeDirectives` through `optionalString`, which trims too — and only then compares against `STORY_BLUEPRINT_LIMITS`. `FormValidationService` measured the raw value.

So surrounding whitespace counted on one side of the seam and not the other. A logline pasted with a trailing newline — the ordinary result of copying a paragraph out of a document — was refused by the form at exactly the cap the route accepts it under, with a message telling the reader to shorten prose that was already short enough.

`describeNarrativeDirectivesOverflow` in the shared limits module was written to avoid this and says so in its own comment: measuring the field any other way "would refuse a request the route would have taken". Both readers of the shared numbers now measure it the same way the route does.

`heatContract.noGoContent` is deliberately left as it was: the parser checks that field's length *without* trimming, so trimming it in the form would accept a contract the route refuses — the drift running the more expensive way.

The parser's own trimming of `logline` and `worldDetails` was stated nowhere, which is how the form came to disagree with it. `tests/story-lab-blueprint-parser.test.ts` now pins it, beside the `narrativeDirectives` case that was already covered.

## Verification

Every fix was reproduced against the old behaviour before being kept. Reverting the changed sources while leaving the new specs in place produced exactly these named Karma failures and no others:

- `selectRandomAuthors draws two voices from the primary bank and one from the secondary bank`
- `offers exactly the thematic seeds the app picker offers`
- `lets a test carry as many seeds as the blueprint route accepts`
- `accepts free text that only exceeds a cap through surrounding whitespace`
- `reads the werewolf and fae banks the API generates those creatures from`
- `never lets a creature draw the same author from both of its banks`

| Check | Result |
| --- | --- |
| `npm test` | passed (all suites) |
| `ng test --watch=false --browsers=ChromeHeadlessNoSandbox` | 184 of 184 passed |
| `tsc -p tsconfig.app.json --noEmit` / `tsconfig.spec.json` | passed |
| Vercel API function typecheck | passed |
| `npm run build` (Angular production) | passed — the `proving-grounds.css` budget warning (68 bytes over 12 kB) predates this branch |
| `git diff --check` | passed |

**Known and left for its own slice:** the ten author banks now exist in full in both trees, which is the same one-copy-per-reader shape `shared/storyLabThemeSeeds.ts` was created to end. Moving them under `shared/` is the durable fix and touches the API tree as well, so it is not folded in here. Recorded in `PR70_RECOVERY_CHANGELOG.md`.

**Non-claim:** this changes no API route, no prompt the server builds, and no generated story. It changes which authors one browser panel previews, which themes that panel offers, and where the Angular form draws the line on three free-text fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rc8Hkx3iw2xrwZyULLu687