### PR TITLE
Three quick wins: an export that welds its paragraphs, one that repeats its title, a PDF that stops after 100 characters

### DIFF
--- a/api/_lib/services/exportSanitizer.ts
+++ b/api/_lib/services/exportSanitizer.ts
@@ -37,8 +37,7 @@ const DANGEROUS_CONTAINER_TAGS = [
   'base'
 ];
 
-const DANGEROUS_TAGS = new Set(DANGEROUS_CONTAINER_TAGS);
-const DANGEROUS_BLOCK_TAGS = new Set([
+const DANGEROUS_BLOCK_TAGS = [
   'script',
   'style',
   'iframe',
@@ -50,7 +49,35 @@ const DANGEROUS_BLOCK_TAGS = new Set([
   'button',
   'textarea',
   'select'
-]);
+];
+
+/**
+ * Elements whose text describes the document rather than telling the story.
+ *
+ * Dropped with their contents for a different reason than the tags above —
+ * nothing here is dangerous — but by the same mechanism, because the question
+ * both lists answer is the same: is the text inside this element part of the
+ * story being exported?
+ *
+ * `<title>` is the case that reaches the exports. `buildStoryHtmlDocument`
+ * hands `/api/export/save` a whole HTML document, and its `<head>` names the
+ * story: `<title>The Vampire's Bargain</title>` sits a few tags above
+ * `<h1>The Vampire's Bargain</h1>`. `<meta>`, `<link>`, and `<base>` are
+ * already dropped and `<style>` takes its contents with it, so `<title>` was
+ * the one head element whose text survived — and, having no break of its own,
+ * it arrived welded to the heading below it. Every `.txt`, `.pdf`, `.epub`,
+ * and `.docx` export opened on the title run into itself, and the `.html`
+ * export opened on a stray unheaded copy above the real `<h1>`.
+ *
+ * The title is not lost by dropping it: every format writes it from
+ * `input.title`, which is what the field is for.
+ */
+const DOCUMENT_METADATA_CONTAINER_TAGS = ['title'];
+
+/** Every tag dropped rather than exported, whichever list it came from. */
+const DROPPED_TAGS = new Set([...DANGEROUS_CONTAINER_TAGS, ...DOCUMENT_METADATA_CONTAINER_TAGS]);
+/** Those of them that take their contents with them. */
+const DROPPED_BLOCK_TAGS = new Set([...DANGEROUS_BLOCK_TAGS, ...DOCUMENT_METADATA_CONTAINER_TAGS]);
 /**
  * The block-level tags a reader sees a break at.
  *
@@ -156,7 +183,7 @@ export function sanitizeStoryHtmlForExport(html: string): string {
   // single break a reader sees rather than one per tag.
   let blockBreakPending = false;
 
-  for (const token of tokenizeHtml(removeDangerousHtml(html))) {
+  for (const token of tokenizeHtml(removeNonStoryHtml(html))) {
     if (!token) {
       continue;
     }
@@ -279,7 +306,7 @@ function escapeStoryText(value: string): string {
 export function stripStoryHtmlForExport(html: string): string {
   let text = '';
 
-  for (const token of tokenizeHtml(removeDangerousHtml(html))) {
+  for (const token of tokenizeHtml(removeNonStoryHtml(html))) {
     if (token.startsWith('<') && token.endsWith('>')) {
       const parsed = parseHtmlTag(token);
       if (!parsed) {
@@ -318,7 +345,7 @@ export function escapePdfText(value: string): string {
   );
 }
 
-function removeDangerousHtml(html: string): string {
+function removeNonStoryHtml(html: string): string {
   let output = '';
   let skippedBlockTag: string | null = null;
   let skippedBlockDepth = 0;
@@ -351,8 +378,8 @@ function removeDangerousHtml(html: string): string {
       continue;
     }
 
-    if (DANGEROUS_TAGS.has(parsed.tagName)) {
-      if (!parsed.isClosing && DANGEROUS_BLOCK_TAGS.has(parsed.tagName) && !parsed.isSelfClosing) {
+    if (DROPPED_TAGS.has(parsed.tagName)) {
+      if (!parsed.isClosing && DROPPED_BLOCK_TAGS.has(parsed.tagName) && !parsed.isSelfClosing) {
         skippedBlockTag = parsed.tagName;
         skippedBlockDepth = 1;
       }
@@ -477,6 +504,37 @@ function parseHtmlTag(token: string): ParsedHtmlTag | null {
   };
 }
 
+/**
+ * Drop the spaces and tabs a line ends on, and nothing else.
+ *
+ * `normalizePlainText` tidies the end of the text every time it writes a
+ * newline, and used `String.prototype.trimEnd` to do it — which counts a
+ * newline as trailing whitespace and so deleted the breaks already written.
+ * That only showed once a third break arrived in a row, because the first two
+ * were rewritten immediately afterwards and the third is the one the two-break
+ * cap declines to rewrite: `One.\n` was trimmed back to `One.` and left that
+ * way, and the paragraphs either side of the boundary were welded into
+ * `One.Two.`.
+ *
+ * Three breaks in a row is not an edge case here — it is what the app's own
+ * export sends. `buildStoryHtmlDocument` writes one tag per line, so an
+ * ordinary `</p>\n<hr>\n<section>` contributes a break for the closing tag, a
+ * break for each literal newline between the tags, and a break for the `<hr>`.
+ * Every `.txt`, `.pdf`, `.epub`, and `.docx` export of a generated story
+ * therefore lost the paragraph break at each of those boundaries, which is the
+ * `door.</p><p>Blood` welding the block-boundary table above exists to prevent
+ * — reintroduced one layer below it.
+ */
+function trimTrailingInlineWhitespace(value: string): string {
+  let end = value.length;
+
+  while (end > 0 && isInlineWhitespace(value[end - 1])) {
+    end -= 1;
+  }
+
+  return value.slice(0, end);
+}
+
 function normalizePlainText(value: string): string {
   let normalized = '';
   let pendingSpace = false;
@@ -484,7 +542,7 @@ function normalizePlainText(value: string): string {
 
   for (const character of value) {
     if (character === '\n') {
-      normalized = normalized.trimEnd();
+      normalized = trimTrailingInlineWhitespace(normalized);
       if (newlineCount < 2) {
         normalized += '\n';
         newlineCount += 1;

--- a/api/_lib/services/exportService.ts
+++ b/api/_lib/services/exportService.ts
@@ -8,7 +8,27 @@ import {
 } from './exportSanitizer';
 import { buildZipArchive, ZipEntry } from './zipArchive';
 
-const PDF_EXCERPT_CODE_POINTS = 100;
+// US Letter, in the points a PDF's default user space is measured in.
+const PDF_PAGE_WIDTH = 612;
+const PDF_PAGE_HEIGHT = 792;
+const PDF_MARGIN = 72;
+const PDF_FONT_SIZE = 12;
+const PDF_LINE_HEIGHT = 16;
+/**
+ * How wide a character is assumed to be, as a fraction of the font size.
+ *
+ * Helvetica is proportional, so a line's real width depends on which glyphs are
+ * in it: `l` is 0.222em and `W` is 0.944em. Rather than ship a width table for
+ * one font, lines are broken on a per-character estimate chosen above
+ * Helvetica's average for lowercase prose (~0.5em), which errs toward a short
+ * line. A short line wraps early; a long one would run off the page edge, since
+ * nothing in a PDF clips a text-showing operator to the media box.
+ */
+const PDF_GLYPH_WIDTH_EM = 0.55;
+const PDF_MAX_LINE_CHARACTERS = Math.floor(
+  (PDF_PAGE_WIDTH - PDF_MARGIN * 2) / (PDF_FONT_SIZE * PDF_GLYPH_WIDTH_EM)
+);
+const PDF_LINES_PER_PAGE = Math.floor((PDF_PAGE_HEIGHT - PDF_MARGIN * 2) / PDF_LINE_HEIGHT);
 // Leaves room for the `_<timestamp>_<token>.<format>` suffix inside the
 // 255-byte filename limit that ext4 and APFS enforce.
 const EXPORT_FILENAME_STEM_MAX_LENGTH = 80;
@@ -24,25 +44,85 @@ const EXPORT_MIME_TYPES: Record<ExportFormat, string> = {
 };
 
 /**
- * Take the first `limit` code points of `value`. Iterating a string yields
- * whole code points rather than UTF-16 code units, so an astral-plane
- * character is either kept whole or dropped whole. The loop stops at the
- * limit, so a book-length story costs no more than a paragraph does.
+ * Cut `value` into runs of at most `limit` code points. Iterating a string
+ * yields whole code points rather than UTF-16 code units, so an astral-plane
+ * character always stays whole — a cut between the halves of a surrogate pair
+ * would encode as U+FFFD on both sides of it.
  */
-function truncateByCodePoint(value: string, limit: number): string {
-  let truncated = '';
+function chunkByCodePoint(value: string, limit: number): string[] {
+  const chunks: string[] = [];
+  let chunk = '';
   let taken = 0;
 
   for (const character of value) {
     if (taken >= limit) {
-      break;
+      chunks.push(chunk);
+      chunk = '';
+      taken = 0;
     }
 
-    truncated += character;
+    chunk += character;
     taken += 1;
   }
 
-  return truncated;
+  if (chunk) {
+    chunks.push(chunk);
+  }
+
+  return chunks;
+}
+
+/** The code points in `value`, which is what the line width is measured in. */
+function countCodePoints(value: string): number {
+  let count = 0;
+
+  for (const _character of value) {
+    count += 1;
+  }
+
+  return count;
+}
+
+/**
+ * Break one paragraph of the story into the lines a PDF page shows it as.
+ *
+ * Words are kept whole where they fit; a word longer than a whole line — a URL,
+ * a run of unbroken text — is cut at code-point boundaries rather than being
+ * allowed to run off the page. A paragraph with no words still yields one
+ * (empty) line, so the blank line between two paragraphs survives into the
+ * document.
+ */
+function wrapPdfParagraph(paragraph: string, maxCharacters: number): string[] {
+  const words = paragraph.split(/\s+/).filter(Boolean);
+  if (words.length === 0) {
+    return [''];
+  }
+
+  const lines: string[] = [];
+  let current = '';
+
+  for (const word of words) {
+    for (const piece of chunkByCodePoint(word, maxCharacters)) {
+      if (current.length === 0) {
+        current = piece;
+        continue;
+      }
+
+      if (countCodePoints(current) + 1 + countCodePoints(piece) <= maxCharacters) {
+        current += ` ${piece}`;
+        continue;
+      }
+
+      lines.push(current);
+      current = piece;
+    }
+  }
+
+  if (current.length > 0) {
+    lines.push(current);
+  }
+
+  return lines;
 }
 
 /**
@@ -165,25 +245,44 @@ export class ExportService {
     }
   }
 
+  /**
+   * Write the story out as a paginated PDF.
+   *
+   * It used to be one page holding the title and `truncateByCodePoint(content,
+   * 100)` followed by a literal `...`, so choosing PDF from the export picker
+   * produced a document with the first hundred characters of the story in it —
+   * about a sentence — while the four other formats shipped the whole thing.
+   * Nothing said so: the file downloaded under the story's own name, at the
+   * size a real PDF of a sentence is, and the trailing ellipsis reads as
+   * ordinary prose in a story that ends on a cliffhanger.
+   *
+   * The text is broken into lines and the lines into pages, and each page is a
+   * `/Page` of its own with its own content stream. `assemblePdfDocument`
+   * measures the cross-reference offsets from whatever objects it is handed, so
+   * the table stays correct however many pages a story runs to.
+   */
   private generatePDFContent(content: string, input: SaveExportSeam['input']): string {
-    const title = escapePdfText(input.title);
-    // The excerpt is cut from the source text and escaped afterwards. Cutting
-    // the escaped text instead splits whatever escaping added at the boundary:
-    // a `\(` pair loses its parenthesis and leaves a dangling backslash that
-    // escapes the following character, and a surrogate pair loses its second
-    // half, so the emoji it encoded is written out as U+FFFD.
-    const excerpt = escapePdfText(truncateByCodePoint(content, PDF_EXCERPT_CODE_POINTS));
-    // `/Length` tells a reader how many bytes of stream follow the `stream`
-    // keyword, so it has to be measured from the stream itself. It used to be
-    // derived from the whole story text, which is neither what the stream
-    // holds nor a byte count, and left readers scanning past `endstream`.
-    const contentStream = `BT
-/F1 12 Tf
-72 720 Td
-(${title}) Tj
-0 -24 Td
-(${excerpt}...) Tj
-ET`;
+    // The title heads the document, then a blank line, then the story — the
+    // same order the `.txt` export puts them in.
+    const lines = [input.title, '', ...content.split('\n')].flatMap(paragraph =>
+      wrapPdfParagraph(paragraph, PDF_MAX_LINE_CHARACTERS)
+    );
+
+    const pages: string[][] = [];
+    for (let index = 0; index < lines.length; index += PDF_LINES_PER_PAGE) {
+      pages.push(lines.slice(index, index + PDF_LINES_PER_PAGE));
+    }
+    // An empty story still gets a page, so the document is a valid PDF with a
+    // page tree rather than one whose `/Kids` array is empty.
+    if (pages.length === 0) {
+      pages.push(['']);
+    }
+
+    // Objects 1, 2 and 3 are the catalog, the page tree and the font; each page
+    // then contributes its `/Page` and the content stream that page points at,
+    // in that order, so both numbers follow from the page's index.
+    const FIRST_PAGE_OBJECT_NUMBER = 4;
+    const pageObjectNumber = (index: number) => FIRST_PAGE_OBJECT_NUMBER + index * 2;
 
     const objects = [
       `<<
@@ -192,26 +291,9 @@ ET`;
 >>`,
       `<<
 /Type /Pages
-/Kids [3 0 R]
-/Count 1
+/Kids [${pages.map((_page, index) => `${pageObjectNumber(index)} 0 R`).join(' ')}]
+/Count ${pages.length}
 >>`,
-      `<<
-/Type /Page
-/Parent 2 0 R
-/MediaBox [0 0 612 792]
-/Contents 4 0 R
-/Resources <<
-/Font <<
-/F1 5 0 R
->>
->>
->>`,
-      `<<
-/Length ${Buffer.byteLength(contentStream, 'utf8')}
->>
-stream
-${contentStream}
-endstream`,
       `<<
 /Type /Font
 /Subtype /Type1
@@ -219,7 +301,55 @@ endstream`,
 >>`
     ];
 
+    pages.forEach((pageLines, index) => {
+      const contentStream = this.buildPdfPageContentStream(pageLines);
+
+      objects.push(
+        `<<
+/Type /Page
+/Parent 2 0 R
+/MediaBox [0 0 ${PDF_PAGE_WIDTH} ${PDF_PAGE_HEIGHT}]
+/Contents ${pageObjectNumber(index) + 1} 0 R
+/Resources <<
+/Font <<
+/F1 3 0 R
+>>
+>>
+>>`,
+        // `/Length` tells a reader how many bytes of stream follow the `stream`
+        // keyword, so it has to be measured from the stream itself. It used to
+        // be derived from the whole story text, which is neither what the
+        // stream holds nor a byte count, and left readers scanning past
+        // `endstream`.
+        `<<
+/Length ${Buffer.byteLength(contentStream, 'utf8')}
+>>
+stream
+${contentStream}
+endstream`
+      );
+    });
+
     return this.assemblePdfDocument(objects);
+  }
+
+  /**
+   * The text operators for one page.
+   *
+   * Each line is escaped as it is written, from the source text rather than
+   * from text that has already been escaped: cutting escaped text splits
+   * whatever the escaping added at the boundary — a `\(` pair loses its
+   * parenthesis and leaves a dangling backslash that escapes the character
+   * after it.
+   */
+  private buildPdfPageContentStream(pageLines: string[]): string {
+    const firstBaseline = PDF_PAGE_HEIGHT - PDF_MARGIN;
+    const operators = pageLines.flatMap((line, index) => [
+      index === 0 ? `${PDF_MARGIN} ${firstBaseline} Td` : `0 -${PDF_LINE_HEIGHT} Td`,
+      `(${escapePdfText(line)}) Tj`
+    ]);
+
+    return [`BT`, `/F1 ${PDF_FONT_SIZE} Tf`, ...operators, `ET`].join('\n');
   }
 
   /**

--- a/tests/export-sanitizer.test.ts
+++ b/tests/export-sanitizer.test.ts
@@ -217,6 +217,79 @@ assert(
   'HTML and plain-text exports should find the same number of block boundaries'
 );
 
+// `normalizePlainText` tidied the end of the text with `String.prototype.trimEnd`
+// every time it wrote a newline, which counts a newline as trailing whitespace
+// and so deleted the breaks already written. The first two breaks in a run were
+// rewritten immediately afterwards, so only the third and later ones vanished —
+// and three in a row is what the app's own export sends, because
+// `buildStoryHtmlDocument` writes one tag per line and the literal newlines
+// between the tags are breaks too.
+const prettyPrintedBoundaries = [
+  {
+    label: 'a pretty-printed horizontal rule between two paragraphs',
+    html: '<p>She opened the door.</p>\n<hr>\n<p>Blood pooled.</p>',
+    expected: 'She opened the door.\n\nBlood pooled.'
+  },
+  {
+    label: 'a pretty-printed section boundary',
+    html: '<section><p>One.</p></section>\n\n<section><p>Two.</p></section>',
+    expected: 'One.\n\nTwo.'
+  },
+  {
+    label: 'a run of nested closings',
+    html: '<ul>\n<li>One.</li>\n</ul>\n<p>Two.</p>',
+    expected: 'One.\n\nTwo.'
+  }
+];
+
+for (const sample of prettyPrintedBoundaries) {
+  const plain = stripStoryHtmlForExport(sample.html);
+  assert(
+    plain === sample.expected,
+    `plain export should render ${sample.label} as ${JSON.stringify(sample.expected)}, got ${JSON.stringify(plain)}`
+  );
+}
+
+// The trailing spaces the trim existed to remove still have to go: a line must
+// not end on the space every dropped inline tag leaves behind.
+assert(
+  stripStoryHtmlForExport('<p>She waited <em>there</em> </p><p>Then left.</p>') === 'She waited there\nThen left.',
+  'plain export should still drop the spaces a line ends on'
+);
+
+// `buildStoryHtmlDocument` sends a whole HTML document, whose `<head>` names the
+// story a few tags above the `<h1>` that names it again. `<title>` was the one
+// head element whose text was not dropped, so every export opened on the title
+// welded to itself.
+const wholeDocument = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>The Vampire's Bargain</title>
+<style>body{font-family:Georgia,serif}</style>
+</head>
+<body>
+<h1>The Vampire's Bargain</h1>
+<p>She traded a name for a night.</p>
+</body>
+</html>`;
+
+const documentPlainText = stripStoryHtmlForExport(wholeDocument);
+assert(
+  documentPlainText === "The Vampire's Bargain\n\nShe traded a name for a night.",
+  `plain export should carry the document's story once, got ${JSON.stringify(documentPlainText)}`
+);
+
+const documentHtml = sanitizeStoryHtmlForExport(wholeDocument);
+assert(
+  documentHtml.startsWith('<h1>'),
+  `HTML export should open on the story's own heading, got ${JSON.stringify(documentHtml.slice(0, 60))}`
+);
+assert(
+  !documentHtml.includes('font-family'),
+  'HTML export should not carry the document stylesheet'
+);
+
 assert(
   escapeHtml('<title>"Angel"</title>') === '&lt;title&gt;&quot;Angel&quot;&lt;/title&gt;',
   'escapeHtml should escape markup and quotes'

--- a/tests/export-service.test.ts
+++ b/tests/export-service.test.ts
@@ -104,24 +104,66 @@ async function testPdfStreamLengthDescribesTheStream(): Promise<void> {
   );
 }
 
-// The excerpt used to be cut out of the *escaped* text, which splits whatever
-// the escaping added at the cut. The 100th code unit of this body falls inside
-// the `\(` written for its parenthesis and inside the surrogate pair written
-// for its dragon, so the old cut left a trailing backslash — escaping the `.`
-// that follows it — and a lone surrogate that encodes as U+FFFD.
-async function testPdfExcerptIsCutOnCharacterBoundaries(): Promise<void> {
+// The PDF used to hold the story's first 100 code points followed by a literal
+// `...`, on a single page, while the four other formats shipped the whole
+// story. Nothing about the file said so — it downloaded under the story's own
+// name, and a trailing ellipsis reads as ordinary prose.
+async function testPdfCarriesTheWholeStoryAcrossPages(): Promise<void> {
+  // Long enough to need several pages, and marked at both ends so a truncation
+  // anywhere between them is visible.
+  const paragraphs = Array.from(
+    { length: 60 },
+    (_unused, index) => `<p>Paragraph ${index} — Élodie counted the 🐉 scales in the (dark).</p>`
+  );
+  const content = `<p>OPENING-MARKER</p>${paragraphs.join('')}<p>CLOSING-MARKER</p>`;
+  const document = await pdfTextOf(createInput({ format: 'pdf', content }));
+
+  const shownText = pdfShownText(document);
+  assert(shownText.includes('OPENING-MARKER'), 'the PDF should show the start of the story');
+  assert(shownText.includes('CLOSING-MARKER'), 'the PDF should show the end of the story');
+  for (let index = 0; index < 60; index += 1) {
+    assert(shownText.includes(`Paragraph ${index} `), `the PDF should show paragraph ${index}`);
+  }
+
+  const pageCount = Number(/\/Count (\d+)/.exec(document)?.[1]);
+  const pageObjects = document.match(/\/Type \/Page\b/g) ?? [];
+  assert(pageCount > 1, `a story this long should run to more than one page (got ${pageCount})`);
+  assert(
+    pageObjects.length === pageCount,
+    `the page tree should declare as many pages as it holds (declared=${pageCount}, objects=${pageObjects.length})`
+  );
+
+  const kids = /\/Kids \[([^\]]*)\]/.exec(document)?.[1].trim().split(/\s+(?=\d+ 0 R)/) ?? [];
+  assert(kids.length === pageCount, `the /Kids array should name every page (named=${kids.length})`);
+  for (const kid of kids) {
+    const objectNumber = Number(/^(\d+) 0 R$/.exec(kid.trim())?.[1]);
+    assert(
+      new RegExp(`\\n${objectNumber} 0 obj\\n<<\\n/Type /Page\\b`).test(document),
+      `/Kids entry ${JSON.stringify(kid)} should name a page object`
+    );
+  }
+}
+
+// Escaping is applied to each line as it is written, from the source text
+// rather than from text that has already been escaped: cutting escaped text
+// splits whatever the escaping added at the cut — a `\(` pair loses its
+// parenthesis and strands a backslash that escapes the next character, and a
+// surrogate pair loses its second half and encodes as U+FFFD.
+async function testPdfLinesBreakOnCharacterBoundaries(): Promise<void> {
   for (const boundary of ['(spice)', '🐉 tail']) {
-    const content = `<p>${'x'.repeat(99)}${boundary}</p>`;
+    // No spaces, so the line is longer than a page is wide and has to be broken
+    // inside the word — the only place a break can land mid-character.
+    const content = `<p>${`${'x'.repeat(60)}${boundary.replace(/\s/g, '')}`.repeat(6)}</p>`;
     const document = await pdfTextOf(createInput({ format: 'pdf', content }));
     const streamBody = extractPdfStreamBody(document);
 
     assert(
-      !/(^|[^\\])(\\\\)*\\\.\.\.\) Tj/.test(streamBody),
-      `a ${boundary} excerpt should not end mid-escape (stream=${JSON.stringify(streamBody)})`
+      !/(^|[^\\])(\\\\)*\\\) Tj/.test(streamBody),
+      `a ${boundary} line should not end mid-escape (stream=${JSON.stringify(streamBody)})`
     );
     assert(
       !/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(streamBody),
-      `a ${boundary} excerpt should not end on half a surrogate pair`
+      `a ${boundary} line should not end on half a surrogate pair`
     );
   }
 }
@@ -130,6 +172,11 @@ function extractPdfStreamBody(document: string): string {
   const match = /\nstream\n([\s\S]*?)\nendstream\n/.exec(document);
   assert(match, 'the PDF should contain a content stream');
   return match[1];
+}
+
+/** The text every page of a PDF actually shows, in page order. */
+function pdfShownText(document: string): string {
+  return Array.from(document.matchAll(/\((.*)\) Tj/g), match => match[1].replace(/\\([\\()])/g, '$1')).join('\n');
 }
 
 async function pdfTextOf(input: SaveExportSeam['input']): Promise<string> {
@@ -397,7 +444,8 @@ async function main(): Promise<void> {
   await testPdfCrossReferenceTablePointsAtItsObjects();
   await testFileSizeIsMeasuredInBytes();
   await testPdfStreamLengthDescribesTheStream();
-  await testPdfExcerptIsCutOnCharacterBoundaries();
+  await testPdfCarriesTheWholeStoryAcrossPages();
+  await testPdfLinesBreakOnCharacterBoundaries();
   await testEpubIsARealZipContainerWithItsChapter();
   await testDocxIsARealZipContainerWithItsDocument();
   await testMetadataReflectsTheActualStory();


### PR DESCRIPTION
All three are in the export pipeline, and all three are visible in the file a reader downloads. Each has a regression test that fails against the code it replaces.

## 1. Every plain-text export lost paragraph breaks

`normalizePlainText` tidied the end of the text with `String.prototype.trimEnd` every time it wrote a newline — which counts a newline as trailing whitespace, and so deleted the breaks it had already written. The first two breaks in a run were rewritten immediately afterwards, so only the third and later ones vanished.

Three breaks in a row is not an edge case here: it is what the app itself sends. `buildStoryHtmlDocument` writes one tag per line, so an ordinary `</p>\n<hr>\n<section>` contributes a break for the closing tag, a break for each literal newline between the tags, and a break for the `<hr>`.

```
before: stripStoryHtmlForExport('<p>One.</p>\n<hr>\n<p>Two.</p>')  →  "One.Two."
after:                                                             →  "One.\n\nTwo."
```

Every `.txt`, `.pdf`, `.epub`, and `.docx` export of a generated story was welded at each of those boundaries — the same `door.</p><p>Blood` failure the block-boundary table was written to prevent, reintroduced one layer below it. The trailing spaces and tabs the trim existed to remove are still dropped; newlines no longer are.

## 2. Every export opened on the story's title, twice

`buildStoryHtmlDocument` sends a whole HTML document, and its `<head>` names the story a few tags above the `<h1>` that names it again. `<meta>`, `<link>`, and `<base>` were already dropped and `<style>` took its contents with it, so `<title>` was the one head element whose text survived — and, having no break of its own, it arrived welded to the heading below it:

```
before: "The Vampire's BargainThe Vampire's Bargain\nShe traded a name for a night."
after:  "The Vampire's Bargain\n\nShe traded a name for a night."
```

The `.html` export opened on a stray unheaded copy above the real `<h1>`. `<title>` is now dropped with its contents, beside the dangerous containers but under a list of its own saying why it is there — nothing about it is dangerous, and the title is not lost, since every format writes it from `input.title`.

## 3. The PDF export held one sentence of the story

`generatePDFContent` wrote the title and `truncateByCodePoint(content, 100)` followed by a literal `...`, on a single page, while the four other formats shipped the whole story. Nothing about the file said so: it downloaded under the story's own name, at the size a real PDF of a sentence is, and a trailing ellipsis reads as ordinary prose in a story that ends on a cliffhanger.

The text is now wrapped into lines and the lines paginated, with one `/Page` object and one content stream per page. `assemblePdfDocument` already measured its cross-reference offsets from whatever objects it was handed, so the table stays correct however long a story runs. Lines are broken on code-point boundaries and escaped as they are written, so neither a surrogate pair nor a `\(` escape can be split across a break.

## Verification

- `npm run test:all` passes.
- New assertions in `tests/export-sanitizer.test.ts` (pretty-printed boundaries, trailing-space handling, whole-document `<title>`/`<style>` handling) and `tests/export-service.test.ts` (`testPdfCarriesTheWholeStoryAcrossPages`, `testPdfLinesBreakOnCharacterBoundaries`).
- Each new test was run against the pre-fix source and fails there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4w7dJCB7gVifhbQQr8qsg)_

## Summary by Sourcery

Fix export formatting and completeness so generated text-based formats preserve story structure, avoid duplicate titles, and PDFs include the full story.

New Features:
- Generate complete, paginated PDF exports containing the entire story across multiple pages.

Bug Fixes:
- Preserve paragraph breaks while removing trailing inline whitespace from plain-text exports.
- Prevent document metadata titles from being duplicated in exported story content.
- Keep PDF line wrapping safe for escaped characters and Unicode code points.

Tests:
- Add regression coverage for pretty-printed HTML boundaries, document metadata removal, trailing-space handling, complete multi-page PDFs, and character-safe PDF line breaks.