### PR TITLE
Three quick wins: a tone the scan cannot spell, an export format no reader can choose, an image error pinned to the wrong chapter

### DIFF
--- a/api/_lib/services/exportService.ts
+++ b/api/_lib/services/exportService.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { SaveExportSeam, ApiResponse, ExportFormat } from '../types/contracts';
+import { SaveExportSeam, ApiResponse, EXPORT_FORMATS, ExportFormat } from '../types/contracts';
 import {
   escapeHtml,
   escapePdfText,
@@ -593,7 +593,10 @@ ${chapterXhtml}
   }
 
   private validateExportInput(input: SaveExportSeam['input']): any {
-    const supportedFormats: ExportFormat[] = ['pdf', 'txt', 'html', 'epub', 'docx'];
+    // The contract's own list rather than a fourth copy of it: the picker, this
+    // guard, and `generateExportContent`'s switch all have to name the same five
+    // formats, and the copy in the picker is the one that had already drifted.
+    const supportedFormats: ExportFormat[] = [...EXPORT_FORMATS];
 
     if (!supportedFormats.includes(input.format)) {
       return {

--- a/api/_lib/services/storyService.ts
+++ b/api/_lib/services/storyService.ts
@@ -1373,7 +1373,7 @@ Write 400-600 words for this chapter. Use HTML: <h3> for chapter title, <p> for 
   private extractPlotThreads(content: string): string[] {
     const threads: string[] = [];
     const lowerContent = content.toLowerCase();
-    
+
     // Check for common plot thread indicators
     if (lowerContent.includes('secret') || lowerContent.includes('mystery')) {
       threads.push('Unresolved mystery or secret');
@@ -1396,18 +1396,29 @@ Write 400-600 words for this chapter. Use HTML: <h3> for chapter title, <p> for 
 
   /**
    * Analyze emotional tone of existing content
+   *
+   * `dominan` was a word stem left behind from a substring scan, and every
+   * keyword here is matched as a whole word. Nothing in English is spelled
+   * `dominan`, so the alternative could never fire: the one register the
+   * `intense` tone exists to name — a chapter written about dominance — was
+   * recognised only if it also happened to say `power`, `control`, or
+   * `command`, and a scene that says `dominant` and nothing else was reported
+   * to the continuation prompt as `romantic with building tension`. The
+   * inflections the stem stood for are spelled out instead, which is the same
+   * repair `extractThemesFromContent` made when it moved to whole-word
+   * matching.
    */
   private analyzeEmotionalTone(content: string): string {
     const lowerContent = content.toLowerCase();
     const tones: string[] = [];
-    
+
     // Emotional indicators
     if (lowerContent.match(/\b(desire|passion|want|need|crave)\b/)) tones.push('passionate');
     if (lowerContent.match(/\b(dark|shadow|danger|fear|threat)\b/)) tones.push('dark/suspenseful');
     if (lowerContent.match(/\b(tease|playful|smile|grin|laugh)\b/)) tones.push('playful');
     if (lowerContent.match(/\b(pain|ache|hurt|wound|scar)\b/)) tones.push('angsty');
-    if (lowerContent.match(/\b(power|control|dominan|command)\b/)) tones.push('intense');
-    
+    if (lowerContent.match(/\b(power|control|dominant|dominance|dominated|command)\b/)) tones.push('intense');
+
     return tones.length > 0 ? tones.join(', ') : 'romantic with building tension';
   }
 

--- a/api/_lib/types/contracts.ts
+++ b/api/_lib/types/contracts.ts
@@ -56,6 +56,32 @@ export type CharacterVoiceType =
 export type AudioSpeed = 0.5 | 0.75 | 1.0 | 1.25 | 1.5;
 export type AudioFormat = 'mp3' | 'wav' | 'aac';
 export type ExportFormat = 'pdf' | 'txt' | 'html' | 'epub' | 'docx';
+
+/**
+ * The export formats, as a value rather than only as a type.
+ *
+ * `ExportFormat` has named five since the export pipeline was written, and
+ * `ExportService.generateExportContent` renders all five. The Angular export
+ * picker restated the list by hand as `['txt', 'pdf', 'epub', 'docx']` and lost
+ * `html` doing it, so the one format with no option in the dropdown was the one
+ * whose renderer is the only path that runs the story through
+ * `sanitizeStoryHtmlForExport` and attaches the export metadata — a reader could
+ * reach the sanitized HTML document from nowhere in the app. (The "Download"
+ * button beside the picker is a different document: the browser builds it from
+ * the workbench, without the sanitizer or the metadata.)
+ *
+ * Both readers take the list from here now, so a format added to the type has
+ * one place to be added to and cannot go missing from the picker again — the
+ * same arrangement `IMAGE_STYLES` and `CREATURE_ARCHETYPES` already have on the
+ * Angular side.
+ */
+export const EXPORT_FORMATS = [
+  'txt',
+  'pdf',
+  'html',
+  'epub',
+  'docx'
+] as const satisfies readonly ExportFormat[];
 export type ImageStyle = 'artistic' | 'photorealistic' | 'fantasy' | 'dark' | 'romantic';
 export type CliffhangerType =
   | 'romantic_tension'

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -18,6 +18,7 @@ import {
   CloudStoryProjectList,
   CloudStoryProjectLoadResult,
   CloudStoryProjectSaveReceipt,
+  EXPORT_FORMATS,
   GeneratedChapter,
   ImageGenerationSeam,
   SaveExportSeam,
@@ -681,6 +682,57 @@ describe('App', () => {
     const preview = fixture.nativeElement.querySelector('[data-testid="chapter-image-preview"]') as HTMLImageElement | null;
     expect(errorText?.textContent?.trim()).toBe('AI image service temporarily unavailable');
     expect(preview).toBeNull();
+  });
+
+  // The image panel belongs to the chapter on screen, and the `<img>` has
+  // always known it: the preview is drawn only when the stored image names the
+  // selected chapter. The error had no such check and nothing cleared it, so a
+  // refusal earned by one chapter stayed pinned under every chapter the reader
+  // opened afterwards, describing a request that was never made for them.
+  it('keeps an image failure under the chapter that earned it', () => {
+    seedWorkbenchForContinuation({
+      batch: {
+        chapters: [
+          createChapter({ chapterId: 'chapter-1', chapterNumber: 1 }),
+          createChapter({ chapterId: 'chapter-2', chapterNumber: 2, title: 'Chapter Two' })
+        ],
+        totalWordCount: 1800,
+        suggestedNextPrompts: []
+      }
+    });
+    component.selectChapter('chapter-1');
+    storyService.generateImage.and.returnValue(of({
+      success: false,
+      error: { code: 'INVALID_INPUT', message: 'Themes are required and must be a non-empty array' }
+    }));
+    fixture.detectChanges();
+
+    (fixture.nativeElement.querySelector('[data-testid="generate-image"]') as HTMLButtonElement).click();
+    fixture.detectChanges();
+
+    const failedChapterError = fixture.nativeElement.querySelector('[data-testid="chapter-image-error"]') as HTMLElement | null;
+    expect(failedChapterError?.textContent?.trim()).toBe('Themes are required and must be a non-empty array');
+
+    component.selectChapter('chapter-2');
+    fixture.detectChanges();
+
+    expect(component.imageGenerationError()).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="chapter-image-error"]')).toBeNull();
+
+    component.selectChapter('chapter-1');
+    fixture.detectChanges();
+
+    expect(component.imageGenerationError()).toBe('Themes are required and must be a non-empty array');
+  });
+
+  // The picker used to restate the export format list by hand and had lost
+  // `html` — the one format the export route renders that no reader could then
+  // ask for.
+  it('offers every export format the route renders', () => {
+    fixture.detectChanges();
+
+    expect(component.exportFormats).toEqual(EXPORT_FORMATS);
+    expect(component.exportFormats).toContain('html');
   });
 
   it('disables cloud save before an active story exists', () => {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -22,6 +22,7 @@ import {
   CloudStoryProjectListItem,
   ContinuityPanelViewModel,
   CreatureArchetype,
+  EXPORT_FORMATS,
   ExportFormat,
   GeneratedChapter,
   HeatContract,
@@ -401,8 +402,34 @@ export class App implements OnDestroy {
   readonly selectedImageStyle = signal<ImageStyle>('artistic');
   readonly isGeneratingImage = signal(false);
   readonly generatedChapterImage = signal<{ chapterId: string; image: ImageGenerationSeam['output'] } | null>(null);
-  readonly imageGenerationError = signal<string | null>(null);
-  readonly exportFormats: ExportFormat[] = ['txt', 'pdf', 'epub', 'docx'];
+  readonly chapterImageFailure = signal<{ chapterId: string; message: string } | null>(null);
+  /**
+   * The image failure to show under the chapter currently open, if it is that
+   * chapter's failure.
+   *
+   * The panel this renders in belongs to the selected chapter, and the image
+   * beside it has always known that: the `<img>` is drawn only when
+   * `generatedChapterImage().chapterId` matches the chapter on screen, so
+   * selecting another chapter puts the preview away. The error had no such
+   * check and nothing cleared it, so a refusal earned by Chapter 1 — "Themes
+   * are required", "Invalid image style" — stayed pinned under Chapter 2,
+   * Chapter 3, and every chapter generated afterwards, describing a request
+   * that was never made for them. It outlived the story, too: loading a saved
+   * project leaves it on screen over chapters from a different story.
+   *
+   * Recording which chapter the failure belongs to and matching it the way the
+   * image already does makes the two halves of the panel agree, and means the
+   * message goes away on its own when the reader moves on.
+   */
+  readonly imageGenerationError = computed(() => {
+    const failure = this.chapterImageFailure();
+    return failure && failure.chapterId === this.selectedChapter()?.chapterId ? failure.message : null;
+  });
+  // Read from the contract rather than restated here: this list had lost
+  // `html`, so the export route's sanitized HTML document — the only rendering
+  // that runs the story through the export sanitizer and carries the export
+  // metadata — had no option in the picker to ask for it.
+  readonly exportFormats: readonly ExportFormat[] = EXPORT_FORMATS;
   readonly selectedExportFormat = signal<ExportFormat>('txt');
   readonly isExporting = signal(false);
   readonly statusMessage = signal<string>('Tell us what kind of enchanted, spicy story you want.');
@@ -1499,7 +1526,7 @@ ${chapters}
     }
 
     this.isGeneratingImage.set(true);
-    this.imageGenerationError.set(null);
+    this.chapterImageFailure.set(null);
 
     const themes = this.blueprint().themes.map(theme => theme.id);
 
@@ -1520,7 +1547,7 @@ ${chapters}
             this.notificationService.success('Image generated', 'Your chapter illustration is ready.');
           } else {
             const message = response.error?.message ?? 'Image generation failed.';
-            this.imageGenerationError.set(message);
+            this.chapterImageFailure.set({ chapterId: chapter.chapterId, message });
             this.notificationService.error('Image generation failed', message);
           }
         },
@@ -1533,7 +1560,7 @@ ${chapters}
         error: error => {
           this.isGeneratingImage.set(false);
           const message = this.formatHttpError(error, 'Image generation failed. Please try again.');
-          this.imageGenerationError.set(message);
+          this.chapterImageFailure.set({ chapterId: chapter.chapterId, message });
           this.notificationService.error('Image generation failed', message);
         }
       });

--- a/story-generator/src/app/contracts.ts
+++ b/story-generator/src/app/contracts.ts
@@ -35,6 +35,10 @@ export type ImageStyle = 'artistic' | 'photorealistic' | 'fantasy' | 'dark' | 'r
 // drift the way the classic `/api/story/*` routes already had (see
 // `expressApiRoutes.ts`).
 export type { ExportFormat, SaveExportSeam } from '../../../api/_lib/types/contracts';
+// The runtime list travels with the type, for the same reason: the export
+// picker used to restate it and dropped `html`, the one format the route
+// renders that no reader could then choose.
+export { EXPORT_FORMATS } from '../../../api/_lib/types/contracts';
 
 export const IMAGE_STYLES = [
   'artistic',

--- a/tests/export-service.test.ts
+++ b/tests/export-service.test.ts
@@ -3,7 +3,7 @@
 
 import { ExportService } from '../api/_lib/services/exportService';
 import { readZipEntries, ZipEntry } from '../api/_lib/services/zipArchive';
-import { SaveExportSeam } from '../api/_lib/types/contracts';
+import { EXPORT_FORMATS, SaveExportSeam } from '../api/_lib/types/contracts';
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -433,6 +433,37 @@ async function testMetadataReflectsTheActualStory(): Promise<void> {
   );
 }
 
+/**
+ * The export format list has three readers — the service's own guard, the
+ * renderer's switch, and the Angular picker — and the picker's hand-written
+ * copy had lost `html`, so the one format nobody could choose was the one whose
+ * renderer runs the story through the export sanitizer and attaches the export
+ * metadata. `EXPORT_FORMATS` is now the single definition; this holds the two
+ * server-side readers to it, and the Angular spec holds the picker to it.
+ */
+async function testEveryDeclaredFormatRenders(): Promise<void> {
+  const exportService = new ExportService();
+
+  assert(EXPORT_FORMATS.includes('html'), 'html is an export format the service renders');
+
+  for (const format of EXPORT_FORMATS) {
+    const result = await exportService.saveAndExport(createInput({ format }));
+    assert(result.success, `${format} is a declared format and must not be refused as unsupported`);
+
+    const content = await exportService.generateExportContent(createInput({ format }));
+    assert(content.length > 0, `${format} should render a non-empty document`);
+  }
+
+  const unsupported = await exportService.saveAndExport(
+    createInput({ format: 'rtf' as SaveExportSeam['input']['format'] })
+  );
+  assert(!unsupported.success, 'a format outside the declared list should still be refused');
+  assert(
+    !unsupported.success && unsupported.error?.code === 'FORMAT_NOT_SUPPORTED',
+    'an unsupported format should be named as such rather than reported as a service failure'
+  );
+}
+
 function escapeForAssertion(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
@@ -449,6 +480,7 @@ async function main(): Promise<void> {
   await testEpubIsARealZipContainerWithItsChapter();
   await testDocxIsARealZipContainerWithItsDocument();
   await testMetadataReflectsTheActualStory();
+  await testEveryDeclaredFormatRenders();
 
   console.log('Export service tests passed');
 }

--- a/tests/story-service-prompt-guards.test.ts
+++ b/tests/story-service-prompt-guards.test.ts
@@ -13,6 +13,7 @@ function assert(condition: unknown, message: string): asserts condition {
 const service = new StoryService() as unknown as {
   formatThemeContext(input: StoryGenerationSeam['input']): string;
   formatStoryLabContext(input: StoryGenerationSeam['input']): string;
+  analyzeEmotionalTone(content: string): string;
 };
 
 const longLabel = 'L'.repeat(120);
@@ -66,5 +67,33 @@ assert(!storyLabContext.includes('N'.repeat(321)), 'narrative directives should 
 assert(storyLabContext.includes('X'.repeat(320)), 'no-go content should be preserved up to the context cap');
 assert(!storyLabContext.includes('X'.repeat(321)), 'no-go content should be capped at the context cap');
 assert(!storyLabContext.includes('undefined'), 'malformed prompt context should not render undefined');
+
+// The continuation prompt is told what the previous chapter's emotional
+// register is. `dominan` was a word stem left over from substring matching and
+// every keyword is matched as a whole word, so nothing could ever match it: a
+// chapter written about dominance and nothing else was described to the model
+// as `romantic with building tension`.
+const dominanceChapter = '<p>She named the terms. He was dominant in every way that counted.</p>';
+const dominanceTone = service.analyzeEmotionalTone(dominanceChapter);
+assert(dominanceTone.includes('intense'), 'a chapter about dominance should read as an intense register');
+assert(
+  service.analyzeEmotionalTone('<p>Her dominance was not in question.</p>').includes('intense'),
+  'the dominance inflection should be recognised too'
+);
+assert(
+  service.analyzeEmotionalTone('<p>A quiet supper by the window.</p>') === 'romantic with building tension',
+  'a chapter carrying none of the registers should still fall back honestly'
+);
+
+// The registers that already worked keep working: this repair spells out one
+// alternative, it does not loosen the whole-word matching around it.
+assert(
+  service.analyzeEmotionalTone('<p>He took control of the room.</p>').includes('intense'),
+  'the registers that already matched should be unchanged'
+);
+assert(
+  !service.analyzeEmotionalTone('<p>The predominant colour was red.</p>').includes('intense'),
+  'a word that merely contains a keyword should still not match'
+);
 
 console.log('Story service prompt guard tests passed');


### PR DESCRIPTION
Three small, independent defects, each with a regression test that fails against the code it replaces.

## 1. A tone the scan cannot spell

`StoryService.analyzeEmotionalTone` matches every keyword as a whole word, and one alternative was `dominan` — a stem left behind from an earlier substring scan. Nothing in English is spelled that, so `/\b(power|control|dominan|command)\b/` could never fire on it.

The `intense` register was therefore reachable only through `power`, `control`, or `command`. A chapter written about dominance and nothing else was described to the continuation prompt as `romantic with building tension` — the opposite of what it is — and the next chapter was written from that description.

The inflections the stem stood for (`dominant`, `dominance`, `dominated`) are spelled out instead. That is the same repair `extractThemesFromContent` made when it moved to whole-word matching.

## 2. An export format no reader can choose

`ExportFormat` has named five formats since the export pipeline was written, and `ExportService.generateExportContent` renders all five. The Angular export picker restated the list by hand as `['txt', 'pdf', 'epub', 'docx']` and lost `html` doing it.

The missing one is not incidental: the HTML renderer is the only path that runs the story through `sanitizeStoryHtmlForExport` and attaches the export metadata, so a reader could reach the sanitized HTML document from nowhere in the app. The "Download" button beside the picker is a different document — the browser builds it from the workbench, without the sanitizer and without the metadata.

The list now has one definition, `EXPORT_FORMATS`, sitting beside the type it satisfies. Both the picker and `validateExportInput` read it, so a format added to the type has one place to be added to — the arrangement `IMAGE_STYLES` and `CREATURE_ARCHETYPES` already have.

## 3. An image error pinned to the wrong chapter

The chapter image panel belongs to the chapter on screen, and the `<img>` has always known it: the preview renders only when the stored image names the selected chapter. The error beside it had no such check, and nothing cleared it.

So a refusal earned by Chapter 1 — "Themes are required and must be a non-empty array", "Invalid image style provided" — stayed pinned under Chapter 2, Chapter 3, and every chapter generated afterwards, describing a request that was never made for them. It outlived the story too: loading a saved project left it on screen over chapters from a different one.

The failure now records which chapter earned it, and `imageGenerationError` is a computed that matches it the way the image already does — so the message goes away on its own when the reader moves on.

## Testing

- `npm test` — full root suite, 0 failures
- `npx ng test --watch=false` — 186 Angular specs, 0 failures
- `scripts/recovery/preflight.sh --skip-status` — typechecks, tests, and the production Angular build

New regression coverage:

| Fix | Test | Fails before |
|---|---|---|
| 1 | `tests/story-service-prompt-guards.test.ts` | yes — verified by restoring `dominan` |
| 2 | `tests/export-service.test.ts`, `app.spec.ts` "offers every export format the route renders" | yes — `html` absent from the picker list |
| 3 | `app.spec.ts` "keeps an image failure under the chapter that earned it" | yes — verified by dropping the chapter match |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGVs4AiRiTKHf5xYDhtdN4

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGVs4AiRiTKHf5xYDhtdN4)_

## Summary by Sourcery

Fix emotional-tone detection, export-format availability, and chapter-specific image errors while adding regression coverage for each defect.

Bug Fixes:
- Recognize dominant, dominance, and dominated as intense emotional-tone indicators for continuation prompts.
- Expose every supported export format, including HTML, through a shared format definition used by the picker and validation.
- Keep image-generation errors associated with the chapter that produced them so they do not appear under other chapters.

Enhancements:
- Centralize export format declarations to prevent the client picker and export service from drifting out of sync.

Tests:
- Add regression coverage for dominance tone detection, complete export-format availability and rendering, and chapter-scoped image-generation errors.