### PR TITLE
Three quick wins: a job stream throttled off fifteen seconds in, a score penalty that says nothing, continuation advice for a hook that is not there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Three Quick Wins — a job stream throttled off fifteen seconds in, a score penalty that says nothing, continuation advice for a hook that is not there (August 26, 2026)
+
+#### The Story Lab job event stream was rate-limited as if it were the genesis stream
+
+- `/api/story-lab/jobs/:jobId/events` replays the events a job has recorded so
+  far and then **ends the response** — every time, for a job that is still
+  running. That is the design, and both sides document it:
+  `shared/eventStreamRetry.ts` exists precisely to tell the Angular reader that
+  the resulting `error` is a reconnect rather than a failure, and
+  `StoryService.streamStoryLabJobEvents` keeps the subscription alive through
+  it. So a browser `EventSource` reopens the connection roughly every three
+  seconds for as long as the generation runs.
+- Wiring access control into the route (#244) gave it `RATE_LIMITS.STREAMING`:
+  **five requests per fifteen minutes**. That tier is sized for
+  `/api/story-lab/stream/genesis`, the opposite kind of stream — one connection
+  held open for a whole paid generation, which the reader deliberately never
+  reopens because reconnecting there re-runs the generation from the beginning.
+- One reader watching one job therefore spent the entire budget about fifteen
+  seconds in. Every reconnect after that was answered `429`, so the job kept
+  running on the server while the page reported *"Story generation updates
+  stopped"* — and could not get them back for fifteen minutes. The route spends
+  nothing: it reads the job store and replays recorded snapshots.
+- Adds `RATE_LIMITS.STORY_LAB_JOB_EVENTS`, sized for the polling the route's own
+  design causes — fifteen minutes of uninterrupted three-second reconnects is
+  three hundred requests — and leaves `STREAMING` to the single-connection
+  genesis stream it was written for. The regression test drives twenty
+  consecutive reconnects without resetting the limit between them, which is what
+  every other scenario in that file does.
+
+#### The audio-readiness dimension penalised overlong paragraphs without saying so
+
+- `scoreAudioReadiness` swings a story's score by **thirty points** on one check
+  — `+12` when no paragraph runs past ninety words, `-18` when one does — and
+  printed a signal only for the passing case. A penalised story came back with a
+  rationale claiming to check paragraph length and a signal list that was
+  entirely about dialogue, so the reader was handed a lower number with nothing
+  explaining it and nothing to act on.
+- Every other dimension already reports what moved it: `scoreTropeFreshness`
+  prints the stale phrases that cost it points. This now prints how many
+  paragraphs are too long and how long the worst one runs, and the threshold is
+  named (`AUDIO_READINESS_MAX_PARAGRAPH_WORDS`) rather than inlined.
+
+#### Cliffhanger analysis suggested continuations for a hook it had not found
+
+- `CliffhangerAnalysis.cliffhangerType` is a closed set with no "none" member, so
+  a chapter with no cliffhanger still has to be labelled *something* — it falls
+  to `plot_twist`. Every other field on the analysis knows that label is a
+  placeholder and reports nothing: `cliffhangerStrength` floors at `0`,
+  `cliffhangerText` is empty.
+- The two fields a caller actually acts on did not. `suggestedContinuations`
+  handed back three instructions written for a twist — *"Reveal the first
+  consequence of the twist"* — for a chapter the same scan had just said ends on
+  no hook at all. `varietyScore` was worse: it asked whether the **placeholder**
+  appeared in `previousCliffhangers`, so a chapter with no cliffhanger scored 3
+  out of 8 for repetition whenever the chapter before it genuinely was a
+  `plot_twist` — a sameness penalty for a hook that does not exist.
+- The whole analysis travels back to the caller as `cliffhangerAnalysis` on the
+  continuation response, so both were public answers about something the service
+  had not detected. An undetected cliffhanger now suggests nothing and cannot
+  repeat anything; the detected side — suggestions, and the variety penalty for a
+  genuinely repeated type — is unchanged and covered by the existing assertions
+  plus new ones.
+
 ### 🐛 Three Quick Wins — a blend voice missing from every prompt preview, a theme picker no reader can reach, a form refusing what the API accepts (August 26, 2026)
 
 #### Proving Grounds never showed the third author the API actually blends in

--- a/api/_lib/constants.ts
+++ b/api/_lib/constants.ts
@@ -41,6 +41,39 @@ export const RATE_LIMITS = {
     maxRequests: 5,
     windowMs: 15 * 60 * 1000    // 15 minutes
   },
+  /**
+   * The Story Lab job event stream, which is not the kind of stream `STREAMING`
+   * describes.
+   *
+   * `STREAMING` is sized for `/api/story-lab/stream/genesis`: one connection
+   * held open for a whole paid generation, which the Angular reader
+   * deliberately never reopens because reconnecting there re-runs the
+   * generation from the beginning. Five of those in fifteen minutes is a
+   * generous cap.
+   *
+   * `/api/story-lab/jobs/:jobId/events` works the opposite way. It replays the
+   * events a job has recorded so far and then *ends the response* — every time,
+   * for a job that is still running — so the browser fires `error`, reopens the
+   * connection, and asks again. That is the documented design on both sides:
+   * `shared/eventStreamRetry.ts` exists to tell the reader to keep the
+   * subscription alive through it, and `StoryService.streamStoryLabJobEvents`
+   * treats a reconnect as normal. So one reader watching one job is not one
+   * request here; it is a request every time the browser retries, roughly every
+   * three seconds.
+   *
+   * Under `STREAMING` that budget was spent about fifteen seconds into the
+   * first generation, and every reconnect after it was answered 429 for the
+   * rest of the window: the job kept running on the server while the reader was
+   * told "Story generation updates stopped", and could not get them back for
+   * fifteen minutes. The route spends nothing — it reads the job store and
+   * replays recorded snapshots — so the cap belongs on the polling, not on the
+   * generation. Fifteen minutes of uninterrupted three-second reconnects is
+   * three hundred requests, which is what this allows.
+   */
+  STORY_LAB_JOB_EVENTS: {
+    maxRequests: 300,
+    windowMs: 15 * 60 * 1000    // 15 minutes
+  },
   STORY_LAB_GENESIS: {
     maxRequests: 10,
     windowMs: 15 * 60 * 1000    // 15 minutes — same tier as story generation

--- a/api/_lib/services/cliffhangerService.ts
+++ b/api/_lib/services/cliffhangerService.ts
@@ -127,13 +127,33 @@ export class CliffhangerService {
     const cliffhangerType = detectedType ?? 'plot_twist';
     const cliffhangerDetected = detectedType !== null || CLIFFHANGER_PUNCTUATION_PATTERN.test(trimmedLastParagraph);
 
+    // `cliffhangerType` is a placeholder when nothing was found — the contract
+    // types it as a `CliffhangerType` rather than as an optional one, so
+    // "no hook" still has to be spelled as some member of the set, and
+    // `plot_twist` is the one it falls to. Every other field already knows that
+    // and reports nothing: strength is floored at 0 and `cliffhangerText` is
+    // empty. These two did not, and they are the two the caller acts on.
+    //
+    // `suggestedContinuations` handed back three instructions written for a
+    // twist — "Reveal the first consequence of the twist", "Show characters
+    // adapting to the new reality" — for a chapter the scan had just said ends
+    // on no hook at all. `varietyScore` was worse than merely wrong: it asked
+    // whether the placeholder appeared in `previousCliffhangers`, so a chapter
+    // with no cliffhanger scored 3 out of 8 for repetition whenever the chapter
+    // before it genuinely was a `plot_twist` — a sameness penalty for a hook
+    // that does not exist, which is the opposite of what a variety score is
+    // for. The whole analysis travels back to the caller as
+    // `cliffhangerAnalysis` on the continuation response, so both were public
+    // answers about a hook the service had not found.
     return {
       cliffhangerDetected,
       cliffhangerType,
       cliffhangerStrength: Math.min(10, Math.max(cliffhangerDetected ? 1 : 0, strength)),
       cliffhangerText: cliffhangerDetected ? lastParagraph : '',
-      suggestedContinuations: this.generateContinuationSuggestions(cliffhangerType),
-      varietyScore: previousCliffhangers.includes(cliffhangerType) ? 3 : 8
+      suggestedContinuations: cliffhangerDetected
+        ? this.generateContinuationSuggestions(cliffhangerType)
+        : [],
+      varietyScore: cliffhangerDetected && previousCliffhangers.includes(cliffhangerType) ? 3 : 8
     };
   }
 

--- a/api/_lib/story-lab/evaluation/storyQualityHeuristics.ts
+++ b/api/_lib/story-lab/evaluation/storyQualityHeuristics.ts
@@ -193,10 +193,17 @@ function scoreProseQuality(storyContent: string, wordCount: number, sentenceCoun
   };
 }
 
+/**
+ * The paragraph length a narrator has to read in one unbroken breath before
+ * this dimension counts it against the story.
+ */
+const AUDIO_READINESS_MAX_PARAGRAPH_WORDS = 90;
+
 function scoreAudioReadiness(dialogueLines: string[], paragraphs: string[]): DimensionDraft {
   const dialogueLineCount = dialogueLines.length;
   const speakers = extractDialogueSpeakers(dialogueLines);
-  const longParagraphs = paragraphs.filter(paragraph => paragraph.split(/\s+/).filter(Boolean).length > 90);
+  const paragraphWordCounts = paragraphs.map(paragraph => paragraph.split(/\s+/).filter(Boolean).length);
+  const longParagraphs = paragraphWordCounts.filter(count => count > AUDIO_READINESS_MAX_PARAGRAPH_WORDS);
   const signals: string[] = [];
   if (dialogueLineCount > 0) {
     signals.push(`Tagged dialogue lines: ${dialogueLineCount}`);
@@ -206,7 +213,21 @@ function scoreAudioReadiness(dialogueLines: string[], paragraphs: string[]): Dim
   } else if (speakers.length === 1) {
     signals.push(`Single speaker: ${speakers[0]}`);
   }
-  if (!longParagraphs.length) {
+  // Both sides of the paragraph-length check are reported, because this is the
+  // only thing in the dimension that can *cost* points and it used to say
+  // nothing when it did. An overlong paragraph swings the score by thirty — the
+  // difference between the `+12` below and the `-18` — so a story carrying one
+  // was scored down to a number the reader had no way to explain: the rationale
+  // claimed to check paragraph length, and every signal beside it was about
+  // dialogue. `scoreTropeFreshness` already prints the stale phrases that cost
+  // it points; this prints how many paragraphs are too long and how long the
+  // worst one runs, which is what a writer needs to act on it.
+  if (longParagraphs.length) {
+    signals.push(
+      `Overlong paragraphs (over ${AUDIO_READINESS_MAX_PARAGRAPH_WORDS} words): ${longParagraphs.length}, ` +
+        `longest ${Math.max(...longParagraphs)} words`
+    );
+  } else {
     signals.push('No overlong paragraphs detected.');
   }
 

--- a/api/_lib/story-lab/jobs/jobRouteHandlers.ts
+++ b/api/_lib/story-lab/jobs/jobRouteHandlers.ts
@@ -264,7 +264,9 @@ async function handleStreamStoryLabJobEventsWithContext(
     withEventStreamAuth(req),
     res,
     'story-lab/jobs/events',
-    RATE_LIMITS.STREAMING
+    // Not `STREAMING`: this route replays and closes, so a reader watching one
+    // job reconnects every few seconds. See `RATE_LIMITS.STORY_LAB_JOB_EVENTS`.
+    RATE_LIMITS.STORY_LAB_JOB_EVENTS
   );
   if (!access.allowed) {
     return;

--- a/tests/cliffhanger-service.test.ts
+++ b/tests/cliffhanger-service.test.ts
@@ -117,6 +117,48 @@ assert(
   `an undetected cliffhanger reports no hook text (got ${JSON.stringify(answeredQuestion.cliffhangerText)})`
 );
 
+// `cliffhangerType` is a placeholder when nothing was detected — the contract
+// has no "none" member — and the two fields the caller acts on used to be built
+// from it anyway. The suggestions described a twist the scan had just said was
+// not there, and the variety score applied a repetition penalty for it.
+assert(
+  answeredQuestion.suggestedContinuations.length === 0,
+  'an undetected cliffhanger suggests no continuations for a hook it did not find ' +
+    `(got ${JSON.stringify(answeredQuestion.suggestedContinuations)})`
+);
+
+const undetectedAfterTwist = service.analyze(
+  '<p>The lamps guttered.</p><p>Did she stay? She stayed, and the night was warm.</p>',
+  ['plot_twist']
+);
+
+assert(
+  !undetectedAfterTwist.cliffhangerDetected,
+  'the same closing paragraph is still not a cliffhanger when a previous type is supplied'
+);
+assert(
+  undetectedAfterTwist.varietyScore === 8,
+  'a chapter with no cliffhanger cannot repeat the previous one, whatever the placeholder type is ' +
+    `(got ${undetectedAfterTwist.varietyScore})`
+);
+
+// The detected side of both fields is unchanged: a real hook still carries its
+// suggestions, and still loses variety when it repeats the type before it.
+const repeatedDanger = service.analyze(
+  '<p>The corridor went silent.</p><p>Footsteps stopped outside the door, and her blood froze.</p>',
+  ['danger']
+);
+
+assert(repeatedDanger.cliffhangerType === 'danger', 'a repeated danger hook is still a danger hook');
+assert(
+  repeatedDanger.suggestedContinuations.length > 0,
+  'a detected cliffhanger still carries its continuation suggestions'
+);
+assert(
+  repeatedDanger.varietyScore === 3,
+  `a detected hook repeating the previous type still loses variety (got ${repeatedDanger.varietyScore})`
+);
+
 // The same paragraph, left on the question, is still the mystery hook it was.
 const openQuestion = service.analyze('<p>The lamps guttered.</p><p>The night was warm, and she stayed. But had she chosen well?</p>');
 

--- a/tests/story-lab-job-routes.test.ts
+++ b/tests/story-lab-job-routes.test.ts
@@ -250,6 +250,61 @@ async function testEventsReplaySnapshotsAndClose(): Promise<void> {
 }
 
 /**
+ * The route above replays and *ends the response*, every time, for a job that
+ * is still running — so a browser `EventSource` fires `error` and reopens the
+ * connection, roughly every three seconds, until the job finishes. That is the
+ * documented design on both sides: `shared/eventStreamRetry.ts` exists to tell
+ * the Angular reader to keep the subscription alive through it.
+ *
+ * So one reader watching one job is not one request here. Under
+ * `RATE_LIMITS.STREAMING` — five per fifteen minutes, sized for the *genesis*
+ * stream, which holds a single connection open for a whole paid generation and
+ * is deliberately never reopened — the budget was spent about fifteen seconds
+ * into the first generation. Every reconnect after that was answered 429, so
+ * the reader was told "Story generation updates stopped" for a job the server
+ * was still working on, and could not get the updates back for fifteen minutes.
+ *
+ * This drives the reconnects the design causes without resetting the limit
+ * between them, which is the thing `createRequest` does for every other
+ * scenario in this file.
+ */
+async function testEventsSurviveTheReconnectsItsOwnDesignCauses(): Promise<void> {
+  nonDurableStoryLabJobStore.reset();
+  setMockRuntime();
+
+  const response = await postGenesisJob();
+  const jobId = (response.body as any).data.job.jobId as string;
+
+  resetRateLimitsForTests();
+  try {
+    // More reconnects than the single-connection `STREAMING` tier allows, and
+    // no more than one job's worth of them: a sixty-second generation retried
+    // every three seconds is about twenty.
+    const reconnects = 20;
+    for (let attempt = 1; attempt <= reconnects; attempt += 1) {
+      const eventsResponse = new FakeResponse();
+      await jobHandler(
+        {
+          method: 'GET',
+          query: { jobId, events: '1' },
+          url: `/api/story-lab/jobs/${encodeURIComponent(jobId)}/events`,
+          headers: {}
+        },
+        eventsResponse
+      );
+
+      assert(
+        eventsResponse.statusCode === 200,
+        `reconnect ${attempt} of ${reconnects} should still be served, got ${eventsResponse.statusCode} ` +
+          `${JSON.stringify(eventsResponse.body)}`
+      );
+    }
+  } finally {
+    resetRateLimitsForTests();
+  }
+}
+
+/**
  * A reader who closes the tab while the route is still reading the job store.
  *
  * The replay is reached only after two awaited store lookups, so the response
@@ -538,6 +593,7 @@ async function testThrownEngineFailureFinishesTheJob(): Promise<void> {
 async function run(): Promise<void> {
   await testGenesisJobCompletesInMockMode();
   await testEventsReplaySnapshotsAndClose();
+  await testEventsSurviveTheReconnectsItsOwnDesignCauses();
   await testEventsReplayStopsAtAClosedResponse();
   await testPreflightAdvertisesEveryMethodTheRouteServes();
   await testInvalidAndUnknownJobIds();

--- a/tests/story-quality-evals.test.ts
+++ b/tests/story-quality-evals.test.ts
@@ -164,6 +164,53 @@ function testHtmlStoriesAreScoredOnTheirProse(): void {
 }
 
 /**
+ * The one thing in the audio-readiness dimension that can cost points has to
+ * say so.
+ *
+ * An overlong paragraph swings the score by thirty — the difference between the
+ * `+12` a clean story gets and the `-18` a penalised one takes — and the
+ * dimension printed nothing about it. The rationale claimed to check paragraph
+ * length while every signal beside it was about dialogue, so the reader was
+ * handed a number with no way to explain it and nothing to act on.
+ */
+function testOverlongParagraphsAreReportedNotJustPenalised(): void {
+  const longParagraph = Array.from({ length: 120 }, (_, index) => `word${index}`).join(' ');
+  const configuration = {
+    creature: 'siren',
+    themes: ['blood_oaths'],
+    spicyLevel: 3,
+    wordCount: 900
+  };
+
+  const audioReadiness = (storyContent: string) => {
+    const report = buildStoryQualityHeuristicReport({ storyContent, configuration });
+    const found = report.dimensions.find(entry => entry.id === 'audio_readiness');
+    assert(found, 'report should include the audio_readiness dimension');
+    return found;
+  };
+
+  const penalised = audioReadiness(`<p>${longParagraph}</p><p>She ran.</p>`);
+  const clean = audioReadiness('<p>She opened the door.</p><p>She ran.</p>');
+
+  assert(
+    penalised.score < clean.score,
+    `an overlong paragraph should cost the dimension points (penalised=${penalised.score}, clean=${clean.score})`
+  );
+  assert(
+    penalised.signals.some(signal => signal.startsWith('Overlong paragraphs (over 90 words): 1, longest 120 words')),
+    `the penalty should name what caused it (signals=${JSON.stringify(penalised.signals)})`
+  );
+  assert(
+    !penalised.signals.includes('No overlong paragraphs detected.'),
+    'a penalised story should not also claim it has no overlong paragraphs'
+  );
+  assert(
+    clean.signals.includes('No overlong paragraphs detected.'),
+    `a clean story should still report the check passing (signals=${JSON.stringify(clean.signals)})`
+  );
+}
+
+/**
  * The two identity-shaped dimensions have to be able to say "no".
  *
  * Both used to answer yes to everything. `\b[A-Z][a-z]+\b` matches the first
@@ -328,6 +375,7 @@ function testBoundaryRulesRejectOnlyTheBoundary(): void {
 
 async function main(): Promise<void> {
   testHtmlStoriesAreScoredOnTheirProse();
+  testOverlongParagraphsAreReportedNotJustPenalised();
   testAnonymousProseScoresAsAnonymous();
   testNamedProseStillScores();
   testDialogueSpeakersCountAsCast();


### PR DESCRIPTION
Three small, independent defects, each with a regression test that fails without its fix.

---

## 1. The Story Lab job event stream was rate-limited as if it were the genesis stream

`/api/story-lab/jobs/:jobId/events` replays the events a job has recorded so far and then **ends the response** — every time, for a job that is still running. That is the design, and both sides document it: `shared/eventStreamRetry.ts` exists precisely to tell the Angular reader that the resulting `error` is a reconnect rather than a failure, and `StoryService.streamStoryLabJobEvents` keeps the subscription alive through it. So a browser `EventSource` reopens the connection roughly every three seconds for as long as the generation runs.

Wiring access control into the route (#244) gave it `RATE_LIMITS.STREAMING` — **five requests per fifteen minutes**. That tier is sized for `/api/story-lab/stream/genesis`, the opposite kind of stream: one connection held open for a whole paid generation, which the reader deliberately never reopens because reconnecting there re-runs the generation from the beginning.

One reader watching one job therefore spent the entire budget about fifteen seconds in. Every reconnect after that was answered `429`, so the job kept running on the server while the page reported *"Story generation updates stopped"* — and could not get them back for fifteen minutes. The route spends nothing: it reads the job store and replays recorded snapshots.

Adds `RATE_LIMITS.STORY_LAB_JOB_EVENTS`, sized for the polling the route's own design causes (fifteen minutes of uninterrupted three-second reconnects is three hundred requests), and leaves `STREAMING` to the single-connection genesis stream it was written for.

Verified against the old constant — the new test fails at `reconnect 6 of 20 should still be served, got 429`.

## 2. The audio-readiness dimension penalised overlong paragraphs without saying so

`scoreAudioReadiness` swings a story's score by **thirty points** on one check — `+12` when no paragraph runs past ninety words, `-18` when one does — and printed a signal only for the passing case. A penalised story came back with a rationale claiming to check paragraph length and a signal list that was entirely about dialogue, so the reader was handed a lower number with nothing explaining it and nothing to act on.

Every other dimension already reports what moved it: `scoreTropeFreshness` prints the stale phrases that cost it points. This now prints how many paragraphs are too long and how long the worst one runs, and the threshold is named (`AUDIO_READINESS_MAX_PARAGRAPH_WORDS`) rather than inlined.

## 3. Cliffhanger analysis suggested continuations for a hook it had not found

`CliffhangerAnalysis.cliffhangerType` is a closed set with no "none" member, so a chapter with no cliffhanger still has to be labelled *something* — it falls to `plot_twist`. Every other field on the analysis knows that label is a placeholder and reports nothing: `cliffhangerStrength` floors at `0`, `cliffhangerText` is empty.

The two fields a caller actually acts on did not:

- `suggestedContinuations` handed back three instructions written for a twist — *"Reveal the first consequence of the twist"* — for a chapter the same scan had just said ends on no hook at all.
- `varietyScore` was worse: it asked whether the **placeholder** appeared in `previousCliffhangers`, so a chapter with no cliffhanger scored 3 out of 8 for repetition whenever the chapter before it genuinely was a `plot_twist` — a sameness penalty for a hook that does not exist.

The whole analysis travels back to the caller as `cliffhangerAnalysis` on the continuation response, so both were public answers about something the service had not detected. An undetected cliffhanger now suggests nothing and cannot repeat anything.

The detected side is unchanged, including the tested decision that a chapter ending on `!` falls through to the default type rather than being reclassified by the question fallback — that case is a *detected* cliffhanger and still carries its suggestions and its variety penalty.

---

## Testing

`npm run test:all` passes in full. New coverage:

- `tests/story-lab-job-routes.test.ts` — twenty consecutive job-event reconnects without resetting the limit between them (which is what every other scenario in that file does).
- `tests/story-quality-evals.test.ts` — an overlong paragraph costs points *and* names what caused it; a clean story still reports the check passing.
- `tests/cliffhanger-service.test.ts` — an undetected cliffhanger suggests nothing and scores full variety even when a matching previous type is supplied; a detected one still carries suggestions and still loses variety on repetition.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyrHVFbwbmmfLoS4V1H6yz)_

## Summary by Sourcery

Fix Story Lab streaming limits and make story-quality and cliffhanger analysis accurately explain only the issues they detect.

Bug Fixes:
- Prevent Story Lab job event reconnects from being blocked by the single-connection streaming rate limit.
- Explain audio-readiness penalties for overlong paragraphs in quality reports.
- Suppress continuation suggestions and repetition penalties when no cliffhanger is detected.

Tests:
- Add regression coverage for repeated job-event reconnects, audio-readiness penalty signals, and detected versus undetected cliffhanger behavior.