### PR TITLE
Three quick wins: a continuity id that merges two characters into one, a scene the image model never sees the end of, a genesis payload guard weaker than its twin

### DIFF
--- a/api/_lib/services/imageService.ts
+++ b/api/_lib/services/imageService.ts
@@ -67,6 +67,91 @@ export function readGeneratedImageUrl(responseData: unknown): string {
   return url.trim();
 }
 
+/**
+ * The longest scene description handed to the image model, in code points.
+ *
+ * Unchanged from the `substring(0, 200)` it replaces — the cap is not what was
+ * wrong with it.
+ */
+export const IMAGE_SCENE_DESCRIPTION_MAX_LENGTH = 200;
+
+/**
+ * One sentence: a run of text up to and including whatever ends it, or the
+ * trailing run a story that stops mid-sentence leaves behind.
+ *
+ * Both branches are linear — the engine can only take `[^.!?]` for the run and
+ * `[.!?]` for the terminator, so there is nothing to backtrack over on a long
+ * paragraph that ends without punctuation.
+ */
+const SCENE_SENTENCE_PATTERN = /[^.!?]+[.!?]+|[^.!?]+$/g;
+
+/** How many opening sentences describe the scene, as it always was. */
+const SCENE_SENTENCE_COUNT = 3;
+
+/**
+ * Describe the opening of a story for the image model.
+ *
+ * The story arrives as the generator's HTML. Deleting the tags on their own
+ * welds the words they separated — `door.</p><p>Blood` becomes `door.Blood` —
+ * and leaves `&amp;` and `&quot;` sitting in the prose as literal entity text,
+ * so the scene handed to the image model is neither what a reader sees nor
+ * valid English. `stripStoryHtmlToText` puts a paragraph break where the markup
+ * put one and decodes the entities the generator writes, which is the same
+ * rendering the cliffhanger and continuity scanners read.
+ *
+ * What was left after that was the sentence reading itself, and it got both
+ * halves wrong:
+ *
+ * - **`split('.')` is not a sentence split.** `?` and `!` end a sentence too,
+ *   and this app writes dialogue-heavy openings — the sibling story-quality scan
+ *   splits on `/[.!?]+/` for exactly that reason. A chapter that opens on three
+ *   questions has no period anywhere near its start, so "the first three
+ *   sentences" was the whole chapter, and the only thing that stopped it was the
+ *   200-character cut below. Rejoining with `'.'` then made it worse: the
+ *   terminator each piece actually ended on was replaced by a period, so
+ *   `"Where is she?"` reached the model as `"Where is she."`, and the final
+ *   sentence lost its punctuation entirely.
+ * - **`substring(0, 200)` counts UTF-16 code units.** A cut between the halves
+ *   of a surrogate pair leaves a lone surrogate — the failure `chunkByCodePoint`
+ *   in the export service and `capUtf8Bytes` in the download filename both
+ *   iterate code points to avoid — and a cut anywhere else lands mid-word, so
+ *   the prompt ended on a fragment. Capping at a code-point boundary and then
+ *   backing up to the last space keeps whole characters and whole words.
+ *
+ * Exported so the text actually sent to the provider can be asserted on
+ * directly, the way `readGeneratedImageUrl` above is; reaching it through
+ * `generateImage` needs a configured provider and would prove nothing about the
+ * prompt either way.
+ */
+export function buildSceneDescriptionFromStory(content: string): string {
+  const sentences = stripStoryHtmlToText(content).match(SCENE_SENTENCE_PATTERN) ?? [];
+  const opening = sentences.slice(0, SCENE_SENTENCE_COUNT).join('').trim();
+
+  return capAtWordBoundary(opening, IMAGE_SCENE_DESCRIPTION_MAX_LENGTH);
+}
+
+/**
+ * Cut to at most `maxCodePoints` whole characters, then back up to the last
+ * whitespace so the description does not end mid-word. A first word longer than
+ * the whole cap has no whitespace to back up to and is kept as it is, which is
+ * still a whole-character cut.
+ */
+function capAtWordBoundary(value: string, maxCodePoints: number): string {
+  const characters = Array.from(value);
+  if (characters.length <= maxCodePoints) {
+    return value;
+  }
+
+  const capped = characters.slice(0, maxCodePoints).join('');
+  for (let index = capped.length - 1; index >= 0; index -= 1) {
+    if (/\s/.test(capped[index])) {
+      return capped.slice(0, index).trimEnd();
+    }
+  }
+
+  return capped;
+}
+
 export class ImageService {
   private grokApiKey: string | undefined;
   private grokApiUrl: string;
@@ -191,23 +276,9 @@ export class ImageService {
     return `${basePrompt}. ${creatureContext}. Visual elements: ${themeElements}. ${styleModifier}. High quality, detailed, atmospheric lighting.`;
   }
 
-  /**
-   * Describe the opening of a story for the image model.
-   *
-   * The story arrives as the generator's HTML. Deleting the tags on their own
-   * welds the words they separated — `door.</p><p>Blood` becomes `door.Blood`
-   * — and leaves `&amp;` and `&quot;` sitting in the prose as literal entity
-   * text, so the scene handed to the image model is neither what a reader sees
-   * nor valid English. `stripStoryHtmlToText` puts a paragraph break where the
-   * markup put one and decodes the entities the generator emits, which is the
-   * same rendering the cliffhanger and continuity scanners read.
-   */
+  /** See `buildSceneDescriptionFromStory` for how the opening is read. */
   private extractSceneFromStory(content: string, creature: string): string {
-    const cleanContent = stripStoryHtmlToText(content);
-    const sentences = cleanContent.split('.').slice(0, 3); // First few sentences
-    const sceneDescription = sentences.join('.').substring(0, 200);
-
-    return `A scene featuring a ${creature}: ${sceneDescription}`;
+    return `A scene featuring a ${creature}: ${buildSceneDescriptionFromStory(content)}`;
   }
 
   /**

--- a/api/_lib/story-lab/continuityExtractor.ts
+++ b/api/_lib/story-lab/continuityExtractor.ts
@@ -346,18 +346,48 @@ function isNonEmptyString(value: unknown): value is string {
  * to slug, so its id falls back to a digest of the name — unreadable, but
  * distinct, which is the property the merge actually depends on. The cap is
  * applied over code points so it cannot cut an astral character in half.
+ *
+ * Letters and numbers are not the whole of a word, though.
+ * `shared/storyDownloadFilename.ts` cites this function as the reading it was
+ * modelled on and then names two things it has to do differently, and both of
+ * them are things this one was getting wrong:
+ *
+ * - **A combining mark is not a letter**, so every mark was read as a separator
+ *   and the word it belongs to was cut apart at each one. `मेरी कहानी` slugged to
+ *   `म-र-कह-न` and `เรื่องของฉัน` to `เร-องของฉ-น` — the vowels and tone marks
+ *   deleted, hyphens left where they had been. That is the same collapse the
+ *   ASCII-only pattern caused, one step in: not every such name becomes the bare
+ *   prefix, but names that differ only in their marks now share an id, and the
+ *   merge keeps one entry for both.
+ * - **The same name has two spellings.** `é` and `e` + U+0301 are different
+ *   strings, so a model that wrote `José` decomposed in one batch and
+ *   precomposed in the next produced two ids for one character — and the merge,
+ *   which exists to fold a re-mentioned character back into the entry it already
+ *   has, instead carried two half-populated copies of them into the prompt the
+ *   next continuation is built from. Normalizing is what makes the two spellings
+ *   one key; the digest fallback is normalized for the same reason.
+ *
+ * Retaining marks is right for a mark attached to a letter and wrong for one
+ * left on its own — an emoji's variation selector is a nonspacing mark, so `❤️`
+ * split into a part holding nothing but the selector. So a part counts only if
+ * it has a letter or number in it, and the finished slug is checked the same way
+ * because the cap can leave a tail of only the leading marks of a part it cut
+ * into. A name with nothing else in it still reaches the digest.
  */
 function slugId(prefix: string, value: unknown): string | undefined {
   if (!isNonEmptyString(value)) {
     return undefined;
   }
 
-  const name = value.trim();
+  const name = value.normalize('NFC').trim();
   // Splitting on the unsupported runs and joining the parts back collapses each
   // run and drops the leading and trailing ones in a single linear pass, the way
   // the export filename stem is built. Trimming them with `/^-+|-+$/` instead is
   // quadratic on a long run of separators.
-  const parts = name.toLowerCase().split(SLUG_SEPARATOR_PATTERN).filter(Boolean);
+  const parts = name
+    .toLowerCase()
+    .split(SLUG_SEPARATOR_PATTERN)
+    .filter(part => SLUG_PART_HAS_WORD_CHARACTER.test(part));
   // The cap counts code points, so an astral character is kept whole or dropped
   // whole, and it can strand at most the one separator the join left behind.
   const slug = Array.from(parts.join('-'))
@@ -365,11 +395,12 @@ function slugId(prefix: string, value: unknown): string | undefined {
     .join('')
     .replace(/-$/, '');
 
-  return `${prefix}-${slug || digestName(name)}`;
+  return `${prefix}-${SLUG_PART_HAS_WORD_CHARACTER.test(slug) ? slug : digestName(name)}`;
 }
 
 const SLUG_ID_MAX_LENGTH = 48;
-const SLUG_SEPARATOR_PATTERN = /[^\p{L}\p{N}]+/u;
+const SLUG_SEPARATOR_PATTERN = /[^\p{L}\p{N}\p{M}]+/u;
+const SLUG_PART_HAS_WORD_CHARACTER = /[\p{L}\p{N}]/u;
 
 function digestName(name: string): string {
   return createHash('sha256').update(name, 'utf8').digest('hex').slice(0, 12);

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -1184,6 +1184,38 @@ describe('App', () => {
     expect(component.workspaceSaveStatus()).toBe('Saved in this browser.');
   });
 
+  // The continuation twin of this has been asserted since the guard was written
+  // — "keeps existing chapters when a completed continuation job has a malformed
+  // story payload" below. Genesis only asked whether `job.result` was present at
+  // all, so a result that is merely *there* reached `applyIteration`, which
+  // reads `summary.storyId` and `batch.chapters` straight through. The throw
+  // lands inside the job event stream's `next` callback, where nothing catches
+  // it: the batch stays in progress, the progress timer keeps running, and the
+  // reader is told nothing.
+  const malformedGenesisPayloads: Array<[string, StoryIterationPayload]> = [
+    ['no batch', { summary: createSummary(), state: createState() } as unknown as StoryIterationPayload],
+    ['no summary', {
+      state: createState(),
+      batch: { chapters: [createChapter()], totalWordCount: 900, suggestedNextPrompts: [] }
+    } as unknown as StoryIterationPayload]
+  ];
+
+  for (const [label, malformedPayload] of malformedGenesisPayloads) {
+    it(`fails the genesis batch when a completed job has a malformed story payload (${label})`, () => {
+      const events$ = new Subject<StoryLabJobEvent<StoryIterationPayload>>();
+      startGenesisJobFlow('A vampire princess bound by forbidden vows.', events$);
+
+      expect(() => events$.next(createJobEvent(createGenesisJobResponse(malformedPayload)))).not.toThrow();
+
+      expect(component.workbench().story).toBeNull();
+      expect(component.workbench().chapterHistory).toEqual([]);
+      expect(component.activeBatchQueue().at(-1)?.status).toBe('failed');
+      expect(component.statusMessage()).toContain('without a story payload');
+      expect(component.isGenerating()).toBeFalse();
+      expect(component.generationProgress().active).toBeFalse();
+    });
+  }
+
   it('updates genesis progress from Story Lab job snapshots', () => {
     const events$ = new Subject<StoryLabJobEvent<StoryIterationPayload>>();
     startGenesisJobFlow(

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -1881,7 +1881,16 @@ ${chapters}
     this.updateJobStatusFromJob(job, durabilityWarning);
 
     if (job.status === 'completed') {
-      if (!job.result) {
+      // The same guard the continuation twin below uses, rather than a bare
+      // `!job.result`. `applyIteration` reads `payload.batch.chapters` and
+      // `payload.summary.storyId` straight through, so a completed job carrying
+      // a result that is merely *present* — a stored job row from an older
+      // payload shape, a durable store that answered a partial record — threw a
+      // `TypeError` inside the job event stream's `next` callback. That is not a
+      // path with a handler on it: the batch stays "in progress" forever, the
+      // progress timer keeps running, and the reader is told nothing at all,
+      // where the continuation path answers the message below.
+      if (!this.hasRenderableIterationPayload(job.result)) {
         this.failGenesisJob(batchId, 'Story generation finished without a story payload. Please try again.');
         return true;
       }
@@ -2026,8 +2035,18 @@ ${chapters}
     this.stopProgress();
   }
 
+  /**
+   * Whether a finished job's result is a payload `applyIteration` can read.
+   *
+   * The check is the set of fields that method dereferences, not a spot check of
+   * one of them. `batch.chapters` was already here; `summary.storyId` was not,
+   * and it is read first — `applyIteration` compares it against the current
+   * story before it touches the chapter list, so a result with a chapter array
+   * and no summary got past this guard and threw one line further in.
+   */
   private hasRenderableIterationPayload(payload: StoryIterationPayload | undefined): payload is StoryIterationPayload {
-    return Array.isArray(payload?.batch?.chapters);
+    return Array.isArray(payload?.batch?.chapters)
+      && typeof payload?.summary?.storyId === 'string';
   }
 
   private failContinuationJob(batchId: string, message: string) {

--- a/tests/image-service.test.ts
+++ b/tests/image-service.test.ts
@@ -2,7 +2,12 @@
 // Created: 2026-08-24 23:40 UTC
 
 import axios from 'axios';
-import { ImageService, readGeneratedImageUrl } from '../api/_lib/services/imageService';
+import {
+  IMAGE_SCENE_DESCRIPTION_MAX_LENGTH,
+  ImageService,
+  buildSceneDescriptionFromStory,
+  readGeneratedImageUrl
+} from '../api/_lib/services/imageService';
 import { CreatureType, ImageGenerationSeam } from '../api/_lib/types/contracts';
 import { STORY_LAB_THEME_SEED_IDS } from '../shared/storyLabThemeSeeds';
 
@@ -50,6 +55,77 @@ async function testSceneDescriptionReadsAsProse(): Promise<void> {
   // before failing for want of a `>`, which is quadratic in the run's length.
   // Excluding `<` decides each position once, and `<p>` still matches.
   assert(!/<[^<>]*>/.test(prompt), `no markup should reach the image model (got: ${prompt})`);
+}
+
+// `split('.')` is not a sentence split: `?` and `!` end a sentence too, and
+// this app writes dialogue-heavy openings. A chapter that opens on questions had
+// no period anywhere near its start, so "the first three sentences" was the
+// whole chapter — and rejoining the pieces with `'.'` replaced whatever
+// terminator each one actually ended on, so a question reached the image model
+// as a statement.
+function testTheOpeningSentencesAreReadAsSentences(): void {
+  const questions = '<p>Where is she? Who took her? Why now? '
+    + 'The hunter counted his knives and did not answer any of it.</p>';
+  const description = buildSceneDescriptionFromStory(questions);
+
+  assert(
+    description === 'Where is she? Who took her? Why now?',
+    `three questions are three sentences, terminators and all (got: ${JSON.stringify(description)})`
+  );
+  assert(
+    !description.includes('counted his knives'),
+    `the fourth sentence should not be in the scene (got: ${JSON.stringify(description)})`
+  );
+}
+
+// A story that stops mid-sentence still has a scene in it, and a story shorter
+// than three sentences is not padded or truncated.
+function testShortAndUnterminatedStoriesSurviveWhole(): void {
+  const unterminated = '<p>She opened the door and the cold came in</p>';
+  assert(
+    buildSceneDescriptionFromStory(unterminated) === 'She opened the door and the cold came in',
+    `a trailing unterminated sentence should still be read (got: ${JSON.stringify(buildSceneDescriptionFromStory(unterminated))})`
+  );
+
+  // The paragraph break between them is the one `stripStoryHtmlToText` put
+  // where the markup had a `</p><p>`, and it stays: welding those two words
+  // together is what that helper exists to prevent.
+  const twoSentences = '<p>He shut the door.</p><p>Blood pooled at her feet.</p>';
+  assert(
+    buildSceneDescriptionFromStory(twoSentences) === 'He shut the door.\n\nBlood pooled at her feet.',
+    `two sentences should come back as two (got: ${JSON.stringify(buildSceneDescriptionFromStory(twoSentences))})`
+  );
+}
+
+// `substring(0, 200)` counts UTF-16 code units, so a cut between the halves of a
+// surrogate pair left a lone surrogate in the text sent to the provider, and a
+// cut anywhere else landed mid-word.
+function testTheCapKeepsWholeCharactersAndWholeWords(): void {
+  const longSentence = `<p>${'astral '.repeat(40)}end.</p>`;
+  const description = buildSceneDescriptionFromStory(longSentence);
+
+  assert(
+    Array.from(description).length <= IMAGE_SCENE_DESCRIPTION_MAX_LENGTH,
+    `the description should respect the cap (got ${Array.from(description).length} code points)`
+  );
+  assert(
+    description.endsWith('astral'),
+    `the cap should land on a word boundary (got: ${JSON.stringify(description.slice(-20))})`
+  );
+
+  // One astral character per code point, so a UTF-16 cut at the cap falls
+  // between the halves of a surrogate pair.
+  const astral = `<p>${'𝔞'.repeat(300)}</p>`;
+  const astralDescription = buildSceneDescriptionFromStory(astral);
+
+  assert(
+    !/[\uD800-\uDFFF]/.test(astralDescription.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, '')),
+    'the cap should never strand half of a surrogate pair'
+  );
+  assert(
+    Array.from(astralDescription).length === IMAGE_SCENE_DESCRIPTION_MAX_LENGTH,
+    `an unbroken astral run should be cut at the cap in whole characters (got ${Array.from(astralDescription).length})`
+  );
 }
 
 // A malformed `themes` reached `input.themes.map(...)` and threw, and the
@@ -301,6 +377,9 @@ async function main(): Promise<void> {
   await testEveryCreatureArchetypeReachesThePrompt();
   await testEveryThemeTheAppOffersReachesThePrompt();
   await testSceneDescriptionReadsAsProse();
+  testTheOpeningSentencesAreReadAsSentences();
+  testShortAndUnterminatedStoriesSurviveWhole();
+  testTheCapKeepsWholeCharactersAndWholeWords();
   await testMalformedThemesAreRejectedAsCallerError();
   await testAspectRatioNeverContradictsTheDimensions();
   testProviderResponsesWithoutAUrlAreRefused();

--- a/tests/story-lab-continuity-merge.test.ts
+++ b/tests/story-lab-continuity-merge.test.ts
@@ -117,6 +117,86 @@ function testAsciiNamesKeepTheirExistingIds(): void {
   );
 }
 
+/**
+ * A combining mark belongs to the word it is attached to, not between words.
+ *
+ * Reading marks as separators cut a Devanagari or Thai name apart at every
+ * vowel sign, which is the same collapse the ASCII-only pattern caused one step
+ * in: `मीरा` and `मिरा` differ only in their vowel sign, so both slugged to the
+ * same `म-र` and the merge kept one character for two.
+ */
+function testCombiningMarksStayInsideTheirWord(): void {
+  const state = mergeNames({
+    characters: [{ displayName: 'मीरा' }, { displayName: 'मिरा' }],
+    threads: [{ label: 'เรื่องของฉัน' }]
+  });
+
+  assert(
+    new Set(state.characters.map(character => character.id)).size === 2,
+    `two names differing only in a vowel sign should keep two ids (got ${JSON.stringify(state.characters.map(character => character.id))})`
+  );
+  assert(
+    state.characters.some(character => character.id === 'character-मीरा'),
+    `a Devanagari name should keep its marks in its id (got ${JSON.stringify(state.characters.map(character => character.id))})`
+  );
+  assert(
+    state.threads[0]?.id === 'thread-เรื่องของฉัน',
+    `a Thai label should keep its tone marks in its id (got ${state.threads[0]?.id})`
+  );
+}
+
+/**
+ * The merge exists to fold a re-mentioned name back into the entry it already
+ * has, and `é` written as one code point and as `e` plus a combining acute are
+ * different strings. Without normalizing, one character mentioned across two
+ * batches became two half-populated entries in the state the next continuation
+ * prompt is built from.
+ */
+function testEquivalentSpellingsOfOneNameMerge(): void {
+  // Written as escapes so the two spellings survive any editor or tool that
+  // normalizes this file: they have to be different strings for the test to be
+  // testing anything.
+  const precomposed = 'Jos\u00E9';
+  const decomposed = 'Jose\u0301';
+  assert(precomposed !== decomposed, 'the two spellings must be different strings');
+
+  const state = mergeNames({
+    characters: [
+      { displayName: precomposed, summary: 'Precomposed mention.' },
+      { displayName: decomposed, currentGoal: 'Decomposed mention.' }
+    ]
+  });
+
+  assert(
+    state.characters.length === 1,
+    `both spellings of one name should merge (got ${JSON.stringify(state.characters.map(character => character.id))})`
+  );
+  assert(
+    state.characters[0]?.id === 'character-josé',
+    `the merged id should be the normalized spelling (got ${state.characters[0]?.id})`
+  );
+}
+
+/**
+ * A mark left on its own is not a word. An emoji carries a variation selector,
+ * which is a nonspacing mark, so retaining marks must not turn `❤️` into a slug
+ * of one invisible character that every other emoji name also collides with.
+ */
+function testMarkOnlyNamesStillReachTheDigest(): void {
+  const state = mergeNames({
+    characters: [{ displayName: '❤️' }, { displayName: '🌙' }]
+  });
+
+  assert(
+    new Set(state.characters.map(character => character.id)).size === 2,
+    `emoji-only names should not merge into one character (got ${JSON.stringify(state.characters.map(character => character.id))})`
+  );
+  assert(
+    state.characters.every(character => /^character-[0-9a-f]{12}$/.test(character.id)),
+    `an emoji-only name should fall back to a digest id (got ${JSON.stringify(state.characters.map(character => character.id))})`
+  );
+}
+
 /** A model-supplied id still wins, and the same name merges onto itself. */
 function testExplicitIdsAndRepeatedNamesStillMerge(): void {
   const state = mergeNames({
@@ -142,6 +222,9 @@ function main(): void {
   testThreadsAndArtifactsStayDistinct();
   testNamesWithNoSluggableCharactersStayDistinct();
   testAsciiNamesKeepTheirExistingIds();
+  testCombiningMarksStayInsideTheirWord();
+  testEquivalentSpellingsOfOneNameMerge();
+  testMarkOnlyNamesStillReachTheDigest();
   testExplicitIdsAndRepeatedNamesStillMerge();
 
   console.log('Story Lab continuity merge tests passed');


### PR DESCRIPTION
Three small, independent fixes, each with a test that fails on `main`.

---

### 1. A continuity id that cannot tell two names apart — and splits one name in two

`slugId` in `api/_lib/story-lab/continuityExtractor.ts` is the key `mergeCharacters`, `mergeThreads`, and `mergeArtifacts` deduplicate on. It kept only Unicode letters and numbers, and a combining mark is neither:

- **Marks were read as separators**, so the word they belong to was cut apart at each one. `मीरा` and `मिरा` differ only in their vowel sign and both slugged to `म-र`, so the merge kept *one* character for two. Verified against `main`:

  ```
  Error: two names differing only in a vowel sign should keep two ids (got ["character-म-र"])
  ```

  This is the same collapse the ASCII-only pattern used to cause, one step in — and `shared/storyDownloadFilename.ts` already documents both halves of it while citing this very function as the reading it was modelled on.

- **Nothing normalized the name.** `é` and `e` + U+0301 are different strings, so a model that wrote `José` precomposed in one batch and decomposed in the next produced two ids for one character. The merge exists to fold a re-mentioned character back into the entry it already has; instead the state the next continuation prompt is built from carried two half-populated copies.

Marks are now retained, the name is NFC-normalized (the digest fallback too), and a part with no letter or number in it is dropped — so `❤️`, whose variation selector *is* a nonspacing mark, still reaches the digest rather than becoming an invisible slug every other emoji name collides with. ASCII names slug exactly as before.

### 2. A scene description the image model never sees the end of

`extractSceneFromStory` in `api/_lib/services/imageService.ts` read "the first three sentences" as `split('.')`:

- `?` and `!` end a sentence too, and this app writes dialogue-heavy openings. A chapter opening on three questions has no period anywhere near its start, so "the first three sentences" was the **whole chapter** — the only thing stopping it was the 200-character cut. Measured on `main`:

  ```
  OLD questions: "Where is she? Who took her? Why now? The hunter counted his knives and did not answer any of it."
  ```

- Rejoining the pieces with `'.'` replaced whatever terminator each one actually ended on, so `"Where is she?"` reached the model as a statement, and the last sentence lost its punctuation entirely.

- `substring(0, 200)` counts UTF-16 code units, so the cut landed mid-word (`"l astral astral astr"`) and, on a story written in an astral script, between the halves of a surrogate pair — a lone `\ud835` in the text sent to the provider.

The reading is now a real sentence split that keeps each terminator, and the cap falls on a whole character and then backs up to a word boundary. The 200 cap itself is unchanged. `buildSceneDescriptionFromStory` is exported so the text actually sent to the provider can be asserted on directly, the way `readGeneratedImageUrl` beside it already is.

### 3. A completed genesis job guarded more weakly than its continuation twin

`handleGenesisJobSnapshot` in `story-generator/src/app/app.ts` asked only whether `job.result` was present, then handed it to `applyIteration`, which reads `summary.storyId` and `batch.chapters` straight through. A result that is merely *there* — a stored job row from an older payload shape, a durable store that answered a partial record — threw a `TypeError` inside the job event stream's `next` callback, where nothing catches it: the batch stays "in progress", the progress timer keeps running, and the reader is told nothing.

The continuation path has answered a message for exactly this since its guard was written (`keeps existing chapters when a completed continuation job has a malformed story payload`). Both now use that guard, and it covers `summary.storyId` as well — the field `applyIteration` dereferences first, which a chapter-array-only check let past.

---

## Testing

- `npm test` — full root suite, exit 0 (53 lines matching /error|fail/ are the deliberate provider-failure fixtures existing tests print).
- `npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox` — **192 SUCCESS**, including the two new genesis cases.
- `scripts/recovery/preflight.sh --skip-status` — exit 0 (the `proving-grounds.css` budget warning is pre-existing on `main`).

Each fix was reverted in turn to confirm its test fails without it:

- continuity ids → `two names differing only in a vowel sign should keep two ids (got ["character-म-र"])`
- genesis guard → `App fails the genesis batch when a completed job has a malformed story payload (no batch) FAILED`
- scene description → old behaviour reproduced directly (whole chapter returned; lone high surrogate at the cut)

New coverage: 3 cases in `tests/story-lab-continuity-merge.test.ts`, 3 in `tests/image-service.test.ts`, 2 in `story-generator/src/app/app.spec.ts`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbGGt5YHLHnAfzPDtM6doo)_

## Summary by Sourcery

Fix Unicode continuity merging, image scene extraction, and malformed genesis job handling.

Bug Fixes:
- Preserve combining marks and normalize Unicode names so continuity entities with equivalent or visually distinct spellings receive stable, distinct merge identifiers.
- Build image scene descriptions from the first three properly terminated sentences while preserving punctuation and avoiding mid-character or mid-word truncation.
- Reject malformed completed genesis job payloads before processing so generation batches fail cleanly instead of remaining indefinitely in progress.

Enhancements:
- Export the scene-description builder for direct validation of the prompt text sent to image providers.

Tests:
- Add coverage for Unicode continuity identifiers, sentence extraction and length limits, and malformed genesis payload handling.