### PR TITLE
***WORST TO BEST*** Error Logging & Display: fully-built panel and service, wired into nothing, now caught, shown, and lazy-loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🔌 Error Logging & Display: a built and tested panel that was never plugged in (August 26, 2026)
+
+- `ErrorDisplayComponent` (component, template, CSS, 4 passing unit tests) subscribed
+  to the real, actively-used `ErrorLoggingService` but was never mounted anywhere in
+  the app — not in `app.html`, not routed, not referenced outside its own directory.
+  100% dead code from a user's perspective.
+- There was also no Angular `ErrorHandler` override, so an uncaught exception never
+  reached `ErrorLoggingService` in the first place — the wire was missing on both
+  ends of the pipe.
+- Added `GlobalErrorHandler` (`src/app/global-error-handler.ts`), which forwards
+  uncaught errors to `ErrorLoggingService.logCritical` and still delegates to
+  Angular's default `ErrorHandler` so existing console output doesn't regress.
+  Provided via `{ provide: ErrorHandler, useClass: GlobalErrorHandler }` in
+  `app.config.ts`.
+- Mounted `<app-error-display>` next to the existing `<app-debug-panel>`, gated by
+  the same `?debug=1` signal — matching the panel's own self-description
+  (":bug: Debug Errors") and the existing convention for debug-only surfaces,
+  rather than shipping it to every reader.
+- Wrapped both debug-only panels in an `@defer (when showDebugPanel())` block so
+  neither component's code ships in the initial bundle for the vast majority of
+  readers who never pass `?debug=1` — a bonus fix over just wiring the panel in,
+  since mounting it eagerly pushed the initial bundle over its 500kB budget.
+
 ### 🐛 Three Quick Wins — a preflight nobody may cache, an export that fails without saying so, a cut between the halves of a character (August 26, 2026)
 
 #### Every cross-origin request paid for its own preflight

--- a/story-generator/src/app/app.config.ts
+++ b/story-generator/src/app/app.config.ts
@@ -1,13 +1,15 @@
-import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
+import { ApplicationConfig, ErrorHandler, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
+import { GlobalErrorHandler } from './global-error-handler';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideHttpClient(),
-    provideRouter(routes)
+    provideRouter(routes),
+    { provide: ErrorHandler, useClass: GlobalErrorHandler }
   ]
 };

--- a/story-generator/src/app/app.html
+++ b/story-generator/src/app/app.html
@@ -880,4 +880,7 @@
   </main>
 </div>
 
-<app-debug-panel data-testid="story-lab-debug-panel" *ngIf="showDebugPanel()"></app-debug-panel>
+@defer (when showDebugPanel()) {
+  <app-debug-panel data-testid="story-lab-debug-panel"></app-debug-panel>
+  <app-error-display data-testid="story-lab-error-display"></app-error-display>
+}

--- a/story-generator/src/app/app.spec.ts
+++ b/story-generator/src/app/app.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, DeferBlockState, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ActivatedRoute, convertToParamMap, ParamMap } from '@angular/router';
 import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
@@ -350,8 +350,10 @@ describe('App', () => {
     ]);
     const errorLoggingSpy = jasmine.createSpyObj<ErrorLoggingService>('ErrorLoggingService', [
       'logInfo',
-      'logError'
+      'logError',
+      'getErrors'
     ]);
+    errorLoggingSpy.getErrors.and.returnValue(of([]));
 
     await TestBed.configureTestingModule({
       imports: [App, HttpClientTestingModule],
@@ -569,6 +571,19 @@ describe('App', () => {
   it('enables the debug panel with the debug query parameter', () => {
     queryParamMap$.next(convertToParamMap({ debug: '1' }));
     expect(component.showDebugPanel()).toBeTrue();
+  });
+
+  it('hides the error display panel unless debug mode is requested', () => {
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="story-lab-error-display"]')).toBeNull();
+  });
+
+  it('mounts the error display panel with the debug query parameter', async () => {
+    queryParamMap$.next(convertToParamMap({ debug: '1' }));
+    fixture.detectChanges();
+    const [deferBlock] = await fixture.getDeferBlocks();
+    await deferBlock.render(DeferBlockState.Complete);
+    expect(fixture.nativeElement.querySelector('[data-testid="story-lab-error-display"]')).not.toBeNull();
   });
 
   it('toggles theme selections', () => {

--- a/story-generator/src/app/app.ts
+++ b/story-generator/src/app/app.ts
@@ -48,6 +48,7 @@ import { StoryService } from './story.service';
 import { StoryWorkspaceStorageService } from './story-workspace-storage.service';
 import { ErrorLoggingService } from './error-logging';
 import { DebugPanel } from './debug-panel/debug-panel';
+import { ErrorDisplayComponent } from './error-display/error-display';
 import { NotificationService } from './notification.service';
 import { NotificationsComponent } from './notifications.component';
 
@@ -235,7 +236,7 @@ type ContinuationJobResult = StoryIterationPayload & { appendedChapterNumbers: n
 @Component({
   selector: 'app-story-lab',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink, NotificationsComponent, DebugPanel],
+  imports: [CommonModule, FormsModule, RouterLink, NotificationsComponent, DebugPanel, ErrorDisplayComponent],
   templateUrl: './app.html',
   styleUrls: ['./app.css', './app-reader-library.css']
 })

--- a/story-generator/src/app/global-error-handler.spec.ts
+++ b/story-generator/src/app/global-error-handler.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from '@angular/core/testing';
+import { ErrorHandler } from '@angular/core';
+import { GlobalErrorHandler } from './global-error-handler';
+import { ErrorLoggingService } from './error-logging';
+
+describe('GlobalErrorHandler', () => {
+  let handler: GlobalErrorHandler;
+  let errorLogging: ErrorLoggingService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [GlobalErrorHandler, ErrorLoggingService]
+    });
+
+    handler = TestBed.inject(GlobalErrorHandler);
+    errorLogging = TestBed.inject(ErrorLoggingService);
+  });
+
+  it('logs uncaught errors to the ErrorLoggingService as critical', () => {
+    spyOn(errorLogging, 'logCritical');
+    const error = new Error('uncaught boom');
+
+    handler.handleError(error);
+
+    expect(errorLogging.logCritical).toHaveBeenCalledWith(error, 'GlobalErrorHandler');
+  });
+
+  it('still delegates to the default ErrorHandler so console output does not regress', () => {
+    const defaultHandleError = spyOn(ErrorHandler.prototype, 'handleError');
+    const error = new Error('uncaught boom');
+
+    handler.handleError(error);
+
+    expect(defaultHandleError).toHaveBeenCalledWith(error);
+  });
+});

--- a/story-generator/src/app/global-error-handler.ts
+++ b/story-generator/src/app/global-error-handler.ts
@@ -1,0 +1,19 @@
+import { ErrorHandler, Injectable, inject } from '@angular/core';
+import { ErrorLoggingService } from './error-logging';
+
+/**
+ * Angular only calls `handleError` for errors that escape a zone task uncaught —
+ * a component or service that already caught an error and passed it to
+ * `ErrorLoggingService` manually never reaches this handler, so there is no
+ * double-logging path to guard against here.
+ */
+@Injectable()
+export class GlobalErrorHandler implements ErrorHandler {
+  private readonly errorLogging = inject(ErrorLoggingService);
+  private readonly defaultHandler = new ErrorHandler();
+
+  handleError(error: unknown): void {
+    this.errorLogging.logCritical(error, 'GlobalErrorHandler');
+    this.defaultHandler.handleError(error);
+  }
+}


### PR DESCRIPTION
_Feature:_ Error Logging & Display (`story-generator/src/app/error-display/*`, `story-generator/src/app/error-logging.ts`)

### Was worst because

1. `ErrorDisplayComponent` (75-line component + template + CSS) is fully built with 4 passing unit tests (`error-display.spec.ts`), and subscribes to a real, actively-used `ErrorLoggingService` (367 lines, ~33 call sites across `app.ts`/`story.service.ts`, sophisticated redaction of API keys/tokens/prompts/user text) — but it was never mounted anywhere. Confirmed via grep: outside its own directory, the only references were in its own spec file. Not in `app.html`, not in any other template, not routed. 100% dead code from a user's perspective.
2. There was no Angular `ErrorHandler` override. `app.config.ts` calls `provideBrowserGlobalErrorListeners()` (Angular's `window.onerror`/`unhandledrejection` hookup), but without a custom `ErrorHandler`, uncaught exceptions just hit the default handler (console only) instead of `ErrorLoggingService`. So even mounting the panel would only ever have shown the ~33 manually-logged call sites, not real uncaught crashes — the gap was on both ends of the pipe.
3. Same shape as prior "WORST TO BEST" runs (#223 Real-Time Streaming, #227 Image Generation): real infrastructure on both sides, never wired together.

### Plan (posted to #claude-routines at 12:33 EDT by a prior run of this routine; picked up and executed here after ~2 hours with no critique from @codex)

1. Add `GlobalErrorHandler implements ErrorHandler` (`src/app/global-error-handler.ts`) that forwards uncaught errors to `ErrorLoggingService.logCritical(error, 'GlobalErrorHandler')` and still delegates to Angular's default `ErrorHandler` so existing console output doesn't regress. Provided via `{ provide: ErrorHandler, useClass: GlobalErrorHandler }` in `app.config.ts`.
2. Mount `<app-error-display>` next to the existing `<app-debug-panel>`, gated by the same `?debug=1`-driven `showDebugPanel()` signal — matches the existing convention for debug-only surfaces and the panel's own self-description (":bug: Debug Errors"), rather than shipping it to all users.
3. Tests: new `global-error-handler.spec.ts` (verifies it logs to `ErrorLoggingService` and still delegates to the default handler); extended `app.spec.ts` to assert `app-error-display` is absent with no debug param and present with `?debug=1`; the 4 existing `error-display.spec.ts` tests are untouched and still pass.
4. `CHANGELOG.md` entry. (`AGENTS.md` doesn't currently document debug-only UI surfaces at all, so nothing to extend there — skipped rather than starting a new section out of scope.)
5. Full validation: Angular unit tests, `npm run build`, `build:verify`, Vercel function-count guard (frontend-only change, unaffected).

### Bonus fix found during execution — not in the original plan

Mounting `<app-error-display>` and `<app-debug-panel>` eagerly pushed the initial JS bundle from ~499.9kB to 504.46kB, tripping Angular's 500kB budget warning for the first time in this repo. Since both panels are debug-only (`?debug=1`), the fix is to defer them rather than grow the budget: wrapped both in `@defer (when showDebugPanel())`, which code-splits `debug-panel` and `error-display` into separate lazy chunks. Net result: the initial bundle for the vast majority of readers who never pass `?debug=1` is now **smaller** than before this PR (498.23kB), and `DebugPanel` — previously eagerly bundled despite being debug-only itself — gets the same treatment for free.

### Verification

- `ng test` (Angular unit suite): 197/197 passing, including the 2 new `app.spec.ts` assertions and the 2 new `global-error-handler.spec.ts` tests.
- `npm run build` + `build:verify`: green. Only pre-existing warning remains (`proving-grounds.css`, unrelated).
- `scripts/recovery/check-vercel-function-count.sh`: 9/12, unaffected (frontend-only change).

### Open question that was raised for critique, still worth a second look

Angular's `ErrorHandler.handleError` only fires for errors that escape a zone task uncaught — it shouldn't double-log errors a component already caught and manually passed to `errorLogging.logError`/`logCritical`. Went with relying on that uncaught-only semantics rather than adding a dedup safeguard, since no critique arrived to weigh in either way.

### Running list of the last 10 worst-to-best features (newest first)

1. **Error Logging & Display** — this PR
2. [#249](https://github.com/Phazzie/FairytaleswithSpice/pull/249) Story Lab Genesis & Continuation routes — hand-rolled preamble and near-zero logging on the two most-used paid routes, dead twins carrying the missing infra deleted
3. [#244](https://github.com/Phazzie/FairytaleswithSpice/pull/244) API Authentication & Rate-Limiting — fully-built middleware wired into zero routes, now guards every paid endpoint
4. [#236](https://github.com/Phazzie/FairytaleswithSpice/pull/236) Story Export/Download — dead backend wired up, fake zip/storage/metadata made real
5. [#233](https://github.com/Phazzie/FairytaleswithSpice/pull/233) Proving Grounds — broken test + silently-faked evaluation scores, fixed
6. [#227](https://github.com/Phazzie/FairytaleswithSpice/pull/227) Image Generation — fully-built backend nobody could reach, wired up
7. [#223](https://github.com/Phazzie/FairytaleswithSpice/pull/223) Real-Time Story Streaming — dead duplicate SSE route retired, the one live implementation wired up

_(Still-open candidate for next time, per #249's notes: the Story Lab async job recovery system — job creation always finishes synchronously, ~400 lines of frontend recovery/reconnect machinery gated on a status the backend never sends.)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gp4xm42NZXWkmcxfGK8uTo)_

## Summary by Sourcery

Wire the error logging pipeline into Angular and expose its display through the debug interface without increasing the normal initial bundle.

New Features:
- Capture uncaught Angular errors through a global handler and forward them to the existing error logging service.
- Expose the error display alongside the debug panel when debug mode is enabled.

Bug Fixes:
- Connect previously unused error logging and display infrastructure so uncaught errors can be recorded and viewed.

Enhancements:
- Lazy-load both debug panels to keep them out of the initial bundle for normal users.

Documentation:
- Document the error logging and debug-panel integration in the changelog.

Tests:
- Add coverage for global error logging, default-handler delegation, and debug-mode error-panel visibility.