### PR TITLE
***WORST TO BEST*** Backend Seam Contracts: 120 dead lines describing streaming/audio features that were never built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ***WORST TO BEST*** Backend Seam Contracts — 120 dead lines describing features that were never built (August 26, 2026)
+
+- `api/_lib/types/contracts.ts` is the canonical "seam contract" reference every
+  story/export/cliffhanger service imports from — the one file a reader goes to
+  in order to learn what the app's boundaries actually are. About a quarter of
+  its 534 lines described two seams nothing implements: `StreamingStoryGenerationSeam`,
+  a pre-SSE "real-time generation" contract superseded by the real streaming
+  route, and `AudioConversionSeam` (plus its supporting `VoiceType`,
+  `CharacterVoiceType`, `AudioSpeed`, `AudioFormat`, `AudioProgress` types), a
+  fully-specified audio-conversion contract with its own error codes even
+  though audio generation is explicitly deferred and out of scope. Neither had
+  a single import anywhere in the repo.
+- Removed both interfaces and their now-unused supporting types (534 → 403
+  lines). Pure deletion — verified with a repo-wide grep for every removed
+  symbol, `tsc --noEmit` over the API layer and the Angular app/specs, the full
+  `npm run test:all` backend suite, and the Angular test suite, all clean.
+  Recorded here so the removal reads as deliberate cleanup rather than an
+  accidental drop of a real seam.
+
 ### 🐛 Three Quick Wins — a words-per-second with no clock in it, an image prompt nothing measures, a continuation numbered NaN (August 26, 2026)
 
 #### A generation speed that was not a speed

--- a/api/_lib/types/contracts.ts
+++ b/api/_lib/types/contracts.ts
@@ -46,15 +46,6 @@ export interface StoryGenerationContext {
   heatContract?: HeatContractIntent;
   themeSeeds?: GenerationThemeSeed[];
 }
-export type VoiceType = 'female' | 'male' | 'neutral';
-export type CharacterVoiceType = 
-  | 'vampire_male' | 'vampire_female' 
-  | 'werewolf_male' | 'werewolf_female'
-  | 'fairy_male' | 'fairy_female'
-  | 'human_male' | 'human_female'
-  | 'narrator';
-export type AudioSpeed = 0.5 | 0.75 | 1.0 | 1.25 | 1.5;
-export type AudioFormat = 'mp3' | 'wav' | 'aac';
 export type ExportFormat = 'pdf' | 'txt' | 'html' | 'epub' | 'docx';
 
 /**
@@ -120,13 +111,6 @@ export interface ChapterFailure {
   chapterNumber: number;
   message: string;
   errorCode?: string;
-}
-
-export interface AudioProgress {
-  percentage: number; // 0-100
-  status: 'queued' | 'processing' | 'completed' | 'failed';
-  message: string;
-  estimatedTimeRemaining?: number; // in seconds
 }
 
 // ==================== SEAM 1: USER INPUT → STORY GENERATOR ====================
@@ -244,121 +228,6 @@ export interface ChapterContinuationSeam {
       message: string;
       maxChapters: number;
       currentChapters: number;
-    };
-  };
-}
-
-// ==================== SEAM 2.5: REAL-TIME STORY GENERATION ====================
-export interface StreamingStoryGenerationSeam {
-  seamName: "Real-Time Story Generation";
-  description: "Provides real-time updates during story generation for better UX";
-
-  input: {
-    // Same as StoryGenerationSeam input
-    creature: CreatureType;
-    themes: ThemeType[];
-    userInput: string;
-    spicyLevel: SpicyLevel;
-    wordCount: WordCount;
-    requestedChapterCount?: 1 | 2 | 3;
-  };
-
-  progressUpdate: {
-    streamId: string;
-    storyId?: string; // Generated after stream starts
-    type: 'connected' | 'progress' | 'chunk' | 'complete' | 'error';
-    content?: string; // Accumulated content so far
-    isComplete: boolean;
-    metadata: {
-      wordsGenerated: number;
-      totalWordsTarget: number;
-      estimatedWordsRemaining: number;
-      generationSpeed: number; // words per second
-      percentage: number; // 0-100
-      estimatedTimeRemaining?: number; // seconds
-    };
-  };
-
-  finalOutput: {
-    // Same as StoryGenerationSeam output
-    storyId: string;
-    title: string;
-    content: string;
-    rawContent?: string;
-    creature: CreatureType;
-    themes: ThemeType[];
-    spicyLevel: SpicyLevel;
-    actualWordCount: number;
-    estimatedReadTime: number;
-    hasCliffhanger: boolean;
-    generatedAt: Date;
-    tropeMetadata?: string;
-    chapters?: Chapter[];
-    totalWordCount?: number;
-    nextChapterHint?: string;
-    appendedToStory?: string;
-    failedChapters?: ChapterFailure[];
-  };
-
-  errors: {
-    STREAMING_CONNECTION_FAILED: {
-      code: "STREAMING_CONNECTION_FAILED";
-      message: string;
-      retryable: boolean;
-    };
-    STREAM_INTERRUPTED: {
-      code: "STREAM_INTERRUPTED";
-      message: string;
-      recoveryOptions: string[];
-      partialContent?: string;
-    };
-    // Inherits all errors from StoryGenerationSeam
-  };
-}
-
-// ==================== SEAM 3: STORY TEXT → AUDIO CONVERTER ====================
-export interface AudioConversionSeam {
-  seamName: "Story Text → Audio Converter";
-  description: "Converts story text to audio format with progress tracking";
-
-  input: {
-    storyId: string;
-    content: string; // Full story HTML content
-    voice?: VoiceType;
-    speed?: AudioSpeed;
-    format?: AudioFormat;
-  };
-
-  output: {
-    audioId: string;
-    storyId: string;
-    audioUrl: string; // Download URL for UI
-    duration: number; // in seconds
-    fileSize: number; // in bytes
-    format: AudioFormat;
-    voice: VoiceType;
-    speed: AudioSpeed;
-    progress: AudioProgress; // For real-time UI updates
-    completedAt: Date;
-  };
-
-  errors: {
-    CONVERSION_FAILED: {
-      code: "CONVERSION_FAILED";
-      message: string;
-      retryable: boolean;
-      stage: "text_processing" | "audio_generation" | "file_creation";
-    };
-    UNSUPPORTED_CONTENT: {
-      code: "UNSUPPORTED_CONTENT";
-      message: string;
-      unsupportedElements: string[];
-    };
-    AUDIO_QUOTA_EXCEEDED: {
-      code: "AUDIO_QUOTA_EXCEEDED";
-      message: string;
-      quotaRemaining: number;
-      resetTime: Date;
     };
   };
 }


### PR DESCRIPTION
## Why this was the worst-implemented feature

`api/_lib/types/contracts.ts` is the canonical "seam contract" file every story/export/cliffhanger service imports from — the one place a reader goes to learn what the app's boundaries actually are. Not touched by any of the last 8 worst-to-best PRs (all within the last ~2 days: streaming, image gen, proving grounds, export, auth, genesis/continuation routes, error logging, AppComponent), so it was a fresh pick.

About a quarter of its 534 lines were dead and actively misleading:

1. `StreamingStoryGenerationSeam` (~68 lines) — a pre-SSE "real-time generation" contract superseded by the real streaming route added in #223. Verified zero imports anywhere in the repo.
2. `AudioConversionSeam` (~45 lines) plus its supporting types `VoiceType`, `CharacterVoiceType`, `AudioSpeed`, `AudioFormat`, `AudioProgress` — a fully-specified "Story Text → Audio Converter" contract with its own error codes (`CONVERSION_FAILED`, `AUDIO_QUOTA_EXCEEDED`, etc.), even though audio is explicitly deferred/out of scope per `NOT_TAKEN_FEATURE_LEDGER.md`. Verified zero imports anywhere in the repo.

Net effect: anyone reading this file to understand what the app actually supports is told token-by-token streaming and audio conversion are defined, contracted features. Neither is true — a maintainability/code-quality problem sitting in the single most-imported types file in the backend.

## What changed

- Deleted `StreamingStoryGenerationSeam` and `AudioConversionSeam`, and their now-unused supporting types (`VoiceType`, `CharacterVoiceType`, `AudioSpeed`, `AudioFormat`, `AudioProgress`), including their section-header comments.
- `contracts.ts`: 534 → 403 lines.
- Added a CHANGELOG entry documenting the removal as deliberate cleanup of vestigial pre-Story-Lab/audio-deferred scaffolding, so it doesn't read as an accidental drop of a real seam later.

Pure deletion — no behavior or UX change.

## Verification

- Repo-wide grep for all 7 removed symbols, before and after deletion: zero references outside `contracts.ts` in either case.
- `tsc --noEmit` over the API layer (repo's own preflight invocation: `find api -name '*.ts' ... | xargs tsc --noEmit --target es2020 ...`) — clean.
- `tsc -p tsconfig.app.json --noEmit` and `tsc -p tsconfig.spec.json --noEmit` (Angular app + specs) — clean.
- `npm test` (full backend suite, 50+ scripts) — all passing.
- `ng test` (Angular/Karma, headless Chrome) — 207/207 passing.

## Plan (as posted to #claude-routines, tagged @codex — no critique received, proceeded as-is)

1. Delete `StreamingStoryGenerationSeam` and `AudioConversionSeam` (and the now-unused supporting types), including their section-header comments.
2. Re-grep after deletion to confirm nothing else referenced them (already confirmed zero references pre-deletion).
3. Run `tsc --noEmit`, `ng test`, and `npm run test:all` to prove the deletion is behaviorally invisible.
4. Add a CHANGELOG note documenting the removal as vestigial pre-Story-Lab/audio-deferred scaffolding.

Out of scope: the still-live `SaveExportSeam`/other seam contracts, and the job-recovery machinery in `app.ts` (already covered by #257, and already well-tested against the "job still running on reconnect" case).

## Running list: last worst-to-best features (most recent first)

| # | Feature | PR |
|---|---|---|
| 9 | Backend Seam Contracts (dead streaming/audio contract types) | this PR |
| 8 | AppComponent (god component, job-handling duplication, layering violation) | [#257](https://github.com/Phazzie/FairytaleswithSpice/pull/257) |
| 7 | Error Logging & Display | [#254](https://github.com/Phazzie/FairytaleswithSpice/pull/254) |
| 6 | Story Lab Genesis & Continuation routes | [#249](https://github.com/Phazzie/FairytaleswithSpice/pull/249) |
| 5 | API Authentication & Rate-Limiting | [#244](https://github.com/Phazzie/FairytaleswithSpice/pull/244) |
| 4 | Story Export/Download | [#236](https://github.com/Phazzie/FairytaleswithSpice/pull/236) |
| 3 | Proving Grounds | [#233](https://github.com/Phazzie/FairytaleswithSpice/pull/233) |
| 2 | Image Generation | [#227](https://github.com/Phazzie/FairytaleswithSpice/pull/227) |
| 1 | Real-Time Story Streaming | [#223](https://github.com/Phazzie/FairytaleswithSpice/pull/223) |


---
_Generated by [Claude Code](https://claude.ai/code/session_018TkhAGNvhipFwDxktyQPHn)_

## Summary by Sourcery

Remove obsolete backend seam contracts for unimplemented streaming and audio features.

Enhancements:
- Remove unused streaming-generation and audio-conversion seam contracts and their supporting types so the backend contract reference reflects only implemented capabilities.

Documentation:
- Document the deliberate removal of obsolete seam definitions in the changelog.

Tests:
- Verify the cleanup with repository-wide reference checks, TypeScript compilation, and the backend and Angular test suites.