### PR TITLE
***WORST TO BEST*** Story Lab Profile Preferences: a safety field captured, validated, and persisted, then never read by generation

### DIFF
--- a/api/_lib/story-lab/jobs/jobRouteHandlers.ts
+++ b/api/_lib/story-lab/jobs/jobRouteHandlers.ts
@@ -30,6 +30,9 @@ import {
   createStoryLabJobStoreConfig,
   type StoryLabJobStoreConfig
 } from './storyLabJobStoreConfig';
+import { createStoryLabCloudStorage } from '../storage/storyLabCloudStorageConfig';
+import type { StoryLabProfileStore } from '../profile/storyLabProfileStore';
+import type { HeatContract } from '../contracts';
 
 type ContinuationJobResult = StoryIterationPayload & { appendedChapterNumbers: number[] };
 type JobResult = StoryIterationPayload | ContinuationJobResult;
@@ -57,6 +60,7 @@ interface ResponseLike extends SseResponseLike {
 
 export interface StoryLabJobRouteDependencies {
   authPort?: AuthPort;
+  profileStore?: StoryLabProfileStore;
   createJobStoreConfig?: () => StoryLabJobStoreConfig;
   generateGenesis?: typeof generateStoryLabGenesis;
   continueStory?: typeof continueStoryLab;
@@ -64,6 +68,7 @@ export interface StoryLabJobRouteDependencies {
 
 interface StoryLabJobRouteContext {
   authPort: AuthPort;
+  profileStore: StoryLabProfileStore;
   createJobStoreConfig: () => StoryLabJobStoreConfig;
   generateGenesis: typeof generateStoryLabGenesis;
   continueStory: typeof continueStoryLab;
@@ -83,6 +88,7 @@ export function createStoryLabJobsRouteHandler(
 ): (req: RequestLike, res: ResponseLike) => Promise<void> {
   const context: StoryLabJobRouteContext = {
     authPort: dependencies.authPort ?? configuredAuthPort,
+    profileStore: dependencies.profileStore ?? createStoryLabCloudStorage().profileStore,
     createJobStoreConfig: dependencies.createJobStoreConfig ?? (() => createStoryLabJobStoreConfig()),
     generateGenesis: dependencies.generateGenesis ?? generateStoryLabGenesis,
     continueStory: dependencies.continueStory ?? continueStoryLab
@@ -394,8 +400,13 @@ async function createGenesisJob(
     return;
   }
 
+  const contentBoundaries = await loadAuthenticatedContentBoundaries(context, req);
+  const genesisInput = contentBoundaries
+    ? { ...parsed.blueprint, heatContract: withMergedContentBoundaries(parsed.blueprint.heatContract, contentBoundaries) }
+    : parsed.blueprint;
+
   const result = await runJobWork(
-    () => context.generateGenesis(parsed.blueprint),
+    () => context.generateGenesis(genesisInput),
     'genesis',
     job.job.jobId
   );
@@ -464,8 +475,13 @@ async function createContinuationJob(
     return;
   }
 
+  const contentBoundaries = await loadAuthenticatedContentBoundaries(context, req);
+  const continuationInput = contentBoundaries && normalized.heatContract
+    ? { ...normalized, heatContract: withMergedContentBoundaries(normalized.heatContract, contentBoundaries) }
+    : normalized;
+
   const result = await runJobWork(
-    () => context.continueStory(normalized),
+    () => context.continueStory(continuationInput),
     'continuation',
     job.job.jobId
   );
@@ -595,9 +611,70 @@ async function resolveJobStoreOrRespond(
 function createDefaultJobRouteContext(): StoryLabJobRouteContext {
   return {
     authPort: configuredAuthPort,
+    profileStore: createStoryLabCloudStorage().profileStore,
     createJobStoreConfig: () => createStoryLabJobStoreConfig(),
     generateGenesis: generateStoryLabGenesis,
     continueStory: continueStoryLab
+  };
+}
+
+/**
+ * A signed-in caller's content boundaries, folded into generation.
+ *
+ * `StoryLabProfilePreferences.contentBoundaries` is validated and persisted by
+ * the account routes, but nothing has ever read it back — a reader who wrote
+ * "no humiliation" into their profile got no different a story than one who
+ * left it blank. This never requires auth (`requireUser`) the way the account
+ * routes do; a caller with no signed-in identity, which is every caller today
+ * since no `STORY_LAB_AUTH_PROVIDER` is configured, simply gets no boundaries
+ * to fold in, and generation proceeds exactly as it does now. Any failure
+ * along the way — no user, no profile, a store error — is silently treated as
+ * "nothing to add"; a reader's boundary is a courtesy layered onto generation,
+ * not a gate that should ever turn a working request into a failed one.
+ */
+async function loadAuthenticatedContentBoundaries(
+  context: StoryLabJobRouteContext,
+  req: RequestLike
+): Promise<string | undefined> {
+  try {
+    const user = await context.authPort.getCurrentUser(req);
+    if (!user) {
+      return undefined;
+    }
+
+    const loadResult = await context.profileStore.loadProfile(user);
+    return loadResult.success === true
+      ? loadResult.data?.profile.preferences.contentBoundaries
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Folds a profile's content boundaries into an already-accepted Heat Contract.
+ *
+ * Never called on an absent contract, and never changes `adultOnlyConfirmed`
+ * or any other field: `heatContractPolicyError` treats any *present* contract
+ * whose `adultOnlyConfirmed` is not `true` as a policy violation, required or
+ * not, so manufacturing a contract here for a continuation that supplied none
+ * would turn a request that used to succeed into one that fails the adult-
+ * reader gate it never actually asked for. Only `noGoContent` — the free-text
+ * field this is the profile-wide counterpart of — is touched, joined onto
+ * whatever the request itself already carried rather than replacing it.
+ */
+function withMergedContentBoundaries(
+  heatContract: HeatContract,
+  contentBoundaries: string | undefined
+): HeatContract {
+  if (!contentBoundaries) {
+    return heatContract;
+  }
+
+  const existing = heatContract.noGoContent?.trim();
+  return {
+    ...heatContract,
+    noGoContent: existing ? `${existing}\n${contentBoundaries}` : contentBoundaries
   };
 }
 

--- a/tests/story-lab-job-routes.test.ts
+++ b/tests/story-lab-job-routes.test.ts
@@ -5,11 +5,21 @@ import jobHandler from '../api/story-lab/jobs';
 import type { AuthPort, AuthUser } from '../api/_lib/story-lab/auth/authPort';
 import { AuthError } from '../api/_lib/story-lab/auth/authPort';
 import type {
+  HeatContract,
+  StoryContinuationSeam,
   StoryGenerationSeam,
   StoryLabJobCreationRequest,
-  StoryLabJobCreationResponse
+  StoryLabJobCreationResponse,
+  StoryLabUserProfile
 } from '../api/_lib/story-lab/contracts';
 import { createStoryLabJobsRouteHandler } from '../api/_lib/story-lab/jobs/jobRouteHandlers';
+import {
+  generateStoryLabGenesis as realGenerateStoryLabGenesis,
+  continueStoryLab as realContinueStoryLab
+} from '../api/_lib/story-lab/storyLabEngine';
+import type { StoryLabProfileStore } from '../api/_lib/story-lab/profile/storyLabProfileStore';
+import { createDefaultStoryLabUserProfile } from '../api/_lib/story-lab/profile/storyLabProfileStore';
+import { createSavedStoryProjectFixture } from './story-lab-test-fixtures';
 import { resetRateLimitsForTests } from '../api/_lib/middleware/security';
 import { NonDurableStoryLabJobStore, nonDurableStoryLabJobStore } from '../api/_lib/story-lab/jobs/jobStore';
 import { StoryLabJobStoreError } from '../api/_lib/story-lab/jobs/postgresStoryLabJobStore';
@@ -590,6 +600,129 @@ async function testThrownEngineFailureFinishesTheJob(): Promise<void> {
   assert(statusBody.data.job.status === 'failed', 'the stored job should read as failed, not running');
 }
 
+async function testGenesisJobFoldsAuthenticatedProfileContentBoundariesIntoHeatContract(): Promise<void> {
+  nonDurableStoryLabJobStore.reset();
+  setMockRuntime();
+
+  const profile = createDefaultStoryLabUserProfile(owner, {
+    preferences: { contentBoundaries: 'No humiliation.' }
+  });
+  let capturedInput: StoryGenerationSeam['input'] | null = null;
+  const handler = createStoryLabJobsRouteHandler({
+    authPort: createStaticAuthPort(owner),
+    profileStore: createStubProfileStore(profile),
+    generateGenesis: async input => {
+      capturedInput = input;
+      return realGenerateStoryLabGenesis(input);
+    }
+  });
+
+  const response = new FakeResponse();
+  await handler(createRequest('POST', createGenesisJobRequest()), response);
+
+  assert(response.statusCode === 200, 'genesis job with a profile should still succeed');
+  assert(capturedInput !== null, 'the engine should have been called');
+  assert(
+    capturedInput!.heatContract.noGoContent === 'No coercion.\nNo humiliation.',
+    `profile content boundaries should be appended to the request's own noGoContent, got ${JSON.stringify(capturedInput!.heatContract.noGoContent)}`
+  );
+}
+
+async function testGenesisJobLeavesHeatContractUnchangedWithNoAuthenticatedUser(): Promise<void> {
+  nonDurableStoryLabJobStore.reset();
+  setMockRuntime();
+
+  let capturedInput: StoryGenerationSeam['input'] | null = null;
+  const handler = createStoryLabJobsRouteHandler({
+    authPort: createRejectingAuthPort(),
+    profileStore: createStubProfileStore(
+      createDefaultStoryLabUserProfile(owner, { preferences: { contentBoundaries: 'Should never be read.' } })
+    ),
+    generateGenesis: async input => {
+      capturedInput = input;
+      return realGenerateStoryLabGenesis(input);
+    }
+  });
+
+  const response = new FakeResponse();
+  await handler(createRequest('POST', createGenesisJobRequest()), response);
+
+  assert(response.statusCode === 200, 'genesis job with no authenticated user should still succeed');
+  assert(
+    capturedInput!.heatContract.noGoContent === 'No coercion.',
+    'with no authenticated caller, the request heat contract should reach the engine unchanged'
+  );
+}
+
+async function testContinuationJobFoldsContentBoundariesWhenHeatContractProvided(): Promise<void> {
+  nonDurableStoryLabJobStore.reset();
+  setMockRuntime();
+
+  const profile = createDefaultStoryLabUserProfile(owner, {
+    preferences: { contentBoundaries: 'Keep the danger emotional.' }
+  });
+  let capturedInput: StoryContinuationSeam['input'] | null = null;
+  const handler = createStoryLabJobsRouteHandler({
+    authPort: createStaticAuthPort(owner),
+    profileStore: createStubProfileStore(profile),
+    continueStory: async input => {
+      capturedInput = input;
+      return realContinueStoryLab(input);
+    }
+  });
+
+  const response = new FakeResponse();
+  await handler(
+    createRequest('POST', createContinuationJobRequest({
+      adultOnlyConfirmed: true,
+      tensionMode: 'slow_burn',
+      intimacyBoundary: 'closed_door',
+      noGoContent: 'No permanent injury.'
+    })),
+    response
+  );
+
+  assert(response.statusCode === 200, 'continuation job with a profile should still succeed');
+  assert(
+    capturedInput!.heatContract?.noGoContent === 'No permanent injury.\nKeep the danger emotional.',
+    `profile content boundaries should be appended to the continuation's own noGoContent, got ${JSON.stringify(capturedInput!.heatContract?.noGoContent)}`
+  );
+}
+
+/**
+ * A continuation that supplies no Heat Contract at all must stay that way even
+ * when a profile has content boundaries to offer. `heatContractPolicyError`
+ * treats any *present* contract as needing `adultOnlyConfirmed: true` — so
+ * manufacturing one here (to carry nothing but the boundary text) would reject
+ * a continuation that used to succeed, over a confirmation it never asked for.
+ */
+async function testContinuationJobSkipsContentBoundariesWithNoRequestHeatContract(): Promise<void> {
+  nonDurableStoryLabJobStore.reset();
+  setMockRuntime();
+
+  const profile = createDefaultStoryLabUserProfile(owner, {
+    preferences: { contentBoundaries: 'Keep the danger emotional.' }
+  });
+  let capturedInput: StoryContinuationSeam['input'] | null = null;
+  const handler = createStoryLabJobsRouteHandler({
+    authPort: createStaticAuthPort(owner),
+    profileStore: createStubProfileStore(profile),
+    continueStory: async input => {
+      capturedInput = input;
+      return realContinueStoryLab(input);
+    }
+  });
+
+  const response = new FakeResponse();
+  await handler(createRequest('POST', createContinuationJobRequest(undefined)), response);
+
+  assert(response.statusCode === 200, 'continuation job with no request heat contract should still succeed');
+  assert(
+    capturedInput!.heatContract === undefined,
+    'a continuation that supplied no heat contract must not gain one just because a profile has content boundaries'
+  );
+}
+
 async function run(): Promise<void> {
   await testGenesisJobCompletesInMockMode();
   await testEventsReplaySnapshotsAndClose();
@@ -609,6 +742,10 @@ async function run(): Promise<void> {
   testStoreEvictsOldestJobs();
   await testProductionMissingProviderCreatesFailedJob();
   await testThrownEngineFailureFinishesTheJob();
+  await testGenesisJobFoldsAuthenticatedProfileContentBoundariesIntoHeatContract();
+  await testGenesisJobLeavesHeatContractUnchangedWithNoAuthenticatedUser();
+  await testContinuationJobFoldsContentBoundariesWhenHeatContractProvided();
+  await testContinuationJobSkipsContentBoundariesWithNoRequestHeatContract();
 
   console.log('Story Lab job route tests passed');
 }
@@ -739,5 +876,58 @@ function createRejectingAuthPort(): AuthPort {
     async requireUser() {
       throw new AuthError('Account authentication is required.');
     }
+  };
+}
+
+function createStubProfileStore(profile: StoryLabUserProfile | null): StoryLabProfileStore {
+  return {
+    mode: 'non_durable_memory',
+    durable: false,
+    isConfigured: () => true,
+    async saveProfile(user, savedProfile) {
+      return {
+        success: true,
+        data: {
+          userId: user.userId,
+          profile: savedProfile,
+          createdAt: savedProfile.createdAt,
+          updatedAt: savedProfile.updatedAt,
+          storageMode: 'non_durable_memory'
+        }
+      };
+    },
+    async loadProfile(user) {
+      return {
+        success: true,
+        data: profile
+          ? {
+              userId: user.userId,
+              profile,
+              createdAt: profile.createdAt,
+              updatedAt: profile.updatedAt,
+              storageMode: 'non_durable_memory'
+            }
+          : null
+      };
+    }
+  };
+}
+
+function createContinuationJobRequest(heatContract?: HeatContract): StoryLabJobCreationRequest {
+  const fixture = createSavedStoryProjectFixture({ storyId: 'story_continuation' });
+  const continuation: StoryContinuationSeam['input'] = {
+    storyId: fixture.storyId,
+    storyState: fixture.state,
+    previouslyGeneratedChapters: fixture.chapters,
+    existingSummary: fixture.summary,
+    chapterBatchSize: 1,
+    heatContract
+  };
+
+  return {
+    kind: 'continuation',
+    continuation,
+    projectId: 'project_private',
+    storyId: fixture.storyId
   };
 }


### PR DESCRIPTION
## Was worst because

`StoryLabProfilePreferences.contentBoundaries` — a free-text "what this reader does not want written" field, on par with a per-story `heatContract.noGoContent` — is carefully validated and size-capped (`describeOversizedStoryLabProfileField` in `accountRouteHandlers.ts`) and durably persisted via `storyLabProfileStore.ts`, backed by 1,000+ lines of tests (`tests/story-lab-account-routes.test.ts`, `tests/story-lab-profile-store.test.ts`, `tests/story-lab-profile-contracts.test.ts`). But nothing in Story Lab generation ever read it back: grepping `contentBoundaries`, `favoriteCreatures`, `favoriteTones`, and `defaultHeatContract` across `api/_lib/story-lab` and `story-generator/src/app` turned up zero hits outside the profile store, contracts, and their own tests. A reader who wrote "no humiliation" into their profile got exactly the same story as one who left it blank — a safety-relevant field that looked fully built and did nothing.

## What changed (and what didn't)

The original candidate was broader — the whole account/profile subsystem has no real entry point in production (no login UI, no Clerk SDK, `configuredAuthPort.ts` defaults to deny-by-default). The initial plan proposed gating `accountRouteHandlers.ts`'s auth requirement the same way `jobRouteHandlers.ts` already does for non-durable stores. **That was wrong**, caught before implementation: `tests/story-lab-account-routes.test.ts::testDefaultAccountRouteFailsClosedWithoutAuthProvider` explicitly locks in fail-closed behavior for account/profile routes regardless of durability — a deliberate security decision, since profile/project data is more sensitive than an ephemeral generation job. Bypassing that would have let every visitor to a non-durable deployment share one "local-anonymous" profile and library. See the full self-correction posted mid-routine in `#claude-routines` for the reasoning.

This PR is the safe, narrower fix that survives that correction:

- `jobRouteHandlers.ts` soft-checks `authPort.getCurrentUser(req)` (never `requireUser` — no auth requirement changes anywhere, no new route becomes reachable) when creating a genesis or continuation job. Today this always resolves to `null` (no `STORY_LAB_AUTH_PROVIDER` configured), so the change is fully inert in production until an operator configures real auth — at which point it activates with no further code changes.
- When a real user is present, their profile's `contentBoundaries` is folded into the request's own `heatContract.noGoContent` (joined, not replacing) before calling `generateStoryLabGenesis`/`continueStoryLab`. `storyLabEngine.ts` itself is untouched — it stays a pure function of its input.
- For continuation, the merge only happens when the request **already supplied** a heat contract. `heatContractPolicyError` treats any *present* contract lacking `adultOnlyConfirmed: true` as a policy violation, so manufacturing one from a profile default (as originally planned) would have turned previously-succeeding continuations — which validly omit a heat contract — into failures over a confirmation they never asked for. Dropped that fallback entirely rather than risk it.
- Also dropped: reordering `buildSuggestedPrompts` by `favoriteCreatures`/`favoriteTones`. That function turned out to have no creature/tone-specific content to reorder in the first place (its three candidate lines are generic), so "prioritizing" would have meant inventing new prompt copy — out of scope for this fix.

## Tests

Added to `tests/story-lab-job-routes.test.ts`:
- Genesis job folds an authenticated caller's `contentBoundaries` into `heatContract.noGoContent`, joined onto the request's own value.
- Genesis job leaves the heat contract untouched when no authenticated user is present (today's default — regression guard for the inert-by-default behavior).
- Continuation job folds `contentBoundaries` when the request already supplied a heat contract.
- Continuation job does **not** manufacture a heat contract when the request supplied none, even with profile boundaries available (guards the consent-gate bug described above).

Full backend suite (`npm run test:all`) passes. No `tsc --noEmit` config exists for the backend (only `story-generator/tsconfig*.json` for the Angular app); backend type-safety runs through the `tsx`-executed test suite. No frontend files were touched, so the Angular suite is unaffected.

## Running list of the last 10 worst-to-best features

1. #274 — Story Continuity State Tracking
2. #271 — Real-Time Story Streaming (StreamingStoryComponent retirement)
3. #267 — storyLabEngine
4. #263 — StoryService content-analysis heuristics
5. #260 — Backend Seam Contracts
6. #257 — AppComponent
7. #254 — Error Logging & Display
8. #249 — Story Lab Genesis & Continuation routes
9. #244 — API Authentication & Rate-Limiting
10. #236 — Story Export/Download

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQJ9X6T7FRVjB8HhRCrhwV)_

## Summary by Sourcery

Fold authenticated profile content boundaries into Story Lab generation while preserving existing authentication and continuation consent behavior.

New Features:
- Apply authenticated users’ persisted content boundaries to Story Lab generation requests as additional no-go content.

Bug Fixes:
- Ensure profile safety preferences influence genesis and eligible continuation generations instead of being persisted without affecting output.
- Preserve unauthenticated generation behavior and avoid creating a heat contract for continuations that did not provide one.

Tests:
- Add job-route coverage for authenticated profile-boundary merging, unauthenticated requests, and continuation heat-contract behavior.