### PR TITLE
***WORST TO BEST*** Story Lab Auth & Profile Storage failure logging: the last two console.warn call sites, on the paths that decide whether a session and its profile data are trustworthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ***WORST TO BEST*** Story Lab Auth & Profile Storage failure logging (`clerkAuthPort.ts`, `postgresStoryLabProfileStore.ts`) — the last two `console.warn` call sites in the backend, on the two failure paths that decide whether a signed-in user's session and profile data are trustworthy (August 27, 2026)
+
+- Every sibling paid-surface service (`imageService.ts`, `exportService.ts`, `security.ts`'s
+  `authenticateRequest`, `api/story-lab/evaluate.ts`) had already been migrated off bare
+  `console.warn`/`console.error` onto the structured `logWarn`/`logError` in
+  `api/_lib/utils/logger.ts`. `clerkAuthPort.ts`'s session-verification failure and
+  `postgresStoryLabProfileStore.ts`'s save/load failures were the two call sites left behind —
+  and they guard the paths that matter most for account integrity: whether a signed-in user's
+  session is real, and whether their profile data actually got saved or loaded. A bare
+  `console.warn` here carried no request/user correlation, skipped `redactSensitiveLogData`, and
+  never reached the shared `logBuffer` the Error Display panel reads via `getRecentLogs()` — an
+  operator watching that panel during a production auth or profile incident would have seen
+  nothing.
+- `clerkAuthPort.ts`'s `requireUser` now logs a verification failure through `logWarn` with the
+  request's own correlation id (`readRequestCorrelationId(req)`, the same helper every route
+  already uses) and an `endpoint` tag, instead of a structureless `console.warn`.
+- `postgresStoryLabProfileStore.ts`'s `saveProfile`/`loadProfile` now log a storage failure
+  through `logWarn` with the acting user's id and an `endpoint` tag naming the failing operation
+  (`postgresStoryLabProfileStore.save`/`.load`), instead of `console.warn`.
+- No behavior change to any success path, no contract changes.
+- Added regression coverage in `tests/story-lab-clerk-auth.test.ts` and
+  `tests/story-lab-profile-store.test.ts` asserting the failures land in the structured log
+  buffer with the expected correlation context, and updated the existing malformed-profile test
+  (previously spying on raw `console.warn`) to read `logger.getRecentLogs()` instead, since a
+  single `logWarn` call now produces more than one `console.warn` line.
+
 ### ***WORST TO BEST*** Story Lab's mock generation engine (`mockData.ts`) — the actual runtime path for every keyless deployment, local dev session, and CI run, discarding nearly all of its own input (August 27, 2026)
 
 - `mockData.ts` is what every local dev session, CI run, and any deployment without

--- a/api/_lib/story-lab/auth/clerkAuthPort.ts
+++ b/api/_lib/story-lab/auth/clerkAuthPort.ts
@@ -1,6 +1,8 @@
 // Created: 2026-06-08 10:40 EDT
 
 import { AuthError, type AuthPort, type AuthRequestLike, type AuthUser } from './authPort';
+import { readRequestCorrelationId } from '../../http/requestCorrelationId';
+import { logWarn } from '../../utils/logger';
 
 export interface VerifiedClerkSession {
   userId: string;
@@ -51,7 +53,7 @@ export function createClerkAuthPort(options: ClerkAuthPortOptions = {}): AuthPor
         if (error instanceof AuthError) {
           throw error;
         }
-        warnAuthVerificationFailure(error);
+        warnAuthVerificationFailure(error, req);
         throw new AuthError('Clerk session could not be verified.');
       }
     }
@@ -132,9 +134,13 @@ function findFirstWhitespaceIndex(value: string): number {
   return -1;
 }
 
-function warnAuthVerificationFailure(error: unknown): void {
+function warnAuthVerificationFailure(error: unknown, req: AuthRequestLike): void {
   const errorName = error instanceof Error ? error.name : typeof error;
-  console.warn('Clerk session verification failed.', { errorName });
+  logWarn(
+    'Clerk session verification failed.',
+    { requestId: readRequestCorrelationId(req), endpoint: 'clerkAuthPort.requireUser' },
+    { errorName }
+  );
 }
 
 function toAuthUser(session: VerifiedClerkSession): AuthUser {

--- a/api/_lib/story-lab/profile/postgresStoryLabProfileStore.ts
+++ b/api/_lib/story-lab/profile/postgresStoryLabProfileStore.ts
@@ -2,6 +2,7 @@
 
 import type { AuthUser } from '../auth/authPort';
 import type { StoryLabProfilePreferences, StoryLabUserProfile } from '../contracts';
+import { logWarn } from '../../utils/logger';
 import {
   createStoredStoryLabProfileRecord,
   createStoryLabProfileStoreError,
@@ -109,7 +110,7 @@ class PostgresStoryLabProfileStore implements StoryLabProfileStore {
 
       return successResult(recordFromRow(row));
     } catch (error) {
-      warnProfileStorageFailure('save', error);
+      warnProfileStorageFailure('save', user.userId, error);
       return errorResult(this.storageError());
     }
   }
@@ -129,7 +130,7 @@ class PostgresStoryLabProfileStore implements StoryLabProfileStore {
 
       return successResult(recordFromRow(row));
     } catch (error) {
-      warnProfileStorageFailure('load', error);
+      warnProfileStorageFailure('load', user.userId, error);
       return errorResult(this.storageError());
     }
   }
@@ -234,9 +235,13 @@ function preferencesFromJson(value: unknown): StoryLabProfilePreferences {
   }
 }
 
-function warnProfileStorageFailure(operation: 'save' | 'load', error: unknown): void {
+function warnProfileStorageFailure(operation: 'save' | 'load', userId: string, error: unknown): void {
   const errorName = error instanceof Error ? error.name : typeof error;
-  console.warn('Story Lab profile storage operation failed.', { operation, errorName });
+  logWarn(
+    'Story Lab profile storage operation failed.',
+    { userId, endpoint: `postgresStoryLabProfileStore.${operation}` },
+    { errorName }
+  );
 }
 
 function toIsoString(value: string | Date): string {

--- a/tests/story-lab-clerk-auth.test.ts
+++ b/tests/story-lab-clerk-auth.test.ts
@@ -6,6 +6,7 @@ import {
   createClerkAuthPort,
   readClerkSessionToken
 } from '../api/_lib/story-lab/auth/clerkAuthPort';
+import { logger } from '../api/_lib/utils/logger';
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -19,6 +20,7 @@ async function main() {
   await testClerkAuthReadsSessionCookie();
   await testClerkAuthIgnoresMalformedRuntimeHeaders();
   await testClerkAuthRejectsInvalidSessionWithoutLeakingToken();
+  await testClerkAuthVerificationFailureLogsThroughStructuredLogger();
 
   console.log('Story Lab Clerk auth tests passed');
 }
@@ -113,6 +115,48 @@ async function testClerkAuthRejectsInvalidSessionWithoutLeakingToken() {
     assert(isAuthError(error), 'invalid Clerk session should throw AuthError');
     assert(!error.message.includes('invalid-session-token'), 'invalid token should not appear in auth errors');
   }
+}
+
+// The raw `console.warn(..., { errorName })` this used to be never reached the
+// shared recent-log buffer the Error Display panel reads and carried no
+// request correlation. This asserts the failure now lands there, tagged with
+// the request's own correlation id, and that the verifier's thrown error
+// (which could carry a session token in its message) never reaches the log.
+async function testClerkAuthVerificationFailureLogsThroughStructuredLogger() {
+  const auth = createClerkAuthPort({
+    verifySessionToken: async () => {
+      throw new Error('upstream Clerk session-token-abc123 lookup timed out');
+    }
+  });
+
+  const original = { log: console.log, warn: console.warn, error: console.error };
+  console.log = () => {};
+  console.warn = () => {};
+  console.error = () => {};
+  logger.clearLogs();
+
+  try {
+    await auth.requireUser({
+      headers: {
+        authorization: 'Bearer session-token-abc123',
+        'x-request-id': 'req-clerk-test-1'
+      }
+    });
+    throw new Error('a verifier that throws should still fail the request');
+  } catch (error) {
+    assert(isAuthError(error), 'verifier failures should surface as AuthError');
+  } finally {
+    console.log = original.log;
+    console.warn = original.warn;
+    console.error = original.error;
+  }
+
+  const warnings = logger.getRecentLogs(50, 'warn');
+  assert(warnings.length === 1, 'a verifier failure should emit exactly one structured warning');
+  const [entry] = warnings;
+  assert(entry.context?.requestId === 'req-clerk-test-1', 'the warning should carry the request correlation id');
+  assert(entry.context?.endpoint === 'clerkAuthPort.requireUser', 'the warning should identify the failing port method');
+  assert(!JSON.stringify(entry).includes('session-token-abc123'), 'the verifier error message should not reach the log');
 }
 
 main().catch(error => {

--- a/tests/story-lab-profile-store.test.ts
+++ b/tests/story-lab-profile-store.test.ts
@@ -2,6 +2,7 @@
 // Created: 2026-06-08 07:58 EDT
 
 import type { AuthUser } from '../api/_lib/story-lab/auth/authPort';
+import { logger } from '../api/_lib/utils/logger';
 import { createNonDurableInMemoryStoryLabProfileStore } from '../api/_lib/story-lab/profile/inMemoryStoryLabProfileStore';
 import {
   createDefaultStoryLabUserProfile,
@@ -27,13 +28,23 @@ interface CapturedQuery {
 class FakePostgresExecutor implements PostgresProfileQueryExecutor {
   readonly queries: CapturedQuery[] = [];
   private readonly queuedRows: unknown[][] = [];
+  private queuedError: Error | null = null;
 
   enqueueRows(rows: unknown[]): void {
     this.queuedRows.push(rows);
   }
 
+  forceNextQueryError(error: Error): void {
+    this.queuedError = error;
+  }
+
   async query<T = unknown>(sql: string, params: readonly unknown[]): Promise<{ rows: T[] }> {
     this.queries.push({ sql, params });
+    if (this.queuedError) {
+      const error = this.queuedError;
+      this.queuedError = null;
+      throw error;
+    }
     return {
       rows: (this.queuedRows.shift() ?? []) as T[]
     };
@@ -63,6 +74,7 @@ async function main() {
   await testPostgresProfileStoreReadiness();
   await testPostgresProfileStoreExecutorPath();
   await testPostgresProfileStoreMalformedRowsFailClosed();
+  await testPostgresProfileStoreFailuresLogThroughStructuredLogger();
 
   console.log('Story Lab profile store tests passed');
 }
@@ -223,13 +235,50 @@ async function testPostgresProfileStoreMalformedRowsFailClosed() {
       preferences_json: '{not valid json'
     }
   ]);
-  const { result: loadResult, warnings } = await captureWarnings(() => store.loadProfile(owner));
+  const { result: loadResult, entries } = await captureRecentLogs(() => store.loadProfile(owner));
   assert(!loadResult.success, 'malformed profile JSON should fail closed on load');
   assert(loadResult.error.code === 'STORY_LAB_PROFILE_STORAGE_ERROR', 'malformed profile should return storage error');
   assert(!loadResult.error.message.includes(owner.email ?? ''), 'malformed profile error should not leak user email');
-  assert(warnings.length === 1, 'malformed profile load should emit one redacted diagnostic warning');
-  assert(JSON.stringify(warnings).includes('STORY_LAB_PROFILE_STORAGE_ERROR') === false, 'diagnostic warning should not include typed storage payloads');
-  assert(!JSON.stringify(warnings).includes(owner.email ?? ''), 'diagnostic warning should not leak user email');
+  assert(entries.length === 1, 'malformed profile load should emit one structured diagnostic warning');
+  assert(JSON.stringify(entries).includes('STORY_LAB_PROFILE_STORAGE_ERROR') === false, 'diagnostic warning should not include typed storage payloads');
+  assert(!JSON.stringify(entries).includes(owner.email ?? ''), 'diagnostic warning should not leak user email');
+}
+
+// The last two `console.warn` call sites in the backend were this store's save/load failure
+// paths and `clerkAuthPort`'s session-verification failure — every sibling service migrated to
+// the structured logger already, which redacts, correlates, and lands the entry in the buffer
+// `getRecentLogs()` (and the Error Display panel) actually reads. This asserts the migration
+// landed: a save/load failure reaches the buffer as a `warn` entry naming the failing user and
+// operation, not just some console output.
+async function testPostgresProfileStoreFailuresLogThroughStructuredLogger() {
+  const executor = new FakePostgresExecutor();
+  const store = createPostgresStoryLabProfileStore({
+    databaseUrl: 'postgres://example.invalid/story_lab',
+    executor,
+    now: () => now
+  });
+  const profile = createDefaultStoryLabUserProfile(owner, { displayName: 'Avery', now });
+
+  executor.enqueueRows([]);
+  const { result: saveResult, entries: saveEntries } = await captureRecentLogs(() => store.saveProfile(owner, profile));
+  assert(!saveResult.success, 'a save with no returned row should fail');
+  assert(saveEntries.length === 0, 'a forbidden save result should not itself log a storage warning');
+
+  executor.forceNextQueryError(new Error('connection reset'));
+  const { result: failedSave, entries: failedSaveEntries } = await captureRecentLogs(() => store.saveProfile(owner, profile));
+  assert(!failedSave.success, 'a Postgres error should fail the save');
+  const saveWarning = failedSaveEntries[0];
+  assert(saveWarning?.level === 'warn', 'a save failure should log at warn level');
+  assert(saveWarning?.context?.userId === owner.userId, 'a save failure should carry the acting user id for correlation');
+  assert(saveWarning?.context?.endpoint === 'postgresStoryLabProfileStore.save', 'a save failure should identify the failing operation');
+  assert(!JSON.stringify(saveWarning).includes('connection reset'), 'the raw driver error message should not be logged verbatim');
+
+  executor.forceNextQueryError(new Error('connection reset'));
+  const { result: failedLoad, entries: failedLoadEntries } = await captureRecentLogs(() => store.loadProfile(owner));
+  assert(!failedLoad.success, 'a Postgres error should fail the load');
+  const loadWarning = failedLoadEntries[0];
+  assert(loadWarning?.context?.userId === owner.userId, 'a load failure should carry the acting user id for correlation');
+  assert(loadWarning?.context?.endpoint === 'postgresStoryLabProfileStore.load', 'a load failure should identify the failing operation');
 }
 
 function createProfileRow(profile: ReturnType<typeof createDefaultStoryLabUserProfile>) {
@@ -242,20 +291,23 @@ function createProfileRow(profile: ReturnType<typeof createDefaultStoryLabUserPr
   };
 }
 
-async function captureWarnings<T>(fn: () => Promise<T>): Promise<{ result: T; warnings: unknown[][] }> {
-  const originalWarn = console.warn;
-  const warnings: unknown[][] = [];
-  console.warn = (...args: unknown[]) => {
-    warnings.push(args);
-  };
+// The structured logger writes every buffered entry to the console as well, so
+// silence it while capturing to keep the test run readable; nothing here
+// asserts on raw console output.
+async function captureRecentLogs<T>(fn: () => Promise<T>): Promise<{ result: T; entries: ReturnType<typeof logger.getRecentLogs> }> {
+  const original = { log: console.log, warn: console.warn, error: console.error };
+  console.log = () => {};
+  console.warn = () => {};
+  console.error = () => {};
+  logger.clearLogs();
 
   try {
-    return {
-      result: await fn(),
-      warnings
-    };
+    const result = await fn();
+    return { result, entries: logger.getRecentLogs() };
   } finally {
-    console.warn = originalWarn;
+    console.log = original.log;
+    console.warn = original.warn;
+    console.error = original.error;
   }
 }
 


### PR DESCRIPTION
## Was worst because

`grep -rn "console\.warn\|console\.error" api/` turned up exactly two real call sites left in the whole backend: `clerkAuthPort.ts:137` (Clerk session-verification failures) and `postgresStoryLabProfileStore.ts:239` (Postgres profile save/load failures). Every sibling paid-surface service — `imageService.ts`, `exportService.ts`, `security.ts`'s `authenticateRequest`, `api/story-lab/evaluate.ts` — had already been migrated off bare `console.warn`/`console.error` onto the structured `logWarn`/`logError` in `api/_lib/utils/logger.ts`, each documented with why (redaction, correlation, the recent-log buffer). These two were the last holdouts.

They aren't just any two leftover call sites — they guard the two failure paths that matter most for account integrity: whether a signed-in user's session is real, and whether their profile data actually got saved/loaded. `console.warn` here meant no `requestId`/`userId` correlation, no pass through `redactSensitiveLogData`, and — critically — the failure never reached the shared `logBuffer` the Error Display panel (#254) reads via `getRecentLogs()`. An operator watching that panel during a production auth/profile incident would have seen nothing. Neither call site had any test asserting on its logging behavior.

## Plan (posted to #claude-routines for critique; no response arrived in the ~20 min window, executed as posted)

1. `clerkAuthPort.ts`: replace the bare `console.warn` in `requireUser`'s catch block with `logWarn`, carrying `requestId` (via `readRequestCorrelationId(req)`, the same helper every route already uses) and an `endpoint` tag.
2. `postgresStoryLabProfileStore.ts`: replace the bare `console.warn` shared by `saveProfile`/`loadProfile` with `logWarn`, carrying the acting user's `userId` (the store has no request object, but does have `user: AuthUser` in scope) and an `endpoint` tag naming the failing operation.
3. Add regression tests in `tests/story-lab-clerk-auth.test.ts` and `tests/story-lab-profile-store.test.ts` asserting a failure lands in `logger.getRecentLogs()` as a `warn` entry with the expected correlation context, and that the raw error text (which could carry a session token or driver detail) never reaches the log.
4. Update the existing malformed-profile-JSON test, which previously spied on raw `console.warn` and asserted exactly one call — `logWarn` writes the base message *and* a separate context line to `console.warn`, so that count assertion would now be wrong. Switched it to read `logger.getRecentLogs()` instead, which is what the log actually needs to prove.
5. No behavior change to any success path, no contract changes — purely finishing the same "migrate off console, prove it with tests" pattern already applied to `imageService.ts`, `exportService.ts`, `security.ts`, and `evaluate.ts`.

Scope stayed exactly as planned — no revisions were needed. The one open question in the plan (whether `userId` alone is enough correlation for the profile-store side, vs. threading a request-scoped id through `saveProfile`/`loadProfile`) was resolved by keeping `userId` only, since widening those signatures for a two-line logging swap would have been a bigger, out-of-scope change.

## Verified

- `tests/story-lab-clerk-auth.test.ts` and `tests/story-lab-profile-store.test.ts` pass standalone.
- Full backend suite (`npm run test:all`, 80+ tsx/node suites) green.
- `tsc --noEmit` clean on the Vercel API file list (`api/**/*.ts`, excluding specs/tests).
- No frontend files touched.

## Running list of the last 10 worst-to-best features (newest first)

1. Story Lab Auth & Profile Storage failure logging — this PR
2. Story Lab mock generation engine (#286)
3. Story Lab job recovery machinery (#281)
4. Story Lab Profile Preferences (#277)
5. Story Continuity State Tracking (#274)
6. Real-Time Story Streaming / `StreamingStoryComponent` (#271)
7. `storyLabEngine` (#267)
8. `StoryService` content-analysis heuristics (#263)
9. Backend Seam Contracts (#260)
10. `AppComponent` (#257)

---
_Generated by [Claude Code](https://claude.ai/code/session_011z2hZbhRiBWQbUNf9Bn8tK)_

## Summary by Sourcery

Replace the final backend console warnings on Story Lab authentication and profile storage failure paths with structured, correlated logging and regression coverage.

Enhancements:
- Route Clerk session-verification and Postgres profile storage failures through the structured logger with request or user correlation and operation context.
- Ensure sensitive error details remain redacted and failures are available in the shared recent-log buffer used for operational diagnostics.

Tests:
- Add regression coverage verifying structured auth and profile-storage warnings, correlation context, and redaction of raw error messages.