### PR TITLE
The export tokenizer ended a tag at the first `>` rather than at the tag's own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 The export tokenizer ended a tag at the first `>` rather than at the tag's own (August 28, 2026)
+
+- A tag does not end at the first `>` — it ends at the first `>` that is not inside
+  a quoted attribute value. `tokenizeHtml` in `exportSanitizer.ts` used
+  `indexOf('>')`, so `<p class="a>b">Hello.</p>` was split mid-attribute and the
+  remainder read as prose: the plain-text export answered `b">Hello.`.
+- Both exported readers share that tokenizer, so the fragment reached every
+  format. `stripStoryHtmlForExport` feeds `ExportService.toPlainText`, which
+  `.txt`, `.pdf`, `.epub` and `.docx` all go through; `sanitizeStoryHtmlForExport`
+  carried it into `.html`.
+- The costlier half was silent. The truncation also takes the trailing `/` of a
+  self-closing tag, so `<svg data-x="1>2"/>` parsed as a plain opening tag and put
+  `removeNonStoryHtml` into block-skipping for an element that never closes —
+  every word after it was dropped from the export. `<p>Before.</p><svg
+  data-x="1>2"/><p>After.</p>` exported as `Before.` alone.
+- `findTagEnd` now scans past quoted attribute values. Two limits keep it inside
+  the markup it began in — a quoted run stops at `<`, and an attribute value's
+  closing quote must be followed by whitespace, `/` or `>` — and markup with no
+  well-formed reading falls back to the older first-`>` scan. Without the second,
+  `<p class='unterminated>` finds its partner in the apostrophe of `It's` and
+  deletes the reader's words; keeping prose matters more than removing a fragment.
+- Closes the `exportSanitizer.ts` row of #296. The two `]*>` readers in
+  `storyContentAnalysis.ts` and `storyService.ts` are separate rows and are not
+  fixed here.
+
+#### Validation
+
+- `npm run test:all` exits `0` across every registered suite. Tests extend
+  `tests/export-sanitizer.test.ts`, so `test:all` gains no entries.
+- Vercel API function typecheck clean under preflight's exact command;
+  `check-vercel-function-count.sh` 8/12, unchanged; `git diff --check` clean.
+- Differential fuzzing against `origin/main`'s implementation: **0 differences**
+  over 200,000 inputs with no `>` inside a quoted value, 0 over 100,000 with
+  unterminated quotes, and 0 over 100,000 with a `<` inside a value. On 232,895
+  inputs that do carry such a `>`, the fixed reader answered exactly what both
+  readers already answer for the same markup written without it — 0 disagreements.
+- Five semantic counterfactuals run and reverted; none is committed. Two of them
+  passed against the first draft of the tests, which means those assertions were
+  not pinning their claims, and both were replaced by ones that do.
+
 ### 🐛 The `.pdf` export was the only one that showed a title's markup to the reader (August 27, 2026)
 
 - `generatePDFContent` receives the story body already through

--- a/PR70_RECOVERY_CHANGELOG.md
+++ b/PR70_RECOVERY_CHANGELOG.md
@@ -4,6 +4,28 @@ Created: 2026-05-26 00:12 EDT
 
 This is the chronological work log for the PR #70 recovery. It should capture commands, decisions, self-review notes, validation results, and anything that changes the plan.
 
+## 2026-08-28 UTC - The Export Tokenizer's Tag Boundary (the `exportSanitizer.ts` row of #296)
+
+Actions:
+
+- Replaced `tokenizeHtml`'s `indexOf('>')` tag boundary with `findTagEnd`, which scans past quoted attribute values. A tag ends at the first `>` that is not inside one; reading it as the first `>` full stop split `<p class="a>b">Hello.</p>` mid-attribute and read `b">Hello.` as prose. Both exported readers share this tokenizer, so the fragment reached all five formats — `.txt`, `.pdf`, `.epub` and `.docx` through `stripStoryHtmlForExport` → `ExportService.toPlainText`, and `.html` through `sanitizeStoryHtmlForExport`.
+- The silent half mattered more than the visible one. The truncation also takes the trailing `/` of a self-closing tag, so `<svg data-x="1>2"/>` was parsed as a plain opening tag and `removeNonStoryHtml` began block-skipping for an element that never closes. `<p>Before.</p><svg data-x="1>2"/><p>After.</p>` exported as `Before.` — the rest of the story dropped with no fragment to show for it.
+- Extended `tests/export-sanitizer.test.ts` with a `TAG BOUNDARIES` section. No new test files, so no new `test:all` entries.
+
+Decisions:
+
+- Two limits keep the scan inside the markup it began in, both pinned by counterfactuals rather than asserted: a quoted run stops at `<`, and an attribute value's closing quote must be followed by whitespace, `/` or `>`. Without the second, `<p class='unterminated>It's dangerous > here.</p>` finds the malformed attribute's partner in the apostrophe of `It's` and deletes `It's dangerous`. Deleting prose the reader wrote is worse than the fragment this change exists to remove, so markup with no well-formed reading falls back to the older first-`>` scan and is tokenized exactly as before.
+- Kept the `<` break in `findTagEnd` after measuring both directions. It costs a fragment on `<p <em title="a>b">` (doubly-malformed markup), and it pays on `<p>Alpha < Beta "gamma>delta" Epsilon.</p>`, where removing it deletes `Epsilon.` outright. Preferring the reader's words over a cleaner string is the module's existing principle, so the break stays and the case that pays is asserted.
+- Did not export a shared pattern from `shared/storyTextBlocks.ts`. #296 suggests reusing `tagAttributesPattern`, but that is a regex added by the unmerged #295 and this reader is a hand-written character scanner, not a pattern — the reading is reimplemented in the tokenizer's own idiom, including the follow-set rule #296 flags as the one a reimplementation is most likely to miss.
+
+Self-review:
+
+- Five semantic counterfactuals run and reverted; none is committed. **Two passed against the first draft of the tests** — the follow-set and the quoted-run `<` bound — which means those assertions were not discriminating, because the fallback rescued the mutated reading on the inputs I had chosen. Both were replaced by inputs that do discriminate (`It's dangerous > here.` and a run reaching into the next tag's `title="x"`).
+- Differential fuzzing against `origin/main`'s implementation, copied verbatim: 0 differences over 200,000 inputs with no `>` inside a quoted value, 0 over 100,000 with unterminated quotes, 0 over 100,000 with a `<` inside a value. The strong statement is the twin comparison — over 232,895 inputs carrying such a `>`, the fixed reader answered exactly what both readers already answer for the same markup written without it, with 0 disagreements.
+- A first fuzz harness reported implausible numbers because its LCG (`seed % n` on a power-of-two modulus) has degenerate low bits, so the four-way attribute-kind choice was periodic. Replaced with xorshift and re-run; the corrected numbers are the ones above.
+- Non-claim: the dropped-tag lists are read from the tag name, which sits before any attribute, so the truncation never let a dangerous element through. Asserted so the boundary change is on the record as not having moved the sanitizer's security boundary.
+- `npm run test:all` exits 0; API function typecheck clean under preflight's exact command; function count 8/12 unchanged; `git diff --check` clean.
+
 ## 2026-08-27 UTC - A Title Only Four Exports Agree On (rebase of the 2026-08-26 three-quick-wins slice)
 
 Actions:

--- a/api/_lib/services/exportSanitizer.ts
+++ b/api/_lib/services/exportSanitizer.ts
@@ -592,7 +592,7 @@ function tokenizeHtml(value: string): string[] {
       continue;
     }
 
-    const tagEnd = value.indexOf('>', tagStart + 1);
+    const tagEnd = findTagEnd(value, tagStart);
     if (tagEnd === -1) {
       tokens.push(value.slice(tagStart));
       break;
@@ -603,6 +603,105 @@ function tokenizeHtml(value: string): string[] {
   }
 
   return tokens;
+}
+
+/**
+ * Where the tag opening at `tagStart` ends.
+ *
+ * A tag does not end at the first `>` — it ends at the first `>` that is not
+ * inside a quoted attribute value. Reading `<p class="a>b">Hello.</p>` with the
+ * first `>` splits the tag mid-attribute, and the remainder (`b">Hello.`) is
+ * then read as prose. That fragment reaches every export: `stripStoryHtmlForExport`
+ * feeds `ExportService.toPlainText`, which `.txt`, `.pdf`, `.epub` and `.docx`
+ * all go through, and `sanitizeStoryHtmlForExport` carries it into `.html`.
+ *
+ * The truncation also costs the trailing `/` of a self-closing tag, which is
+ * worse than a visible fragment because it is silent: `<svg data-x="1>2"/>`
+ * parsed as a plain opening tag puts `removeNonStoryHtml` into block-skipping
+ * for an element that never closes, and every word after it is dropped from the
+ * export.
+ *
+ * Prose is what this runs on, so widening what a match may cross is the risk to
+ * weigh against the fragment. Two limits keep the scan inside the markup it
+ * began in, and a fallback keeps malformed markup reading exactly as it did
+ * before:
+ *
+ * 1. A quoted run stops at `<`, which is where the next tag starts.
+ * 2. An attribute value's closing quote must be followed by whitespace, `/` or
+ *    `>` — HTML's own syntax, never a word character. Without this,
+ *    `<p class='unterminated>It's dangerous > here.</p>` finds the malformed
+ *    attribute's partner in the apostrophe of `It's`, runs on to the `>` after
+ *    `dangerous`, and deletes the words between them. Losing prose the reader
+ *    wrote is worse than the fragment this function exists to remove.
+ *
+ * Where neither reading applies the caller falls back to the older first-`>`
+ * scan, so markup with no well-formed reading is tokenized exactly as before.
+ *
+ * Returns `-1` when no `>` closes the tag at all.
+ */
+function findTagEnd(value: string, tagStart: number): number {
+  let index = tagStart + 1;
+
+  while (index < value.length) {
+    const character = value[index];
+
+    if (character === '>') {
+      return index;
+    }
+
+    // The next tag starts here, so this one has no well-formed end.
+    if (character === '<') {
+      break;
+    }
+
+    if (character === '"' || character === "'") {
+      const valueEnd = findAttributeValueEnd(value, index);
+      if (valueEnd === -1) {
+        break;
+      }
+
+      index = valueEnd + 1;
+      continue;
+    }
+
+    index += 1;
+  }
+
+  // No well-formed reading: answer exactly as the older scan did.
+  return value.indexOf('>', tagStart + 1);
+}
+
+/**
+ * Where the quoted attribute value opening at `quoteStart` closes, or `-1`.
+ *
+ * Bounded at `<` and at the follow-set described on `findTagEnd`, which are the
+ * two rules that stop an unterminated quote reaching across the story text after
+ * it.
+ */
+function findAttributeValueEnd(value: string, quoteStart: number): number {
+  const quote = value[quoteStart];
+  let index = quoteStart + 1;
+
+  while (index < value.length) {
+    const character = value[index];
+
+    if (character === '<') {
+      return -1;
+    }
+
+    if (character === quote && mayEndAttributeValue(value[index + 1])) {
+      return index;
+    }
+
+    index += 1;
+  }
+
+  return -1;
+}
+
+/** What may follow an attribute value's closing quote. Never a word character. */
+function mayEndAttributeValue(character: string | undefined): boolean {
+  return character === undefined || isWhitespace(character) || character === '/' || character === '>';
 }
 
 function parseHtmlTag(token: string): ParsedHtmlTag | null {

--- a/tests/export-sanitizer.test.ts
+++ b/tests/export-sanitizer.test.ts
@@ -143,6 +143,121 @@ assert(
   'an unterminated comment should swallow the rest of the document rather than leaking it'
 );
 
+// ==================== TAG BOUNDARIES ====================
+// A tag ends at the first `>` that is not inside a quoted attribute value.
+// Reading it as the first `>` full stop split the tag mid-attribute and read the
+// remainder as prose, so `<p class="a>b">Hello.</p>` exported as `b">Hello.` —
+// through `stripStoryHtmlForExport`, which `.txt`, `.pdf`, `.epub` and `.docx`
+// all reach via `ExportService.toPlainText`, and through the `.html` export
+// beside it.
+const quotedAttributeSamples: Array<{ label: string; html: string; text: string; markup: string }> = [
+  {
+    label: 'double-quoted value',
+    html: '<p class="a>b">Hello.</p>',
+    text: 'Hello.',
+    markup: '<p>Hello.</p>'
+  },
+  {
+    label: 'single-quoted value',
+    html: "<p class='a>b'>She turned.</p>",
+    text: 'She turned.',
+    markup: '<p>She turned.</p>'
+  },
+  {
+    label: 'a heading, whose text becomes a chapter title',
+    html: '<h3 data-chapter="1>2">Real Title</h3>',
+    text: 'Real Title',
+    markup: '<h3>Real Title</h3>'
+  },
+  {
+    label: 'a value that is prose in its own right',
+    html: '<p title="Ash > Ember">The door opened.</p>',
+    text: 'The door opened.',
+    markup: '<p>The door opened.</p>'
+  }
+];
+
+for (const sample of quotedAttributeSamples) {
+  const text = stripStoryHtmlForExport(sample.html);
+  assert(
+    text === sample.text,
+    `a \`>\` inside a ${sample.label} should not end the tag (got ${JSON.stringify(text)})`
+  );
+
+  const markup = sanitizeStoryHtmlForExport(sample.html);
+  assert(
+    markup === sample.markup,
+    `the HTML export should not carry an attribute fragment into the story (got ${JSON.stringify(markup)})`
+  );
+}
+
+// The costly half of the same defect, because it is silent rather than visible.
+// Losing the tag's trailing `/` makes a dropped element look like a block that
+// opens and never closes, and `removeNonStoryHtml` then skips every token after
+// it — so a single `<svg data-x="1>2"/>` deleted the rest of the story from
+// every export.
+const truncatedSelfClosing = '<p>Before.</p><svg data-x="1>2"/><p>After.</p>';
+assert(
+  stripStoryHtmlForExport(truncatedSelfClosing) === 'Before.\nAfter.',
+  `a self-closing dropped tag must not swallow the story after it (got ${JSON.stringify(stripStoryHtmlForExport(truncatedSelfClosing))})`
+);
+assert(
+  sanitizeStoryHtmlForExport(truncatedSelfClosing) === '<p>Before.</p><p>After.</p>',
+  'the HTML export should keep the story after a self-closing dropped tag too'
+);
+
+// Reading a quoted value is only safe while the quote is real. Prose is what
+// this runs on, and a malformed attribute whose quote never closes must not go
+// looking for its partner in the story: `<p class='unterminated>` finds the
+// apostrophe of `It's` and deletes the words between them. Keeping the reader's
+// words matters more than removing the fragment, so markup with no well-formed
+// reading falls back to the older first-`>` scan.
+const unterminatedDouble = '<p class="unterminated>It\'s dangerous here.</p>';
+assert(
+  stripStoryHtmlForExport(unterminatedDouble) === "It's dangerous here.",
+  `an unterminated attribute quote must not consume prose (got ${JSON.stringify(stripStoryHtmlForExport(unterminatedDouble))})`
+);
+// Stated on prose that also carries a later `>`, which is what makes the
+// apostrophe reachable: without the follow-set rule the run closes at the `'` of
+// `It's`, the scan then finds the `>` after `dangerous`, and the whole span
+// becomes part of the tag — `It's dangerous` is deleted from the story.
+const unterminatedSingle = "<p class='unterminated>It's dangerous > here.</p>";
+assert(
+  stripStoryHtmlForExport(unterminatedSingle) === "It's dangerous > here.",
+  `an apostrophe in the prose must not close a malformed attribute (got ${JSON.stringify(stripStoryHtmlForExport(unterminatedSingle))})`
+);
+
+// The other limit that keeps a malformed quote inside its own tag: a quoted run
+// stops at `<`, because that is where the next tag starts. Without it the run
+// above reaches the `title="x"` of the *following* paragraph, closes there, and
+// swallows `Alpha.` along with the markup between them.
+const runAcrossTags = '<p class="unterminated>Alpha.</p><p title="x">Beta.</p>';
+assert(
+  stripStoryHtmlForExport(runAcrossTags) === 'Alpha.\nBeta.',
+  `a quoted run must not reach into the next tag (got ${JSON.stringify(stripStoryHtmlForExport(runAcrossTags))})`
+);
+
+// A stray `<` in the prose is where the scan stops looking for a well-formed
+// end, for the same reason: the tag it would otherwise run to belongs to
+// different markup, and everything between them is the reader's words. This
+// module already loses the span between a literal `<` and the next `>` — that is
+// unchanged from before this fix, and both readings drop `< Beta` here — but the
+// scan must not carry on past `Epsilon.` and take that with it.
+const strayAngleBracket = '<p>Alpha < Beta "gamma>delta" Epsilon.</p>';
+assert(
+  stripStoryHtmlForExport(strayAngleBracket).endsWith('Epsilon.'),
+  `a stray \`<\` must not delete the prose after the next tag (got ${JSON.stringify(stripStoryHtmlForExport(strayAngleBracket))})`
+);
+
+// The dropped-tag lists are read from the tag name, which sits before any
+// attribute, so the truncation never let a dangerous element through. Asserted
+// so the boundary change above is on the record as not having moved it.
+assert(
+  !stripStoryHtmlForExport('<script foo="a>b">stealPrivateStory()</script><p>Story survives.</p>')
+    .includes('stealPrivateStory'),
+  'a script carrying a quoted `>` must still be dropped with its contents'
+);
+
 // ==================== BLOCK BOUNDARIES ====================
 // A tag outside the allowed set is replaced with nothing, so a block-level one
 // welded the words on either side of it: `<h4>The Vault</h4><div>She opened the


### PR DESCRIPTION
Closes the `exportSanitizer.ts` row of #296.

A tag does not end at the first `>` — it ends at the first `>` that is not inside a quoted attribute value. `tokenizeHtml` used `indexOf('>')`:

```
stripStoryHtmlForExport('<p class="a>b">Hello.</p>')
  →  'b">Hello.'      // on main
  →  'Hello.'         // here
```

## Why it reaches every export, not one

Both of this module's exported readers share that tokenizer. `stripStoryHtmlForExport` feeds `ExportService.toPlainText`, which `.txt`, `.pdf`, `.epub` and `.docx` all go through; `sanitizeStoryHtmlForExport` carries the same fragment into `.html`. So the attribute remnant is in all five downloads.

**#296 recorded the strip path only. The `.html` export is the same defect through the other reader**, and both are fixed here by the one change.

## The silent half, which costs more than the visible one

The truncation also takes the trailing `/` of a self-closing tag. A dropped element then looks like a block that opens and never closes, and `removeNonStoryHtml` skips every token after it:

```
stripStoryHtmlForExport('<p>Before.</p><svg data-x="1>2"/><p>After.</p>')
  →  'Before.'            // on main — `After.` is gone from every format
  →  'Before.\nAfter.'    // here
```

No fragment appears, no error is raised, and the rest of the story is simply absent from the download. This was not in #296's record; it is the reason this row was worth taking before the two `]*>` ones.

## Where the line falls

Prose is what this runs on, so widening what a match may cross is the risk to weigh against the fragment. Two limits keep the scan inside the markup it began in, and a fallback keeps malformed markup reading exactly as before. Each is pinned by a counterfactual rather than asserted:

1. **A quoted run stops at `<`**, which is where the next tag starts. Without it the run in `<p class="unterminated>Alpha.</p><p title="x">Beta.</p>` reaches the *following* paragraph's attribute, closes there, and swallows `Alpha.`.
2. **An attribute value's closing quote must be followed by whitespace, `/` or `>`** — HTML's own syntax, never a word character. Without it, `<p class='unterminated>It's dangerous > here.</p>` finds the malformed attribute's partner in the apostrophe of `It's`, runs on to the next `>`, and deletes `It's dangerous`. Losing prose the reader wrote is worse than the fragment this change exists to remove.
3. **Markup with no well-formed reading falls back to the older first-`>` scan**, so it is tokenized exactly as it was.

This is the follow-set rule #296 flags as the one a reimplementation is most likely to miss, and it is why the reading is reimplemented in the tokenizer's own idiom rather than by exporting `tagAttributesPattern` from #295: that is a regex, this reader is a hand-written character scanner, and #295 is unmerged. **This PR therefore touches no file #290, #292, #293 or #295 changes and can merge in any order relative to them.**

### A limit kept deliberately

The `<` break in `findTagEnd` was measured in both directions before keeping it. It costs a fragment on doubly-malformed markup (`<p <em title="a>b">`), and it pays on `<p>Alpha < Beta "gamma>delta" Epsilon.</p>`, where removing it deletes `Epsilon.` outright. Preferring the reader's words over a cleaner string is this module's existing principle, so the break stays and the case that pays is asserted. A story containing a literal `<` still loses the span to the next `>` — unchanged from `main`, and asserted so.

## Validation

- `npm run test:all` — exits `0` across every registered suite. Tests extend `tests/export-sanitizer.test.ts`, so `test:all` gains no entries.
- Vercel API function typecheck clean, `exit 0`, under the repo's pinned `tsc` with the exact command `scripts/recovery/preflight.sh` uses.
- `scripts/recovery/check-vercel-function-count.sh` — 8/12, unchanged from `main`. `git diff --check` clean.
- No test reaches a store, an auth port, or a model provider — both readers are pure functions of a string.

### Differential fuzzing against `origin/main`'s implementation, copied verbatim

| corpus | result |
| --- | --- |
| 200,000 inputs with no `>` inside a quoted value | **0 differences** |
| 100,000 inputs with unterminated attribute quotes | **0 differences** |
| 100,000 inputs with a `<` inside a quoted value | **0 differences** |
| 232,895 inputs that *do* carry a `>` inside a quoted value, each compared against its well-formed twin | **0 disagreements** |

The last row is the strong statement, and the one worth reading: for every input carrying a `>` inside a quoted attribute value, the fixed reader answers **exactly what both implementations already answer for the same markup written without that `>`**. The `>` no longer changes the reading at all.

Worth recording that a first harness reported implausible numbers, because its LCG (`seed % n` on a power-of-two modulus) has degenerate low bits and the four-way attribute-kind choice was periodic. Replaced with xorshift; the numbers above are the corrected run.

### Semantic counterfactuals

Per the test policy in `AGENTS.md`, each claim was inverted and the relevant assertion confirmed failing, then reverted immediately. None of the mutations is committed.

| mutation | result |
| --- | --- |
| tokenizer back to `indexOf('>')` | ``a `>` inside a double-quoted value should not end the tag`` |
| drop the attribute-value follow-set | `an apostrophe in the prose must not close a malformed attribute (got "here.")` |
| drop the `<` bound on a quoted run | `a quoted run must not reach into the next tag (got "Beta.")` |
| drop the malformed-markup fallback | `an unterminated attribute quote must not consume prose (got "")` |
| drop the `<` break in `findTagEnd` | ``a stray `<` must not delete the prose after the next tag (got "Alpha")`` |

**Two of these passed against my first draft of the tests** — the follow-set and the quoted-run `<` bound. A mutation that does not fail means the assertion was not pinning its claim: in both cases the fallback rescued the mutated reading on the inputs I had chosen. Both were replaced by inputs that discriminate, which is what the table above reports.

## Not claimed

- No prompt, no generated story, no route, and no deployable function count changes.
- **This does not make the module an HTML parser.** Unquoted attribute values, comments inside tags, and CDATA are unchanged; only the quoted-value case moves.
- **The sanitizer's security boundary does not move.** The dropped-tag lists are read from the tag name, which sits before any attribute, so the truncation never let a dangerous element through — `<script foo="a>b">` was dropped with its contents before this change and after it. Asserted so that stays on the record.
- A story containing a literal `<` still loses the span between it and the next `>`. That is the pre-existing limit tracked as the fourth row of #296, and it is unchanged in both directions (0 differences across 100,000 such inputs).
- The two `]*>` readers in `storyContentAnalysis.ts` and `storyService.ts` are the other open rows of #296 and are **not** fixed here. `extractChapterTitleAndBody` returns contract-shaped chapter titles and wants its own tests and review, exactly as #296 argues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZVfT4PcRXrnuwJzBoxfAz

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZVfT4PcRXrnuwJzBoxfAz)_

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

## Summary by Sourcery

Fix export tag boundary detection so quoted attribute values do not corrupt or silently truncate exported story content.

Bug Fixes:
- Fix export HTML tokenization so quoted `>` characters in attributes no longer truncate tags or lose subsequent story content across all export formats.

Enhancements:
- Preserve previous behavior for malformed markup while preventing quoted-attribute scanning from consuming prose or crossing into subsequent tags.

Documentation:
- Document the export tokenizer fix, its scope, and validation results in the changelog and recovery work log.

Tests:
- Add coverage for quoted attribute boundaries, self-closing dropped tags, malformed attributes, cross-tag scans, stray angle brackets, and preservation of script filtering.